### PR TITLE
fix: deduplicate 401 logout and fix error interceptor

### DIFF
--- a/src/components/pages/studio/hooks/useBatchSubmit.ts
+++ b/src/components/pages/studio/hooks/useBatchSubmit.ts
@@ -9,7 +9,8 @@ import {
   hasActionLoras,
 } from "../constants/duration-options";
 
-const BATCH_SIZE = 5;
+// Serialized to avoid concurrent auth refresh races (see fix/session-refresh-race on backend)
+const BATCH_SIZE = 1;
 
 export const useBatchSubmit = () => {
   const images = useStudioStore((s) => s.images);

--- a/src/hooks/useHttpInterceptors.ts
+++ b/src/hooks/useHttpInterceptors.ts
@@ -28,6 +28,8 @@ type ResponseGeneratorProps = {
   logout: () => Promise<void>;
 };
 
+let isLoggingOut = false;
+
 const generateResponseInterceptor = async ({
   logout,
 }: ResponseGeneratorProps) => {
@@ -38,14 +40,17 @@ const generateResponseInterceptor = async ({
     (response) => response,
     async (error) => {
       if (error?.response?.status === 401) {
-        // Handle unauthorized error
-        queryClient.clear();
-        await logout();
-        router.navigate(ROUTES.SIGNIN);
+        if (!isLoggingOut) {
+          isLoggingOut = true;
+          queryClient.clear();
+          await logout();
+          router.navigate(ROUTES.SIGNIN);
+          isLoggingOut = false;
+        }
         return Promise.reject(error);
       }
 
-      return error.response;
+      return Promise.reject(error);
     },
   );
 };


### PR DESCRIPTION
## Summary
- Deduplicates concurrent 401 logout handling — multiple simultaneous 401 responses now trigger only one `logout()` + navigate cycle
- Fixes bug where non-401 errors (403, 500, etc.) were resolved instead of rejected by the axios response interceptor (`return error.response` → `return Promise.reject(error)`)
- Reduces studio batch size from 5 to 1 to serialize requests until the backend session refresh dedup fix lands

## Root Cause Analysis

### The Bug
When the studio page fires multiple concurrent API requests (batch submission sends up to 5 at a time via `Promise.allSettled`), and the user's WorkOS access token has expired, **all concurrent requests race to refresh the same session**. WorkOS refresh tokens are single-use (rotated on refresh). Only 1 request wins; the others fail.

### Failure Trace
1. **Studio batch submit** (`useBatchSubmit.ts:84`) fires up to 5 concurrent `Promise.allSettled` requests
2. All 5 requests arrive at `requireAuth` middleware with the **same expired session cookie**
3. Each calls `authenticateWorkOS()` → `authenticateAndGetWorkOSSession()` returns `null` (expired)
4. Each calls `refreshWorkOSSession()` — but WorkOS refresh tokens are **single-use**
5. **Request #1 wins** the refresh, gets new sealed session, updates cookie in response
6. **Requests #2-5** fail refresh (token already consumed) → caught by `catch` block → returns `null`
7. `null` result → `handleWorkOSAuthFailure()` → **clears the `wos-session` cookie** and returns **401**
8. Frontend axios interceptor catches **each** 401 → calls `logout()` multiple times → navigates to sign-in

### Why Only Studio
The studio page is the **only feature that fires concurrent authenticated API requests**. Normal pages make sequential requests, so the refresh happens once and subsequent requests use the new cookie.

### Additional Bug: Error Swallowing
`useHttpInterceptors.ts:48` had `return error.response` which **resolved** the promise for non-401 errors (like 403 Forbidden). This meant role check failures and other server errors were silently treated as successful responses by calling code, masking related auth issues.

## Changes
- `src/hooks/useHttpInterceptors.ts`: Added `isLoggingOut` flag to deduplicate 401 handling; fixed non-401 error path to properly reject
- `src/components/pages/studio/hooks/useBatchSubmit.ts`: BATCH_SIZE 5 → 1 (temporary safety measure until backend fix deploys)

## Companion PR
- Backend: https://github.com/e-dream-ai/backend/pull/384

## Test plan
- [ ] Deploy to stage with backend fix and verify no more sign-outs during studio batch
- [ ] Verify normal 401 (expired session) still redirects to sign-in
- [ ] Verify API errors (403, 500) are now properly surfaced to calling code

🤖 Generated with [Claude Code](https://claude.com/claude-code)