### PR TITLE
fix: remove explicit Content-Type header from presigned post upload

### DIFF
--- a/src/api/dream/mutation/useUploadFilePresignedPost.ts
+++ b/src/api/dream/mutation/useUploadFilePresignedPost.ts
@@ -3,7 +3,6 @@ import { PresignedPostRequest } from "@/types/dream.types";
 import { FILE_FORM } from "@/constants/file.constants";
 import { toast } from "react-toastify";
 import { useTranslation } from "react-i18next";
-import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
 import axios from "axios";
 
 export const UPLOAD_FILE_PRESIGNED_POST_MUTATION_KEY =
@@ -37,9 +36,6 @@ const uploadFilePresignedPost = ({
     formData.append(FILE_FORM.FILE, values?.file ?? "");
     return axios
       .post(values?.params?.url ?? "", formData, {
-        headers: getRequestHeaders({
-          contentType: ContentType.multipart,
-        }),
         onUploadProgress: (ev) => {
           const progress = ev.loaded / (ev?.total ?? 0);
           onChangeUploadProgress?.(Math.round(progress * 100));


### PR DESCRIPTION
## Summary
- Removed manually set `Content-Type: multipart/form-data` header from `useUploadFilePresignedPost`
- When using `FormData`, axios must auto-generate the `Content-Type` with the correct `boundary` parameter — setting it manually strips the boundary, causing S3/R2 to fail to parse the body and return an error
- This was causing `"Expecting value: line 1 column 1 (char 0)"` JSON parse errors on file upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)