### PR TITLE
feat(ci): enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This makes Dependabot automatically create MRs for dependency bumps which will help us to keep dependencies up-to-date.

See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference for more details.