### PR TITLE
feat: Z Image Turbo model picker in studio

### DIFF
--- a/src/components/pages/studio/components/actions-tab.tsx
+++ b/src/components/pages/studio/components/actions-tab.tsx
@@ -32,6 +32,15 @@ export const ActionsTab: React.FC = () => {
   const loadPresetPack = useStudioStore((s) => s.loadPresetPack);
   const images = useStudioStore((s) => s.images);
   const setActiveTab = useStudioStore((s) => s.setActiveTab);
+  const videoGenParams = useStudioStore((s) => s.videoGenParams);
+
+  const filteredPresets = useMemo(
+    () =>
+      ACTION_PRESETS.filter(
+        (p) => p.model === videoGenParams.model || p.model === "all",
+      ),
+    [videoGenParams.model],
+  );
 
   const selectedImageCount = useMemo(
     () =>
@@ -102,7 +111,7 @@ export const ActionsTab: React.FC = () => {
             <option value="" disabled>
               Load Preset Pack...
             </option>
-            {ACTION_PRESETS.map((preset) => (
+            {filteredPresets.map((preset) => (
               <option key={preset.name} value={preset.name}>
                 {preset.name}
               </option>

--- a/src/components/pages/studio/components/generate-tab.styled.tsx
+++ b/src/components/pages/studio/components/generate-tab.styled.tsx
@@ -83,3 +83,9 @@ export const ComboCountText = styled.p`
   color: #888;
   text-align: center;
 `;
+
+export const HintText = styled.p`
+  font-size: 0.8125rem;
+  color: #c9a84c;
+  margin-bottom: 0.75rem;
+`;

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -3,9 +3,11 @@ import { useStudioStore } from "@/stores/studio.store";
 import { useBatchSubmit } from "../hooks/useBatchSubmit";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
 import { axiosClient } from "@/client/axios.client";
+import type { VideoModel } from "@/types/studio.types";
 import {
   clampDurationToAllowed,
   getAllowedDurationsForActions,
+  hasActionLoras,
 } from "../constants/duration-options";
 import { PresignedImage } from "@/components/shared/presigned-image";
 import {
@@ -30,7 +32,13 @@ import {
   DescriptionText,
   SubmittedLabel,
   ComboCountText,
+  HintText,
 } from "./generate-tab.styled";
+
+const VIDEO_MODEL_LABELS: Record<VideoModel, string> = {
+  "ltx-i2v": "LTX 2.3",
+  "wan-i2v": "Wan I2V",
+};
 
 const STEPS_OPTIONS = [20, 25, 30, 40];
 const GUIDANCE_OPTIONS = [3.0, 4.0, 5.0, 6.0, 7.0];
@@ -71,6 +79,12 @@ export const GenerateTab: React.FC = () => {
       ),
     [newCombos, videoGenParams.model],
   );
+
+  const showLtxHint = useMemo(() => {
+    if (videoGenParams.model !== "ltx-i2v") return false;
+    const enabled = actions.filter((a) => a.enabled && a.prompt.trim());
+    return enabled.length > 0 && enabled.every((a) => !hasActionLoras(a));
+  }, [videoGenParams.model, actions]);
 
   useEffect(() => {
     const nextDuration = clampDurationToAllowed(
@@ -172,7 +186,28 @@ export const GenerateTab: React.FC = () => {
 
       <GenerateSection>
         <SectionTitle>Output Settings</SectionTitle>
+        {showLtxHint && (
+          <HintText>
+            LTX works best with motion presets. Add a camera LoRA for better
+            results.
+          </HintText>
+        )}
         <SettingsGrid>
+          <FormField>
+            <FieldLabel>Model:</FieldLabel>
+            <StyledSelect
+              value={videoGenParams.model}
+              onChange={(e) =>
+                setVideoGenParams({ model: e.target.value as VideoModel })
+              }
+            >
+              {(Object.keys(VIDEO_MODEL_LABELS) as VideoModel[]).map((m) => (
+                <option key={m} value={m}>
+                  {VIDEO_MODEL_LABELS[m]}
+                </option>
+              ))}
+            </StyledSelect>
+          </FormField>
           <FormField>
             <FieldLabel>Duration:</FieldLabel>
             <StyledSelect

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -82,9 +82,11 @@ export const GenerateTab: React.FC = () => {
 
   const showLtxHint = useMemo(() => {
     if (videoGenParams.model !== "ltx-i2v") return false;
-    const enabled = actions.filter((a) => a.enabled && a.prompt.trim());
-    return enabled.length > 0 && enabled.every((a) => !hasActionLoras(a));
-  }, [videoGenParams.model, actions]);
+    return (
+      enabledActions.length > 0 &&
+      enabledActions.some((a) => !hasActionLoras(a))
+    );
+  }, [videoGenParams.model, enabledActions]);
 
   useEffect(() => {
     const nextDuration = clampDurationToAllowed(

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -40,6 +40,8 @@ const VIDEO_MODEL_LABELS: Record<VideoModel, string> = {
   "wan-i2v": "Wan I2V",
 };
 
+const VIDEO_MODELS: VideoModel[] = ["ltx-i2v", "wan-i2v"];
+
 const STEPS_OPTIONS = [20, 25, 30, 40];
 const GUIDANCE_OPTIONS = [3.0, 4.0, 5.0, 6.0, 7.0];
 
@@ -203,7 +205,7 @@ export const GenerateTab: React.FC = () => {
                 setVideoGenParams({ model: e.target.value as VideoModel })
               }
             >
-              {(Object.keys(VIDEO_MODEL_LABELS) as VideoModel[]).map((m) => (
+              {VIDEO_MODELS.map((m) => (
                 <option key={m} value={m}>
                   {VIDEO_MODEL_LABELS[m]}
                 </option>

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -38,8 +38,8 @@ const GUIDANCE_OPTIONS = [3.0, 4.0, 5.0, 6.0, 7.0];
 export const GenerateTab: React.FC = () => {
   const images = useStudioStore((s) => s.images);
   const actions = useStudioStore((s) => s.actions);
-  const wanParams = useStudioStore((s) => s.wanParams);
-  const setWanParams = useStudioStore((s) => s.setWanParams);
+  const videoGenParams = useStudioStore((s) => s.videoGenParams);
+  const setVideoGenParams = useStudioStore((s) => s.setVideoGenParams);
   const excludedCombos = useStudioStore((s) => s.excludedCombos);
   const toggleComboExcluded = useStudioStore((s) => s.toggleComboExcluded);
   const outputPlaylistId = useStudioStore((s) => s.outputPlaylistId);
@@ -64,19 +64,23 @@ export const GenerateTab: React.FC = () => {
     [getSelectedCombinations],
   );
   const durationOptions = useMemo(
-    () => getAllowedDurationsForActions(newCombos.map(({ action }) => action)),
-    [newCombos],
+    () =>
+      getAllowedDurationsForActions(
+        newCombos.map(({ action }) => action),
+        videoGenParams.model,
+      ),
+    [newCombos, videoGenParams.model],
   );
 
   useEffect(() => {
     const nextDuration = clampDurationToAllowed(
-      wanParams.duration,
+      videoGenParams.duration,
       durationOptions,
     );
-    if (nextDuration !== wanParams.duration) {
-      setWanParams({ duration: nextDuration });
+    if (nextDuration !== videoGenParams.duration) {
+      setVideoGenParams({ duration: nextDuration });
     }
-  }, [durationOptions, wanParams.duration, setWanParams]);
+  }, [durationOptions, videoGenParams.duration, setVideoGenParams]);
 
   const totalPossible = selectedImages.length * enabledActions.length;
 
@@ -172,9 +176,9 @@ export const GenerateTab: React.FC = () => {
           <FormField>
             <FieldLabel>Duration:</FieldLabel>
             <StyledSelect
-              value={wanParams.duration}
+              value={videoGenParams.duration}
               onChange={(e) =>
-                setWanParams({ duration: Number(e.target.value) })
+                setVideoGenParams({ duration: Number(e.target.value) })
               }
             >
               {durationOptions.map((d) => (
@@ -187,9 +191,9 @@ export const GenerateTab: React.FC = () => {
           <FormField>
             <FieldLabel>Steps:</FieldLabel>
             <StyledSelect
-              value={wanParams.numInferenceSteps}
+              value={videoGenParams.numInferenceSteps}
               onChange={(e) =>
-                setWanParams({ numInferenceSteps: Number(e.target.value) })
+                setVideoGenParams({ numInferenceSteps: Number(e.target.value) })
               }
             >
               {STEPS_OPTIONS.map((s) => (
@@ -202,9 +206,9 @@ export const GenerateTab: React.FC = () => {
           <FormField>
             <FieldLabel>Guidance:</FieldLabel>
             <StyledSelect
-              value={wanParams.guidance}
+              value={videoGenParams.guidance}
               onChange={(e) =>
-                setWanParams({ guidance: Number(e.target.value) })
+                setVideoGenParams({ guidance: Number(e.target.value) })
               }
             >
               {GUIDANCE_OPTIONS.map((g) => (

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { useStudioStore } from "@/stores/studio.store";
 import { axiosClient } from "@/client/axios.client";
-import type { StudioImage } from "@/types/studio.types";
+import type { StudioImage, ImageModel } from "@/types/studio.types";
+import { SIZE_OPTIONS, IMAGE_COUNT_OPTIONS } from "../constants/size-options";
 import {
   GenerateSection,
   SectionTitle,
@@ -29,14 +30,16 @@ import {
 import { PresignedImage } from "@/components/shared/presigned-image";
 import { AddFromPlaylistModal } from "./add-from-playlist-modal";
 
-const SEED_OPTIONS = [1, 4, 8, 12, 16, 24];
-const SIZE_OPTIONS = ["1280*720", "1024*1024", "720*1280", "512*512"];
+const MODEL_LABELS: Record<ImageModel, string> = {
+  "zit-image": "Z Image Turbo",
+  "qwen-image": "Qwen Image",
+};
 
 export const ImagesTab: React.FC = () => {
   const imagePrompt = useStudioStore((s) => s.imagePrompt);
   const setImagePrompt = useStudioStore((s) => s.setImagePrompt);
-  const qwenParams = useStudioStore((s) => s.qwenParams);
-  const setQwenParams = useStudioStore((s) => s.setQwenParams);
+  const imageGenParams = useStudioStore((s) => s.imageGenParams);
+  const setImageGenParams = useStudioStore((s) => s.setImageGenParams);
   const images = useStudioStore((s) => s.images);
   const addImage = useStudioStore((s) => s.addImage);
   const toggleImageSelected = useStudioStore((s) => s.toggleImageSelected);
@@ -50,6 +53,9 @@ export const ImagesTab: React.FC = () => {
   const [expandedImageUuid, setExpandedImageUuid] = useState<string | null>(
     null,
   );
+
+  const sizeOptions = SIZE_OPTIONS[imageGenParams.model];
+
   const processedImages = useMemo(
     () => images.filter((img) => img.status === "processed"),
     [images],
@@ -67,42 +73,47 @@ export const ImagesTab: React.FC = () => {
 
     const baseSeed = Math.floor(Math.random() * 99_000) + 1;
 
-    const promises = Array.from({ length: qwenParams.seedCount }, (_, i) => {
-      const seed = baseSeed + i;
-      const algoParams = {
-        infinidream_algorithm: "qwen-image",
-        prompt: imagePrompt,
-        size: qwenParams.size,
-        seed,
-      };
+    const promises = Array.from(
+      { length: imageGenParams.seedCount },
+      (_, i) => {
+        const seed = baseSeed + i;
+        const algoParams = {
+          infinidream_algorithm: imageGenParams.model,
+          prompt: imagePrompt,
+          size: imageGenParams.size,
+          seed,
+        };
 
-      return axiosClient
-        .post("/v1/dream", {
-          name: `Qwen Image ${images.length + i + 1}`,
-          prompt: JSON.stringify(algoParams),
-          description: "Studio generated image",
-        })
-        .then(({ data }) => {
-          const dream = data.data?.dream;
-          if (!dream) return;
-          addImage({
-            uuid: dream.uuid,
-            url: dream.thumbnail || "",
-            name: dream.name,
-            seed,
-            size: qwenParams.size,
-            status: (dream.status as StudioImage["status"]) || "queue",
-            selected: false,
+        return axiosClient
+          .post("/v1/dream", {
+            name: `${MODEL_LABELS[imageGenParams.model]} ${
+              images.length + i + 1
+            }`,
+            prompt: JSON.stringify(algoParams),
+            description: "Studio generated image",
+          })
+          .then(({ data }) => {
+            const dream = data.data?.dream;
+            if (!dream) return;
+            addImage({
+              uuid: dream.uuid,
+              url: dream.thumbnail || "",
+              name: dream.name,
+              seed,
+              size: imageGenParams.size,
+              status: (dream.status as StudioImage["status"]) || "queue",
+              selected: false,
+            });
+          })
+          .catch((err) => {
+            console.error("Failed to create image:", err);
           });
-        })
-        .catch((err) => {
-          console.error("Failed to create image:", err);
-        });
-    });
+      },
+    );
 
     await Promise.all(promises);
     setIsGenerating(false);
-  }, [imagePrompt, qwenParams, images.length, addImage]);
+  }, [imagePrompt, imageGenParams, images.length, addImage]);
 
   return (
     <>
@@ -115,14 +126,29 @@ export const ImagesTab: React.FC = () => {
         />
         <FormRow>
           <FormField>
-            <FieldLabel>Seeds:</FieldLabel>
+            <FieldLabel>Model:</FieldLabel>
             <StyledSelect
-              value={qwenParams.seedCount}
+              value={imageGenParams.model}
               onChange={(e) =>
-                setQwenParams({ seedCount: Number(e.target.value) })
+                setImageGenParams({ model: e.target.value as ImageModel })
               }
             >
-              {SEED_OPTIONS.map((n) => (
+              {(Object.keys(MODEL_LABELS) as ImageModel[]).map((m) => (
+                <option key={m} value={m}>
+                  {MODEL_LABELS[m]}
+                </option>
+              ))}
+            </StyledSelect>
+          </FormField>
+          <FormField>
+            <FieldLabel>Images:</FieldLabel>
+            <StyledSelect
+              value={imageGenParams.seedCount}
+              onChange={(e) =>
+                setImageGenParams({ seedCount: Number(e.target.value) })
+              }
+            >
+              {IMAGE_COUNT_OPTIONS.map((n) => (
                 <option key={n} value={n}>
                   {n}
                 </option>
@@ -132,10 +158,10 @@ export const ImagesTab: React.FC = () => {
           <FormField>
             <FieldLabel>Size:</FieldLabel>
             <StyledSelect
-              value={qwenParams.size}
-              onChange={(e) => setQwenParams({ size: e.target.value })}
+              value={imageGenParams.size}
+              onChange={(e) => setImageGenParams({ size: e.target.value })}
             >
-              {SIZE_OPTIONS.map((s) => (
+              {sizeOptions.map((s) => (
                 <option key={s} value={s}>
                   {s.replace("*", "x")}
                 </option>

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -202,7 +202,7 @@ export const ImagesTab: React.FC = () => {
                     {img.status === "failed" && "Failed"}
                   </ImageStatus>
                 )}
-                {img.seed != null && <SeedLabel>seed:{img.seed}</SeedLabel>}
+                {img.seed != null && <SeedLabel>#{img.seed}</SeedLabel>}
                 <StarBadge
                   $active={img.selected}
                   onClick={(e) => {

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -31,7 +31,7 @@ import { PresignedImage } from "@/components/shared/presigned-image";
 import { AddFromPlaylistModal } from "./add-from-playlist-modal";
 
 const MODEL_LABELS: Record<ImageModel, string> = {
-  "zit-image": "Z Image Turbo",
+  "z-image-turbo": "Z Image Turbo",
   "qwen-image": "Qwen Image",
 };
 

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -39,6 +39,8 @@ const MODEL_LABELS: Record<ImageModel, string> = {
   "qwen-image": "Qwen Image",
 };
 
+const IMAGE_MODELS: ImageModel[] = ["z-image-turbo", "qwen-image"];
+
 export const ImagesTab: React.FC = () => {
   const imagePrompt = useStudioStore((s) => s.imagePrompt);
   const setImagePrompt = useStudioStore((s) => s.setImagePrompt);
@@ -76,6 +78,7 @@ export const ImagesTab: React.FC = () => {
     setIsGenerating(true);
 
     const baseSeed = Math.floor(Math.random() * 99_000) + 1;
+    const currentImageCount = useStudioStore.getState().images.length;
 
     const promises = Array.from(
       { length: imageGenParams.seedCount },
@@ -91,7 +94,7 @@ export const ImagesTab: React.FC = () => {
         return axiosClient
           .post("/v1/dream", {
             name: `${MODEL_LABELS[imageGenParams.model]} ${
-              images.length + i + 1
+              currentImageCount + i + 1
             }`,
             prompt: JSON.stringify(algoParams),
             description: "Studio generated image",
@@ -117,7 +120,7 @@ export const ImagesTab: React.FC = () => {
 
     await Promise.all(promises);
     setIsGenerating(false);
-  }, [imagePrompt, imageGenParams, images.length, addImage, setIsGenerating]);
+  }, [imagePrompt, imageGenParams, addImage, setIsGenerating]);
 
   return (
     <>
@@ -141,7 +144,7 @@ export const ImagesTab: React.FC = () => {
                 });
               }}
             >
-              {(Object.keys(MODEL_LABELS) as ImageModel[]).map((m) => (
+              {IMAGE_MODELS.map((m) => (
                 <option key={m} value={m}>
                   {MODEL_LABELS[m]}
                 </option>

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -2,7 +2,11 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useStudioStore } from "@/stores/studio.store";
 import { axiosClient } from "@/client/axios.client";
 import type { StudioImage, ImageModel } from "@/types/studio.types";
-import { SIZE_OPTIONS, IMAGE_COUNT_OPTIONS } from "../constants/size-options";
+import {
+  SIZE_OPTIONS,
+  IMAGE_COUNT_OPTIONS,
+  clampSizeToModel,
+} from "../constants/size-options";
 import {
   GenerateSection,
   SectionTitle,
@@ -113,7 +117,7 @@ export const ImagesTab: React.FC = () => {
 
     await Promise.all(promises);
     setIsGenerating(false);
-  }, [imagePrompt, imageGenParams, images.length, addImage]);
+  }, [imagePrompt, imageGenParams, images.length, addImage, setIsGenerating]);
 
   return (
     <>
@@ -129,9 +133,13 @@ export const ImagesTab: React.FC = () => {
             <FieldLabel>Model:</FieldLabel>
             <StyledSelect
               value={imageGenParams.model}
-              onChange={(e) =>
-                setImageGenParams({ model: e.target.value as ImageModel })
-              }
+              onChange={(e) => {
+                const newModel = e.target.value as ImageModel;
+                setImageGenParams({
+                  model: newModel,
+                  size: clampSizeToModel(imageGenParams.size, newModel),
+                });
+              }}
             >
               {(Object.keys(MODEL_LABELS) as ImageModel[]).map((m) => (
                 <option key={m} value={m}>

--- a/src/components/pages/studio/components/results-tab.styled.tsx
+++ b/src/components/pages/studio/components/results-tab.styled.tsx
@@ -101,6 +101,19 @@ export const TimeEstimate = styled.span`
   color: #888;
 `;
 
+export const UprezSelect = styled.select`
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${(props) => props.theme.colorBackgroundQuaternary};
+  border-radius: 6px;
+  background: ${(props) =>
+    props.theme.colorBackgroundSecondary || "transparent"};
+  color: ${(props) => props.theme.textPrimaryColor};
+  font-size: 0.8125rem;
+  cursor: pointer;
+  width: auto;
+  min-width: 180px;
+`;
+
 export const ActionButton = styled.button<{
   $variant?: "primary" | "secondary";
 }>`

--- a/src/components/pages/studio/components/results-tab.tsx
+++ b/src/components/pages/studio/components/results-tab.tsx
@@ -8,8 +8,8 @@ import { useUserPlaylists } from "../hooks/useUserPlaylists";
 import {
   clampDurationToAllowed,
   getAllowedDurationsForActions,
-  hasActionLoras,
 } from "../constants/duration-options";
+import { buildVideoAlgoParams } from "../utils/build-video-algo-params";
 import { PresignedImage } from "@/components/shared/presigned-image";
 import {
   GenerateSection,
@@ -191,13 +191,13 @@ export const ResultsTab: React.FC = () => {
             const algoParams =
               uprezModel === "nvidia-uprez"
                 ? {
-                    infinidream_algorithm: "nvidia-uprez" as const,
+                    infinidream_algorithm: "nvidia-uprez",
                     video_uuid: job.dreamUuid,
                     upscale_factor: 2,
-                    quality: "HIGH" as const,
+                    quality: "HIGH",
                   }
                 : {
-                    infinidream_algorithm: "uprez" as const,
+                    infinidream_algorithm: "uprez",
                     video_uuid: job.dreamUuid,
                     upscale_factor: 2,
                     interpolation_factor: 2,
@@ -288,42 +288,23 @@ export const ResultsTab: React.FC = () => {
             const action = actions.find((a) => a.id === job.actionId);
             if (!image || !action) return;
 
-            const hasLoras = hasActionLoras(action);
+            // Use the original job's model for retry, not the current selection
+            const retryModel =
+              job.jobType === "wan-i2v" || job.jobType === "ltx-i2v"
+                ? job.jobType
+                : videoGenParams.model;
+
             const batchIdentifier = createComboKey(image.uuid, action.prompt);
 
-            let algoParams: Record<string, unknown>;
-            if (videoGenParams.model === "ltx-i2v") {
-              algoParams = {
-                infinidream_algorithm: "ltx-i2v" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-              };
-            } else if (hasLoras) {
-              algoParams = {
-                infinidream_algorithm: "wan-i2v-lora" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-                seed: -1,
-                high_noise_loras: action.highNoiseLoras ?? [],
-                low_noise_loras: action.lowNoiseLoras ?? [],
-              };
-            } else {
-              algoParams = {
-                infinidream_algorithm: "wan-i2v" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                size: image.size || "1280*720",
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-              };
-            }
+            const algoParams = buildVideoAlgoParams({
+              model: retryModel,
+              action,
+              imageUuid: image.uuid,
+              imageSize: image.size,
+              duration,
+              numInferenceSteps: videoGenParams.numInferenceSteps,
+              guidance: videoGenParams.guidance,
+            });
 
             const response = await createDream.mutateAsync({
               name: `${image.name} - ${action.prompt.slice(0, 40)}`,
@@ -339,7 +320,7 @@ export const ResultsTab: React.FC = () => {
               imageId: job.imageId,
               actionId: job.actionId,
               dreamUuid: dream.uuid,
-              jobType: videoGenParams.model,
+              jobType: retryModel,
               status: (dream.status as StudioJob["status"]) || "queue",
               selectedForUprez: false,
             });

--- a/src/components/pages/studio/components/results-tab.tsx
+++ b/src/components/pages/studio/components/results-tab.tsx
@@ -11,11 +11,7 @@ import {
 } from "../constants/duration-options";
 import { buildVideoAlgoParams } from "../utils/build-video-algo-params";
 import { PresignedImage } from "@/components/shared/presigned-image";
-import {
-  GenerateSection,
-  SectionTitle,
-  StyledSelect,
-} from "./images-tab.styled";
+import { GenerateSection, SectionTitle } from "./images-tab.styled";
 import { GridTable, GridHeader, GridRowHeader } from "./generate-tab.styled";
 import {
   ProgressBar,
@@ -31,6 +27,7 @@ import {
   ActionButton,
   ScrollableGrid,
   TimeEstimate,
+  UprezSelect,
 } from "./results-tab.styled";
 
 const BATCH_SIZE = 5;
@@ -39,6 +36,8 @@ const UPREZ_MODEL_LABELS: Record<UprezModel, string> = {
   uprez: "Current Uprez",
   "nvidia-uprez": "Nvidia Super Resolution",
 };
+
+const UPREZ_MODELS: UprezModel[] = ["uprez", "nvidia-uprez"];
 
 export const ResultsTab: React.FC = () => {
   const images = useStudioStore((s) => s.images);
@@ -511,17 +510,16 @@ export const ResultsTab: React.FC = () => {
               : "Select All for Uprez"}
           </ActionButton>
         )}
-        <StyledSelect
+        <UprezSelect
           value={uprezModel}
           onChange={(e) => setUprezModel(e.target.value as UprezModel)}
-          style={{ width: "auto", minWidth: 180 }}
         >
-          {(Object.keys(UPREZ_MODEL_LABELS) as UprezModel[]).map((m) => (
+          {UPREZ_MODELS.map((m) => (
             <option key={m} value={m}>
               {UPREZ_MODEL_LABELS[m]}
             </option>
           ))}
-        </StyledSelect>
+        </UprezSelect>
         <ActionButton
           $variant="primary"
           disabled={uprezCount === 0 || isUprezzing}

--- a/src/components/pages/studio/components/results-tab.tsx
+++ b/src/components/pages/studio/components/results-tab.tsx
@@ -49,7 +49,7 @@ export const ResultsTab: React.FC = () => {
   const createDream = useCreateDreamFromPrompt();
   const { addPlaylistToCache } = useUserPlaylists();
 
-  const wanParams = useStudioStore((s) => s.wanParams);
+  const videoGenParams = useStudioStore((s) => s.videoGenParams);
   const removeJob = useStudioStore((s) => s.removeJob);
 
   const [isUprezzing, setIsUprezzing] = useState(false);
@@ -236,18 +236,22 @@ export const ResultsTab: React.FC = () => {
   ]);
 
   const handleRetryFailed = useCallback(async () => {
-    // Only retry wan-i2v jobs (uprez retries not yet supported)
+    // Only retry video generation jobs (uprez retries not yet supported)
     const failedJobs = jobs.filter(
-      (j) => j.status === "failed" && j.jobType !== "uprez",
+      (j) =>
+        j.status === "failed" &&
+        j.jobType !== "uprez" &&
+        j.jobType !== "nvidia-uprez",
     );
     if (failedJobs.length === 0) return;
 
     const failedActionIds = new Set(failedJobs.map((j) => j.actionId));
     const allowedDurations = getAllowedDurationsForActions(
       actions.filter((action) => failedActionIds.has(action.id)),
+      videoGenParams.model,
     );
     const duration = clampDurationToAllowed(
-      wanParams.duration,
+      videoGenParams.duration,
       allowedDurations,
     );
 
@@ -263,30 +267,41 @@ export const ResultsTab: React.FC = () => {
             if (!image || !action) return;
 
             const hasLoras = hasActionLoras(action);
-
             const batchIdentifier = createComboKey(image.uuid, action.prompt);
 
-            const algoParams = hasLoras
-              ? {
-                  infinidream_algorithm: "wan-i2v-lora" as const,
-                  prompt: action.prompt,
-                  image: image.uuid,
-                  duration,
-                  num_inference_steps: wanParams.numInferenceSteps,
-                  guidance: wanParams.guidance,
-                  seed: -1,
-                  high_noise_loras: action.highNoiseLoras ?? [],
-                  low_noise_loras: action.lowNoiseLoras ?? [],
-                }
-              : {
-                  infinidream_algorithm: "wan-i2v" as const,
-                  prompt: action.prompt,
-                  image: image.uuid,
-                  size: image.size || "1280*720",
-                  duration,
-                  num_inference_steps: wanParams.numInferenceSteps,
-                  guidance: wanParams.guidance,
-                };
+            let algoParams: Record<string, unknown>;
+            if (videoGenParams.model === "ltx-i2v") {
+              algoParams = {
+                infinidream_algorithm: "ltx-i2v" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+              };
+            } else if (hasLoras) {
+              algoParams = {
+                infinidream_algorithm: "wan-i2v-lora" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+                seed: -1,
+                high_noise_loras: action.highNoiseLoras ?? [],
+                low_noise_loras: action.lowNoiseLoras ?? [],
+              };
+            } else {
+              algoParams = {
+                infinidream_algorithm: "wan-i2v" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                size: image.size || "1280*720",
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+              };
+            }
 
             const response = await createDream.mutateAsync({
               name: `${image.name} - ${action.prompt.slice(0, 40)}`,
@@ -302,7 +317,7 @@ export const ResultsTab: React.FC = () => {
               imageId: job.imageId,
               actionId: job.actionId,
               dreamUuid: dream.uuid,
-              jobType: "wan-i2v",
+              jobType: videoGenParams.model,
               status: (dream.status as StudioJob["status"]) || "queue",
               selectedForUprez: false,
             });
@@ -332,7 +347,7 @@ export const ResultsTab: React.FC = () => {
     jobs,
     images,
     actions,
-    wanParams,
+    videoGenParams,
     createDream,
     removeJob,
     addJob,

--- a/src/components/pages/studio/components/results-tab.tsx
+++ b/src/components/pages/studio/components/results-tab.tsx
@@ -3,7 +3,7 @@ import { useStudioStore } from "@/stores/studio.store";
 import { useCreateDreamFromPrompt } from "@/api/dream/mutation/useCreateDreamFromPrompt";
 import { axiosClient } from "@/client/axios.client";
 import { createComboKey } from "@/types/studio.types";
-import type { StudioJob } from "@/types/studio.types";
+import type { StudioJob, UprezModel } from "@/types/studio.types";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
 import {
   clampDurationToAllowed,
@@ -11,7 +11,11 @@ import {
   hasActionLoras,
 } from "../constants/duration-options";
 import { PresignedImage } from "@/components/shared/presigned-image";
-import { GenerateSection, SectionTitle } from "./images-tab.styled";
+import {
+  GenerateSection,
+  SectionTitle,
+  StyledSelect,
+} from "./images-tab.styled";
 import { GridTable, GridHeader, GridRowHeader } from "./generate-tab.styled";
 import {
   ProgressBar,
@@ -30,6 +34,11 @@ import {
 } from "./results-tab.styled";
 
 const BATCH_SIZE = 5;
+
+const UPREZ_MODEL_LABELS: Record<UprezModel, string> = {
+  uprez: "Current Uprez",
+  "nvidia-uprez": "Nvidia Super Resolution",
+};
 
 export const ResultsTab: React.FC = () => {
   const images = useStudioStore((s) => s.images);
@@ -50,6 +59,8 @@ export const ResultsTab: React.FC = () => {
   const { addPlaylistToCache } = useUserPlaylists();
 
   const videoGenParams = useStudioStore((s) => s.videoGenParams);
+  const uprezModel = useStudioStore((s) => s.uprezModel);
+  const setUprezModel = useStudioStore((s) => s.setUprezModel);
   const removeJob = useStudioStore((s) => s.removeJob);
 
   const [isUprezzing, setIsUprezzing] = useState(false);
@@ -59,7 +70,7 @@ export const ResultsTab: React.FC = () => {
   const gridImageIds = useMemo(() => {
     const ids = new Set<string>();
     jobs
-      .filter((j) => j.jobType !== "uprez")
+      .filter((j) => j.jobType !== "uprez" && j.jobType !== "nvidia-uprez")
       .forEach((j) => ids.add(j.imageId));
     return [...ids];
   }, [jobs]);
@@ -67,7 +78,7 @@ export const ResultsTab: React.FC = () => {
   const gridActionIds = useMemo(() => {
     const ids = new Set<string>();
     jobs
-      .filter((j) => j.jobType !== "uprez")
+      .filter((j) => j.jobType !== "uprez" && j.jobType !== "nvidia-uprez")
       .forEach((j) => ids.add(j.actionId));
     return [...ids];
   }, [jobs]);
@@ -89,7 +100,8 @@ export const ResultsTab: React.FC = () => {
   );
 
   const wanJobs = useMemo(
-    () => jobs.filter((j) => j.jobType !== "uprez"),
+    () =>
+      jobs.filter((j) => j.jobType !== "uprez" && j.jobType !== "nvidia-uprez"),
     [jobs],
   );
 
@@ -136,7 +148,7 @@ export const ResultsTab: React.FC = () => {
   const jobMap = useMemo(() => {
     const map = new Map<string, StudioJob>();
     for (const j of jobs) {
-      if (j.jobType !== "uprez") {
+      if (j.jobType !== "uprez" && j.jobType !== "nvidia-uprez") {
         map.set(`${j.imageId}:${j.actionId}`, j);
       }
     }
@@ -149,6 +161,7 @@ export const ResultsTab: React.FC = () => {
         j.selectedForUprez &&
         j.status === "processed" &&
         j.jobType !== "uprez" &&
+        j.jobType !== "nvidia-uprez" &&
         !j.uprezed,
     );
     if (toUprez.length === 0) return;
@@ -175,12 +188,20 @@ export const ResultsTab: React.FC = () => {
 
         const results = await Promise.allSettled(
           batch.map(async (job) => {
-            const algoParams = {
-              infinidream_algorithm: "uprez",
-              video_uuid: job.dreamUuid,
-              upscale_factor: 2,
-              interpolation_factor: 2,
-            };
+            const algoParams =
+              uprezModel === "nvidia-uprez"
+                ? {
+                    infinidream_algorithm: "nvidia-uprez" as const,
+                    video_uuid: job.dreamUuid,
+                    upscale_factor: 2,
+                    quality: "HIGH" as const,
+                  }
+                : {
+                    infinidream_algorithm: "uprez" as const,
+                    video_uuid: job.dreamUuid,
+                    upscale_factor: 2,
+                    interpolation_factor: 2,
+                  };
 
             const response = await createDream.mutateAsync({
               name: `Uprez - ${job.dreamUuid.slice(0, 8)}`,
@@ -195,7 +216,7 @@ export const ResultsTab: React.FC = () => {
               imageId: job.imageId,
               actionId: `uprez-${job.actionId}`,
               dreamUuid: dream.uuid,
-              jobType: "uprez",
+              jobType: uprezModel,
               status: (dream.status as StudioJob["status"]) || "queue",
               selectedForUprez: false,
             });
@@ -230,6 +251,7 @@ export const ResultsTab: React.FC = () => {
     createDream,
     addJob,
     updateJob,
+    uprezModel,
     uprezPlaylistId,
     setUprezPlaylistId,
     addPlaylistToCache,
@@ -508,6 +530,17 @@ export const ResultsTab: React.FC = () => {
               : "Select All for Uprez"}
           </ActionButton>
         )}
+        <StyledSelect
+          value={uprezModel}
+          onChange={(e) => setUprezModel(e.target.value as UprezModel)}
+          style={{ width: "auto", minWidth: 180 }}
+        >
+          {(Object.keys(UPREZ_MODEL_LABELS) as UprezModel[]).map((m) => (
+            <option key={m} value={m}>
+              {UPREZ_MODEL_LABELS[m]}
+            </option>
+          ))}
+        </StyledSelect>
         <ActionButton
           $variant="primary"
           disabled={uprezCount === 0 || isUprezzing}

--- a/src/components/pages/studio/constants/action-presets.ts
+++ b/src/components/pages/studio/constants/action-presets.ts
@@ -129,6 +129,62 @@ export const ACTION_PRESETS: PresetPack[] = [
     ],
   },
   {
+    name: "LTX Camera",
+    model: "ltx-i2v",
+    actions: [
+      {
+        prompt: "static camera, subtle ambient movement",
+        enabled: true,
+        highNoiseLoras: [
+          {
+            path: "ltx-2-19b-lora-camera-control-static.safetensors",
+            scale: 0.4,
+          },
+        ],
+      },
+      {
+        prompt: "slow dolly in, camera pushing forward into the scene",
+        enabled: false,
+        highNoiseLoras: [
+          {
+            path: "ltx-2-19b-lora-camera-control-dolly-in.safetensors",
+            scale: 0.4,
+          },
+        ],
+      },
+      {
+        prompt: "slow dolly out, camera pulling back to reveal",
+        enabled: false,
+        highNoiseLoras: [
+          {
+            path: "ltx-2-19b-lora-camera-control-dolly-out.safetensors",
+            scale: 0.4,
+          },
+        ],
+      },
+      {
+        prompt: "jib up, camera rising above the scene",
+        enabled: false,
+        highNoiseLoras: [
+          {
+            path: "ltx-2-19b-lora-camera-control-jib-up.safetensors",
+            scale: 0.4,
+          },
+        ],
+      },
+      {
+        prompt: "jib down, camera descending into the scene",
+        enabled: false,
+        highNoiseLoras: [
+          {
+            path: "ltx-2-19b-lora-camera-control-jib-down.safetensors",
+            scale: 0.4,
+          },
+        ],
+      },
+    ],
+  },
+  {
     name: "Organic",
     model: "all",
     actions: [

--- a/src/components/pages/studio/constants/action-presets.ts
+++ b/src/components/pages/studio/constants/action-presets.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 export interface PresetPack {
   name: string;
+  model: "wan-i2v" | "ltx-i2v" | "all";
   actions: Omit<StudioAction, "id">[];
 }
 
@@ -14,6 +15,7 @@ const loraUrl = (repo: string, file: string) =>
 export const ACTION_PRESETS: PresetPack[] = [
   {
     name: "Camera Basics",
+    model: "wan-i2v",
     actions: [
       {
         prompt: "slow zoom in, camera gently pushing forward",
@@ -93,6 +95,7 @@ export const ACTION_PRESETS: PresetPack[] = [
   },
   {
     name: "Cinematic",
+    model: "wan-i2v",
     actions: [
       { prompt: "dolly forward, smooth cinematic approach", enabled: true },
       {
@@ -127,6 +130,7 @@ export const ACTION_PRESETS: PresetPack[] = [
   },
   {
     name: "Organic",
+    model: "all",
     actions: [
       { prompt: "gentle breathing motion, subtle life", enabled: true },
       { prompt: "subtle sway, natural wind movement", enabled: true },
@@ -136,6 +140,7 @@ export const ACTION_PRESETS: PresetPack[] = [
   },
   {
     name: "Abstract",
+    model: "all",
     actions: [
       { prompt: "morph and flow, organic transformation", enabled: true },
       { prompt: "color shift, gradual hue rotation", enabled: true },

--- a/src/components/pages/studio/constants/action-presets.ts
+++ b/src/components/pages/studio/constants/action-presets.ts
@@ -17,7 +17,7 @@ export const ACTION_PRESETS: PresetPack[] = [
     actions: [
       {
         prompt: "slow zoom in, camera gently pushing forward",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl("zoom_in_lora", "wan22_14b_i2v_zoom_in.safetensors"),
@@ -27,7 +27,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       },
       {
         prompt: "slow zoom out, camera pulling back to reveal",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl(
@@ -40,7 +40,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       },
       {
         prompt: "pan left to right, smooth motion",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl(
@@ -53,7 +53,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       },
       {
         prompt: "pan right to left, smooth motion",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl(
@@ -66,7 +66,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       },
       {
         prompt: "pan upward, revealing sky",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl("tilt_up_lora", "wan22_14b_i2v_tilt_up.safetensors"),
@@ -76,7 +76,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       },
       {
         prompt: "pan downward, descending",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl(
@@ -97,7 +97,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       { prompt: "dolly forward, smooth cinematic approach", enabled: true },
       {
         prompt: "orbit around subject, 180 degrees, smooth motion",
-        enabled: true,
+        enabled: false,
         highNoiseLoras: [
           {
             path: loraUrl(
@@ -120,7 +120,7 @@ export const ACTION_PRESETS: PresetPack[] = [
       { prompt: "crane up, rising above the scene", enabled: true },
       {
         prompt: "tracking shot, following motion left to right",
-        enabled: true,
+        enabled: false,
       },
       { prompt: "rack focus, shifting depth of field", enabled: true },
     ],

--- a/src/components/pages/studio/constants/duration-options.ts
+++ b/src/components/pages/studio/constants/duration-options.ts
@@ -1,9 +1,11 @@
 import type { StudioAction } from "@/types/studio.types";
+import type { VideoModel } from "@/types/studio.types";
 
 type ActionWithLoras = Pick<StudioAction, "highNoiseLoras" | "lowNoiseLoras">;
 
 export const DURATION_OPTIONS_LORA = [5, 8] as const;
 export const DURATION_OPTIONS_DEFAULT = [5, 8, 10] as const;
+export const DURATION_OPTIONS_LTX = [5, 10, 15, 20] as const;
 
 export const hasActionLoras = (action: ActionWithLoras): boolean =>
   (action.highNoiseLoras?.length ?? 0) > 0 ||
@@ -11,7 +13,12 @@ export const hasActionLoras = (action: ActionWithLoras): boolean =>
 
 export const getAllowedDurationsForActions = (
   actions: ActionWithLoras[],
+  model: VideoModel = "wan-i2v",
 ): number[] => {
+  if (model === "ltx-i2v") {
+    return [...DURATION_OPTIONS_LTX];
+  }
+
   if (actions.length === 0) {
     return [...DURATION_OPTIONS_DEFAULT];
   }

--- a/src/components/pages/studio/constants/size-options.test.ts
+++ b/src/components/pages/studio/constants/size-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { clampSizeToModel } from "./size-options";
+
+describe("clampSizeToModel", () => {
+  it("keeps size if valid for new model", () => {
+    expect(clampSizeToModel("1280*720", "qwen-image")).toBe("1280*720");
+  });
+
+  it("resets to first option when size is invalid for new model", () => {
+    // 768*768 is valid for z-image-turbo but NOT for qwen-image
+    expect(clampSizeToModel("768*768", "qwen-image")).toBe("1280*720");
+  });
+
+  it("keeps ZIT-only sizes when switching to ZIT", () => {
+    expect(clampSizeToModel("768*768", "z-image-turbo")).toBe("768*768");
+  });
+
+  it("resets to first ZIT size when size is invalid", () => {
+    expect(clampSizeToModel("nonsense", "z-image-turbo")).toBe("1280*720");
+  });
+});

--- a/src/components/pages/studio/constants/size-options.ts
+++ b/src/components/pages/studio/constants/size-options.ts
@@ -19,3 +19,11 @@ export const SIZE_OPTIONS: Record<ImageModel, readonly string[]> = {
 };
 
 export const IMAGE_COUNT_OPTIONS = [1, 4, 8, 12, 16, 24] as const;
+
+export const clampSizeToModel = (
+  currentSize: string,
+  model: ImageModel,
+): string => {
+  const sizes = SIZE_OPTIONS[model];
+  return sizes.includes(currentSize) ? currentSize : sizes[0];
+};

--- a/src/components/pages/studio/constants/size-options.ts
+++ b/src/components/pages/studio/constants/size-options.ts
@@ -1,0 +1,21 @@
+import type { ImageModel } from "@/types/studio.types";
+
+const QWEN_SIZES = ["1280*720", "1024*1024", "720*1280", "512*512"] as const;
+
+const ZIT_SIZES = [
+  "1280*720",
+  "1024*1024",
+  "720*1280",
+  "512*512",
+  "768*768",
+  "1280*1280",
+  "1024*768",
+  "768*1024",
+] as const;
+
+export const SIZE_OPTIONS: Record<ImageModel, readonly string[]> = {
+  "qwen-image": QWEN_SIZES,
+  "zit-image": ZIT_SIZES,
+};
+
+export const IMAGE_COUNT_OPTIONS = [1, 4, 8, 12, 16, 24] as const;

--- a/src/components/pages/studio/constants/size-options.ts
+++ b/src/components/pages/studio/constants/size-options.ts
@@ -15,7 +15,7 @@ const ZIT_SIZES = [
 
 export const SIZE_OPTIONS: Record<ImageModel, readonly string[]> = {
   "qwen-image": QWEN_SIZES,
-  "zit-image": ZIT_SIZES,
+  "z-image-turbo": ZIT_SIZES,
 };
 
 export const IMAGE_COUNT_OPTIONS = [1, 4, 8, 12, 16, 24] as const;

--- a/src/components/pages/studio/hooks/useBatchSubmit.ts
+++ b/src/components/pages/studio/hooks/useBatchSubmit.ts
@@ -6,8 +6,8 @@ import { createComboKey } from "@/types/studio.types";
 import {
   clampDurationToAllowed,
   getAllowedDurationsForActions,
-  hasActionLoras,
 } from "../constants/duration-options";
+import { buildVideoAlgoParams } from "../utils/build-video-algo-params";
 
 // Serialized to avoid concurrent auth refresh races (see fix/session-refresh-race on backend)
 const BATCH_SIZE = 1;
@@ -86,41 +86,16 @@ export const useBatchSubmit = () => {
         const results = await Promise.allSettled(
           batch.map(async ({ image, action }) => {
             const batchIdentifier = createComboKey(image.uuid, action.prompt);
-            const hasLoras = hasActionLoras(action);
 
-            let algoParams: Record<string, unknown>;
-            if (videoGenParams.model === "ltx-i2v") {
-              algoParams = {
-                infinidream_algorithm: "ltx-i2v" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-              };
-            } else if (hasLoras) {
-              algoParams = {
-                infinidream_algorithm: "wan-i2v-lora" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-                seed: -1,
-                high_noise_loras: action.highNoiseLoras ?? [],
-                low_noise_loras: action.lowNoiseLoras ?? [],
-              };
-            } else {
-              algoParams = {
-                infinidream_algorithm: "wan-i2v" as const,
-                prompt: action.prompt,
-                image: image.uuid,
-                size: image.size || "1280*720",
-                duration,
-                num_inference_steps: videoGenParams.numInferenceSteps,
-                guidance: videoGenParams.guidance,
-              };
-            }
+            const algoParams = buildVideoAlgoParams({
+              model: videoGenParams.model,
+              action,
+              imageUuid: image.uuid,
+              imageSize: image.size,
+              duration,
+              numInferenceSteps: videoGenParams.numInferenceSteps,
+              guidance: videoGenParams.guidance,
+            });
 
             const response = await createDream.mutateAsync({
               name: `${image.name} - ${action.prompt.slice(0, 40)}`,

--- a/src/components/pages/studio/hooks/useBatchSubmit.ts
+++ b/src/components/pages/studio/hooks/useBatchSubmit.ts
@@ -15,7 +15,7 @@ const BATCH_SIZE = 1;
 export const useBatchSubmit = () => {
   const images = useStudioStore((s) => s.images);
   const actions = useStudioStore((s) => s.actions);
-  const wanParams = useStudioStore((s) => s.wanParams);
+  const videoGenParams = useStudioStore((s) => s.videoGenParams);
   const excludedCombos = useStudioStore((s) => s.excludedCombos);
   const outputPlaylistId = useStudioStore((s) => s.outputPlaylistId);
   const setOutputPlaylistId = useStudioStore((s) => s.setOutputPlaylistId);
@@ -72,9 +72,10 @@ export const useBatchSubmit = () => {
       const combos = getSelectedCombinations();
       const allowedDurations = getAllowedDurationsForActions(
         combos.map(({ action }) => action),
+        videoGenParams.model,
       );
       const duration = clampDurationToAllowed(
-        wanParams.duration,
+        videoGenParams.duration,
         allowedDurations,
       );
       let jobsAdded = 0;
@@ -87,27 +88,39 @@ export const useBatchSubmit = () => {
             const batchIdentifier = createComboKey(image.uuid, action.prompt);
             const hasLoras = hasActionLoras(action);
 
-            const algoParams = hasLoras
-              ? {
-                  infinidream_algorithm: "wan-i2v-lora" as const,
-                  prompt: action.prompt,
-                  image: image.uuid,
-                  duration,
-                  num_inference_steps: wanParams.numInferenceSteps,
-                  guidance: wanParams.guidance,
-                  seed: -1,
-                  high_noise_loras: action.highNoiseLoras ?? [],
-                  low_noise_loras: action.lowNoiseLoras ?? [],
-                }
-              : {
-                  infinidream_algorithm: "wan-i2v" as const,
-                  prompt: action.prompt,
-                  image: image.uuid,
-                  size: image.size || "1280*720",
-                  duration,
-                  num_inference_steps: wanParams.numInferenceSteps,
-                  guidance: wanParams.guidance,
-                };
+            let algoParams: Record<string, unknown>;
+            if (videoGenParams.model === "ltx-i2v") {
+              algoParams = {
+                infinidream_algorithm: "ltx-i2v" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+              };
+            } else if (hasLoras) {
+              algoParams = {
+                infinidream_algorithm: "wan-i2v-lora" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+                seed: -1,
+                high_noise_loras: action.highNoiseLoras ?? [],
+                low_noise_loras: action.lowNoiseLoras ?? [],
+              };
+            } else {
+              algoParams = {
+                infinidream_algorithm: "wan-i2v" as const,
+                prompt: action.prompt,
+                image: image.uuid,
+                size: image.size || "1280*720",
+                duration,
+                num_inference_steps: videoGenParams.numInferenceSteps,
+                guidance: videoGenParams.guidance,
+              };
+            }
 
             const response = await createDream.mutateAsync({
               name: `${image.name} - ${action.prompt.slice(0, 40)}`,
@@ -122,7 +135,7 @@ export const useBatchSubmit = () => {
               imageId: image.uuid,
               actionId: action.id,
               dreamUuid: dream.uuid,
-              jobType: "wan-i2v",
+              jobType: videoGenParams.model,
               status:
                 (dream.status as
                   | "queue"
@@ -157,7 +170,7 @@ export const useBatchSubmit = () => {
     outputPlaylistId,
     setOutputPlaylistId,
     getSelectedCombinations,
-    wanParams,
+    videoGenParams,
     createDream,
     addJob,
     setActiveTab,

--- a/src/components/pages/studio/hooks/useStudioJobProgress.ts
+++ b/src/components/pages/studio/hooks/useStudioJobProgress.ts
@@ -1,4 +1,5 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
 import useSocket from "@/hooks/useSocket";
 import { axiosClient } from "@/client/axios.client";
 import { useStudioStore } from "@/stores/studio.store";
@@ -13,19 +14,19 @@ const POLL_INTERVAL_MS = 10_000;
 
 export const useStudioJobProgress = () => {
   const { socket } = useSocket();
-  const images = useStudioStore((s) => s.images);
-  const jobs = useStudioStore((s) => s.jobs);
 
-  // Stable set of pending UUIDs that need socket rooms
-  const pendingUuids = useMemo(() => {
-    const imageUuids = images
-      .filter((img) => img.status === "queue" || img.status === "processing")
-      .map((img) => img.uuid);
-    const jobUuids = jobs
-      .filter((j) => j.status === "queue" || j.status === "processing")
-      .map((j) => j.dreamUuid);
-    return [...imageUuids, ...jobUuids];
-  }, [images, jobs]);
+  // Stable reference — only changes when the UUID set actually changes, not on every progress update
+  const pendingUuids = useStudioStore(
+    useShallow((s) => {
+      const imageUuids = s.images
+        .filter((img) => img.status === "queue" || img.status === "processing")
+        .map((img) => img.uuid);
+      const jobUuids = s.jobs
+        .filter((j) => j.status === "queue" || j.status === "processing")
+        .map((j) => j.dreamUuid);
+      return [...imageUuids, ...jobUuids];
+    }),
+  );
 
   // --- Effect 1: Register JOB_PROGRESS_EVENT listener ONCE per socket ---
   useEffect(() => {

--- a/src/components/pages/studio/hooks/useUserPlaylists.ts
+++ b/src/components/pages/studio/hooks/useUserPlaylists.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { axiosClient } from "@/client/axios.client";
 import useAuth from "@/hooks/useAuth";
@@ -31,12 +32,15 @@ export const useUserPlaylists = () => {
     { enabled: Boolean(user?.uuid) },
   );
 
-  const addPlaylistToCache = (playlist: PlaylistSummary) => {
-    queryClient.setQueryData<PlaylistSummary[]>(
-      [USER_PLAYLISTS_KEY, user?.uuid],
-      (old) => (old ? [playlist, ...old] : [playlist]),
-    );
-  };
+  const addPlaylistToCache = useCallback(
+    (playlist: PlaylistSummary) => {
+      queryClient.setQueryData<PlaylistSummary[]>(
+        [USER_PLAYLISTS_KEY, user?.uuid],
+        (old) => (old ? [playlist, ...old] : [playlist]),
+      );
+    },
+    [queryClient, user?.uuid],
+  );
 
   return { ...query, playlists: query.data ?? [], addPlaylistToCache };
 };

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -1,11 +1,20 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import { useStudioStore } from "@/stores/studio.store";
 import { StudioTabs } from "./components/studio-tabs";
-import { ImagesTab } from "./components/images-tab";
-import { ActionsTab } from "./components/actions-tab";
-import { GenerateTab } from "./components/generate-tab";
-import { ResultsTab } from "./components/results-tab";
 import { useStudioJobProgress } from "./hooks/useStudioJobProgress";
+
+const ImagesTab = lazy(() =>
+  import("./components/images-tab").then((m) => ({ default: m.ImagesTab })),
+);
+const ActionsTab = lazy(() =>
+  import("./components/actions-tab").then((m) => ({ default: m.ActionsTab })),
+);
+const GenerateTab = lazy(() =>
+  import("./components/generate-tab").then((m) => ({ default: m.GenerateTab })),
+);
+const ResultsTab = lazy(() =>
+  import("./components/results-tab").then((m) => ({ default: m.ResultsTab })),
+);
 import {
   StudioContainer,
   StudioHeader,
@@ -42,10 +51,12 @@ export const StudioPage: React.FC = () => {
         )}
       </StudioHeader>
       <StudioTabs />
-      {activeTab === "images" && <ImagesTab />}
-      {activeTab === "actions" && <ActionsTab />}
-      {activeTab === "generate" && <GenerateTab />}
-      {activeTab === "results" && <ResultsTab />}
+      <Suspense fallback={null}>
+        {activeTab === "images" && <ImagesTab />}
+        {activeTab === "actions" && <ActionsTab />}
+        {activeTab === "generate" && <GenerateTab />}
+        {activeTab === "results" && <ResultsTab />}
+      </Suspense>
     </StudioContainer>
   );
 };

--- a/src/components/pages/studio/utils/build-video-algo-params.test.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { buildVideoAlgoParams } from "./build-video-algo-params";
+import type { StudioAction } from "@/types/studio.types";
+
+const makeAction = (overrides: Partial<StudioAction> = {}): StudioAction => ({
+  id: "act1",
+  prompt: "slow zoom in",
+  enabled: true,
+  ...overrides,
+});
+
+describe("buildVideoAlgoParams", () => {
+  it("builds wan-i2v params without LoRAs", () => {
+    const result = buildVideoAlgoParams({
+      model: "wan-i2v",
+      action: makeAction(),
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+    });
+
+    expect(result).toEqual({
+      infinidream_algorithm: "wan-i2v",
+      prompt: "slow zoom in",
+      image: "img-uuid",
+      size: "1280*720",
+      duration: 5,
+      num_inference_steps: 30,
+      guidance: 5.0,
+    });
+  });
+
+  it("builds wan-i2v-lora params with LoRAs", () => {
+    const action = makeAction({
+      highNoiseLoras: [{ path: "zoom.safetensors", scale: 1.0 }],
+      lowNoiseLoras: [{ path: "detail.safetensors", scale: 0.5 }],
+    });
+
+    const result = buildVideoAlgoParams({
+      model: "wan-i2v",
+      action,
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+    });
+
+    expect(result).toEqual({
+      infinidream_algorithm: "wan-i2v-lora",
+      prompt: "slow zoom in",
+      image: "img-uuid",
+      duration: 5,
+      num_inference_steps: 30,
+      guidance: 5.0,
+      seed: -1,
+      high_noise_loras: [{ path: "zoom.safetensors", scale: 1.0 }],
+      low_noise_loras: [{ path: "detail.safetensors", scale: 0.5 }],
+    });
+  });
+
+  it("builds ltx-i2v params without LoRAs (no steps/guidance — worker controls these)", () => {
+    const result = buildVideoAlgoParams({
+      model: "ltx-i2v",
+      action: makeAction(),
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 10,
+      numInferenceSteps: 25,
+      guidance: 4.0,
+    });
+
+    // LTX worker handles steps/guidance internally
+    expect(result).toEqual({
+      infinidream_algorithm: "ltx-i2v",
+      prompt: "slow zoom in",
+      image: "img-uuid",
+      duration: 10,
+    });
+    expect(result).not.toHaveProperty("num_inference_steps");
+    expect(result).not.toHaveProperty("guidance");
+  });
+
+  it("builds ltx-i2v params WITH high_noise_loras (worker uses first LoRA only)", () => {
+    const action = makeAction({
+      highNoiseLoras: [
+        {
+          path: "ltx-2-19b-lora-camera-control-static.safetensors",
+          scale: 0.4,
+        },
+      ],
+    });
+
+    const result = buildVideoAlgoParams({
+      model: "ltx-i2v",
+      action,
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 10,
+      numInferenceSteps: 25,
+      guidance: 4.0,
+    });
+
+    expect(result).toEqual({
+      infinidream_algorithm: "ltx-i2v",
+      prompt: "slow zoom in",
+      image: "img-uuid",
+      duration: 10,
+      high_noise_loras: [
+        {
+          path: "ltx-2-19b-lora-camera-control-static.safetensors",
+          scale: 0.4,
+        },
+      ],
+    });
+    // Worker only reads high_noise_loras, not low_noise_loras
+    expect(result).not.toHaveProperty("low_noise_loras");
+  });
+
+  it("does not send high_noise_loras for LTX when action has only low_noise_loras", () => {
+    const action = makeAction({
+      lowNoiseLoras: [{ path: "some-lora.safetensors", scale: 0.3 }],
+    });
+
+    const result = buildVideoAlgoParams({
+      model: "ltx-i2v",
+      action,
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+    });
+
+    // LTX only uses high_noise_loras — low_noise_loras are Wan-only
+    expect(result).not.toHaveProperty("high_noise_loras");
+    expect(result).not.toHaveProperty("low_noise_loras");
+  });
+
+  it("defaults imageSize to 1280*720 when empty for wan-i2v", () => {
+    const result = buildVideoAlgoParams({
+      model: "wan-i2v",
+      action: makeAction(),
+      imageUuid: "img-uuid",
+      imageSize: undefined,
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+    });
+
+    expect(result.size).toBe("1280*720");
+  });
+});

--- a/src/components/pages/studio/utils/build-video-algo-params.test.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.test.ts
@@ -76,7 +76,7 @@ describe("buildVideoAlgoParams", () => {
     expect(result).toEqual({
       infinidream_algorithm: "ltx-i2v",
       prompt: "slow zoom in",
-      image: "img-uuid",
+      source_dream_uuid: "img-uuid",
       duration: 10,
     });
     expect(result).not.toHaveProperty("num_inference_steps");
@@ -106,7 +106,7 @@ describe("buildVideoAlgoParams", () => {
     expect(result).toEqual({
       infinidream_algorithm: "ltx-i2v",
       prompt: "slow zoom in",
-      image: "img-uuid",
+      source_dream_uuid: "img-uuid",
       duration: 10,
       high_noise_loras: [
         {

--- a/src/components/pages/studio/utils/build-video-algo-params.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.ts
@@ -28,7 +28,7 @@ export const buildVideoAlgoParams = ({
     const params: Record<string, unknown> = {
       infinidream_algorithm: "ltx-i2v",
       prompt: action.prompt,
-      image: imageUuid,
+      source_dream_uuid: imageUuid,
       duration,
     };
     if (hasLoras && action.highNoiseLoras?.length) {

--- a/src/components/pages/studio/utils/build-video-algo-params.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.ts
@@ -1,0 +1,63 @@
+import type { StudioAction, VideoModel } from "@/types/studio.types";
+import { hasActionLoras } from "../constants/duration-options";
+
+interface BuildVideoAlgoParamsInput {
+  model: VideoModel;
+  action: Pick<StudioAction, "prompt" | "highNoiseLoras" | "lowNoiseLoras">;
+  imageUuid: string;
+  imageSize: string | undefined;
+  duration: number;
+  numInferenceSteps: number;
+  guidance: number;
+}
+
+export const buildVideoAlgoParams = ({
+  model,
+  action,
+  imageUuid,
+  imageSize,
+  duration,
+  numInferenceSteps,
+  guidance,
+}: BuildVideoAlgoParamsInput): Record<string, unknown> => {
+  const hasLoras = hasActionLoras(action);
+
+  if (model === "ltx-i2v") {
+    // Worker handles steps/guidance internally (8+3 steps, cfg 1.0).
+    // Only high_noise_loras[0] is used (single LoRA via Power Lora Loader).
+    const params: Record<string, unknown> = {
+      infinidream_algorithm: "ltx-i2v",
+      prompt: action.prompt,
+      image: imageUuid,
+      duration,
+    };
+    if (hasLoras && action.highNoiseLoras?.length) {
+      params.high_noise_loras = action.highNoiseLoras;
+    }
+    return params;
+  }
+
+  if (hasLoras) {
+    return {
+      infinidream_algorithm: "wan-i2v-lora",
+      prompt: action.prompt,
+      image: imageUuid,
+      duration,
+      num_inference_steps: numInferenceSteps,
+      guidance,
+      seed: -1,
+      high_noise_loras: action.highNoiseLoras ?? [],
+      low_noise_loras: action.lowNoiseLoras ?? [],
+    };
+  }
+
+  return {
+    infinidream_algorithm: "wan-i2v",
+    prompt: action.prompt,
+    image: imageUuid,
+    size: imageSize || "1280*720",
+    duration,
+    num_inference_steps: numInferenceSteps,
+    guidance,
+  };
+};

--- a/src/stores/studio.store.test.ts
+++ b/src/stores/studio.store.test.ts
@@ -144,6 +144,140 @@ describe("studio.store", () => {
     });
   });
 
+  describe("selectAllJobsForUprez", () => {
+    it("does not select nvidia-uprez jobs for uprezzing", () => {
+      useStudioStore.getState().addJob({
+        imageId: "img1",
+        actionId: "act1",
+        dreamUuid: "dream1",
+        jobType: "wan-i2v",
+        status: "processed",
+        selectedForUprez: false,
+      });
+      useStudioStore.getState().addJob({
+        imageId: "img1",
+        actionId: "uprez-act1",
+        dreamUuid: "dream2",
+        jobType: "nvidia-uprez",
+        status: "processed",
+        selectedForUprez: false,
+      });
+      useStudioStore.getState().addJob({
+        imageId: "img1",
+        actionId: "uprez-act2",
+        dreamUuid: "dream3",
+        jobType: "uprez",
+        status: "processed",
+        selectedForUprez: false,
+      });
+
+      useStudioStore.getState().selectAllJobsForUprez();
+
+      const jobs = useStudioStore.getState().jobs;
+      // wan-i2v job should be selected
+      expect(jobs[0].selectedForUprez).toBe(true);
+      // nvidia-uprez job should NOT be selected
+      expect(jobs[1].selectedForUprez).toBe(false);
+      // uprez job should NOT be selected
+      expect(jobs[2].selectedForUprez).toBe(false);
+    });
+  });
+
+  describe("imageGenParams", () => {
+    it("partial update merges correctly", () => {
+      useStudioStore.getState().setImageGenParams({ model: "z-image-turbo" });
+      const params = useStudioStore.getState().imageGenParams;
+      expect(params.model).toBe("z-image-turbo");
+      expect(params.seedCount).toBe(8); // preserved from default
+      expect(params.size).toBe("1280*720"); // preserved from default
+    });
+  });
+
+  describe("videoGenParams", () => {
+    it("partial update merges correctly", () => {
+      useStudioStore.getState().setVideoGenParams({ model: "ltx-i2v" });
+      const params = useStudioStore.getState().videoGenParams;
+      expect(params.model).toBe("ltx-i2v");
+      expect(params.duration).toBe(5); // preserved
+      expect(params.numInferenceSteps).toBe(30); // preserved
+    });
+  });
+
+  describe("uprezModel", () => {
+    it("defaults to uprez", () => {
+      expect(useStudioStore.getState().uprezModel).toBe("uprez");
+    });
+
+    it("can be set to nvidia-uprez", () => {
+      useStudioStore.getState().setUprezModel("nvidia-uprez");
+      expect(useStudioStore.getState().uprezModel).toBe("nvidia-uprez");
+    });
+
+    it("resets on resetSession", () => {
+      useStudioStore.getState().setUprezModel("nvidia-uprez");
+      useStudioStore.getState().resetSession();
+      expect(useStudioStore.getState().uprezModel).toBe("uprez");
+    });
+  });
+
+  describe("migration v2 → v3 (edge cases)", () => {
+    it("supplies defaults when qwenParams has missing fields", () => {
+      const v2State = {
+        qwenParams: { seedCount: 4 }, // missing size
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate?.(v2State, 2) as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const params = migrated.imageGenParams as any;
+      expect(params.model).toBe("qwen-image");
+      expect(params.seedCount).toBe(4);
+      expect(params.size).toBe("1280*720"); // from defaults
+    });
+
+    it("supplies defaults when qwenParams is absent", () => {
+      const v2State = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate?.(v2State, 2) as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const params = migrated.imageGenParams as any;
+      expect(params.model).toBe("qwen-image");
+      expect(params.seedCount).toBe(8);
+      expect(params.size).toBe("1280*720");
+    });
+  });
+
+  describe("migration v3 → v4 (edge cases)", () => {
+    it("supplies defaults when wanParams has missing fields", () => {
+      const v3State = {
+        wanParams: { duration: 8 }, // missing numInferenceSteps, guidance
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate(v3State, 3) as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const params = migrated.videoGenParams as any;
+      expect(params.model).toBe("wan-i2v");
+      expect(params.duration).toBe(8);
+      expect(params.numInferenceSteps).toBe(30); // from defaults
+      expect(params.guidance).toBe(5.0); // from defaults
+    });
+
+    it("supplies defaults when wanParams is absent", () => {
+      const v3State = {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate(v3State, 3) as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const params = migrated.videoGenParams as any;
+      expect(params.model).toBe("wan-i2v");
+      expect(params.duration).toBe(5);
+      expect(params.numInferenceSteps).toBe(30);
+      expect(params.guidance).toBe(5.0);
+    });
+  });
+
   describe("partialize", () => {
     it("excludes previewFrame from persisted images", () => {
       useStudioStore.getState().addImage({

--- a/src/stores/studio.store.test.ts
+++ b/src/stores/studio.store.test.ts
@@ -126,6 +126,24 @@ describe("studio.store", () => {
     });
   });
 
+  describe("migration v3 → v4", () => {
+    it("renames wanParams to videoGenParams with default model", () => {
+      const v3State = {
+        wanParams: { duration: 5, numInferenceSteps: 30, guidance: 5.0 },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate(v3State, 3) as Record<string, unknown>;
+      expect(migrated.videoGenParams).toEqual({
+        model: "wan-i2v",
+        duration: 5,
+        numInferenceSteps: 30,
+        guidance: 5.0,
+      });
+      expect(migrated.wanParams).toBeUndefined();
+    });
+  });
+
   describe("partialize", () => {
     it("excludes previewFrame from persisted images", () => {
       useStudioStore.getState().addImage({

--- a/src/stores/studio.store.test.ts
+++ b/src/stores/studio.store.test.ts
@@ -109,6 +109,23 @@ describe("studio.store", () => {
     });
   });
 
+  describe("migration v2 → v3", () => {
+    it("renames qwenParams to imageGenParams with default model", () => {
+      const v2State = {
+        qwenParams: { seedCount: 8, size: "1280*720" },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const migrate = (useStudioStore as any).persist?.getOptions?.()?.migrate;
+      const migrated = migrate?.(v2State, 2) as Record<string, unknown>;
+      expect(migrated.imageGenParams).toEqual({
+        model: "qwen-image",
+        seedCount: 8,
+        size: "1280*720",
+      });
+      expect(migrated.qwenParams).toBeUndefined();
+    });
+  });
+
   describe("partialize", () => {
     it("excludes previewFrame from persisted images", () => {
       useStudioStore.getState().addImage({

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -190,7 +190,10 @@ export const useStudioStore = create<StudioState>()(
       selectAllJobsForUprez: () =>
         set((s) => ({
           jobs: s.jobs.map((j) =>
-            j.status === "processed" && j.jobType !== "uprez" && !j.uprezed
+            j.status === "processed" &&
+            j.jobType !== "uprez" &&
+            j.jobType !== "nvidia-uprez" &&
+            !j.uprezed
               ? { ...j, selectedForUprez: true }
               : j,
           ),
@@ -286,16 +289,20 @@ export const useStudioStore = create<StudioState>()(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const qp = state.qwenParams as any;
           if (qp) {
-            state.imageGenParams = { model: "qwen-image", ...qp };
+            state.imageGenParams = { ...DEFAULT_IMAGE_GEN_PARAMS, ...qp };
             delete state.qwenParams;
+          } else {
+            state.imageGenParams = { ...DEFAULT_IMAGE_GEN_PARAMS };
           }
         }
         if (version < 4) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const wp = state.wanParams as any;
           if (wp) {
-            state.videoGenParams = { model: "wan-i2v", ...wp };
+            state.videoGenParams = { ...DEFAULT_VIDEO_GEN_PARAMS, ...wp };
             delete state.wanParams;
+          } else {
+            state.videoGenParams = { ...DEFAULT_VIDEO_GEN_PARAMS };
           }
         }
         return state as Record<string, unknown>;

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -5,7 +5,7 @@ import type {
   StudioImage,
   StudioAction,
   StudioJob,
-  QwenParams,
+  ImageGenParams,
   WanI2VParams,
 } from "@/types/studio.types";
 
@@ -15,8 +15,8 @@ type StudioState = {
 
   imagePrompt: string;
   setImagePrompt: (prompt: string) => void;
-  qwenParams: QwenParams;
-  setQwenParams: (params: Partial<QwenParams>) => void;
+  imageGenParams: ImageGenParams;
+  setImageGenParams: (params: Partial<ImageGenParams>) => void;
   images: StudioImage[];
   addImage: (image: StudioImage) => void;
   updateImage: (uuid: string, updates: Partial<StudioImage>) => void;
@@ -60,7 +60,11 @@ type StudioState = {
   resetSession: () => void;
 };
 
-const DEFAULT_QWEN_PARAMS: QwenParams = { seedCount: 8, size: "1280*720" };
+const DEFAULT_IMAGE_GEN_PARAMS: ImageGenParams = {
+  model: "qwen-image",
+  seedCount: 8,
+  size: "1280*720",
+};
 const DEFAULT_WAN_PARAMS: WanI2VParams = {
   duration: 5,
   numInferenceSteps: 30,
@@ -78,9 +82,9 @@ export const useStudioStore = create<StudioState>()(
 
       imagePrompt: "",
       setImagePrompt: (prompt: string) => set({ imagePrompt: prompt }),
-      qwenParams: DEFAULT_QWEN_PARAMS,
-      setQwenParams: (params: Partial<QwenParams>) =>
-        set((s) => ({ qwenParams: { ...s.qwenParams, ...params } })),
+      imageGenParams: DEFAULT_IMAGE_GEN_PARAMS,
+      setImageGenParams: (params: Partial<ImageGenParams>) =>
+        set((s) => ({ imageGenParams: { ...s.imageGenParams, ...params } })),
       images: [] as StudioImage[],
       addImage: (image: StudioImage) =>
         set((s) => ({ images: [...s.images, image] })),
@@ -199,7 +203,7 @@ export const useStudioStore = create<StudioState>()(
         set({
           activeTab: "images" as StudioTab,
           imagePrompt: "",
-          qwenParams: DEFAULT_QWEN_PARAMS,
+          imageGenParams: DEFAULT_IMAGE_GEN_PARAMS,
           images: [],
           actions: [],
           wanParams: DEFAULT_WAN_PARAMS,
@@ -213,11 +217,11 @@ export const useStudioStore = create<StudioState>()(
     }),
     {
       name: "studio-session",
-      version: 2,
+      version: 3,
       partialize: (state) => ({
         activeTab: state.activeTab,
         imagePrompt: state.imagePrompt,
-        qwenParams: state.qwenParams,
+        imageGenParams: state.imageGenParams,
         images: state.images.map((img) => ({
           ...img,
           previewFrame: undefined,
@@ -268,6 +272,14 @@ export const useStudioStore = create<StudioState>()(
                 j.jobType ??
                 (j.actionId?.startsWith("uprez-") ? "uprez" : "wan-i2v"),
             }));
+          }
+        }
+        if (version < 3) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const qp = state.qwenParams as any;
+          if (qp) {
+            state.imageGenParams = { model: "qwen-image", ...qp };
+            delete state.qwenParams;
           }
         }
         return state as Record<string, unknown>;

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -6,7 +6,7 @@ import type {
   StudioAction,
   StudioJob,
   ImageGenParams,
-  WanI2VParams,
+  VideoGenParams,
 } from "@/types/studio.types";
 
 type StudioState = {
@@ -35,8 +35,8 @@ type StudioState = {
   toggleActionEnabled: (id: string) => void;
   loadPresetPack: (actions: StudioAction[]) => void;
 
-  wanParams: WanI2VParams;
-  setWanParams: (params: Partial<WanI2VParams>) => void;
+  videoGenParams: VideoGenParams;
+  setVideoGenParams: (params: Partial<VideoGenParams>) => void;
   outputPlaylistId: string | null;
   setOutputPlaylistId: (id: string | null) => void;
   uprezPlaylistId: string | null;
@@ -65,7 +65,8 @@ const DEFAULT_IMAGE_GEN_PARAMS: ImageGenParams = {
   seedCount: 8,
   size: "1280*720",
 };
-const DEFAULT_WAN_PARAMS: WanI2VParams = {
+const DEFAULT_VIDEO_GEN_PARAMS: VideoGenParams = {
+  model: "wan-i2v",
   duration: 5,
   numInferenceSteps: 30,
   guidance: 5.0,
@@ -136,9 +137,9 @@ export const useStudioStore = create<StudioState>()(
       loadPresetPack: (newActions: StudioAction[]) =>
         set((s) => ({ actions: [...s.actions, ...newActions] })),
 
-      wanParams: DEFAULT_WAN_PARAMS,
-      setWanParams: (params: Partial<WanI2VParams>) =>
-        set((s) => ({ wanParams: { ...s.wanParams, ...params } })),
+      videoGenParams: DEFAULT_VIDEO_GEN_PARAMS,
+      setVideoGenParams: (params: Partial<VideoGenParams>) =>
+        set((s) => ({ videoGenParams: { ...s.videoGenParams, ...params } })),
       outputPlaylistId: null,
       setOutputPlaylistId: (id: string | null) => set({ outputPlaylistId: id }),
       uprezPlaylistId: null,
@@ -206,7 +207,7 @@ export const useStudioStore = create<StudioState>()(
           imageGenParams: DEFAULT_IMAGE_GEN_PARAMS,
           images: [],
           actions: [],
-          wanParams: DEFAULT_WAN_PARAMS,
+          videoGenParams: DEFAULT_VIDEO_GEN_PARAMS,
           outputPlaylistId: null,
           uprezPlaylistId: null,
           excludedCombos: new Set<string>(),
@@ -217,7 +218,7 @@ export const useStudioStore = create<StudioState>()(
     }),
     {
       name: "studio-session",
-      version: 3,
+      version: 4,
       partialize: (state) => ({
         activeTab: state.activeTab,
         imagePrompt: state.imagePrompt,
@@ -227,7 +228,7 @@ export const useStudioStore = create<StudioState>()(
           previewFrame: undefined,
         })),
         actions: state.actions,
-        wanParams: state.wanParams,
+        videoGenParams: state.videoGenParams,
         outputPlaylistId: state.outputPlaylistId,
         uprezPlaylistId: state.uprezPlaylistId,
         excludedCombos: [...(state.excludedCombos as Set<string>)],
@@ -280,6 +281,14 @@ export const useStudioStore = create<StudioState>()(
           if (qp) {
             state.imageGenParams = { model: "qwen-image", ...qp };
             delete state.qwenParams;
+          }
+        }
+        if (version < 4) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const wp = state.wanParams as any;
+          if (wp) {
+            state.videoGenParams = { model: "wan-i2v", ...wp };
+            delete state.wanParams;
           }
         }
         return state as Record<string, unknown>;

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -7,6 +7,7 @@ import type {
   StudioJob,
   ImageGenParams,
   VideoGenParams,
+  UprezModel,
 } from "@/types/studio.types";
 
 type StudioState = {
@@ -39,6 +40,8 @@ type StudioState = {
   setVideoGenParams: (params: Partial<VideoGenParams>) => void;
   outputPlaylistId: string | null;
   setOutputPlaylistId: (id: string | null) => void;
+  uprezModel: UprezModel;
+  setUprezModel: (model: UprezModel) => void;
   uprezPlaylistId: string | null;
   setUprezPlaylistId: (id: string | null) => void;
 
@@ -142,6 +145,8 @@ export const useStudioStore = create<StudioState>()(
         set((s) => ({ videoGenParams: { ...s.videoGenParams, ...params } })),
       outputPlaylistId: null,
       setOutputPlaylistId: (id: string | null) => set({ outputPlaylistId: id }),
+      uprezModel: "uprez" as UprezModel,
+      setUprezModel: (model: UprezModel) => set({ uprezModel: model }),
       uprezPlaylistId: null,
       setUprezPlaylistId: (id: string | null) => set({ uprezPlaylistId: id }),
 
@@ -208,6 +213,7 @@ export const useStudioStore = create<StudioState>()(
           images: [],
           actions: [],
           videoGenParams: DEFAULT_VIDEO_GEN_PARAMS,
+          uprezModel: "uprez" as UprezModel,
           outputPlaylistId: null,
           uprezPlaylistId: null,
           excludedCombos: new Set<string>(),
@@ -229,6 +235,7 @@ export const useStudioStore = create<StudioState>()(
         })),
         actions: state.actions,
         videoGenParams: state.videoGenParams,
+        uprezModel: state.uprezModel,
         outputPlaylistId: state.outputPlaylistId,
         uprezPlaylistId: state.uprezPlaylistId,
         excludedCombos: [...(state.excludedCombos as Set<string>)],

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -48,7 +48,10 @@ export interface WanI2VParams {
   guidance: number;
 }
 
-export interface QwenParams {
+export type ImageModel = "qwen-image" | "zit-image";
+
+export interface ImageGenParams {
+  model: ImageModel;
   seedCount: number;
   size: string;
 }

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -46,12 +46,6 @@ export interface StudioJob {
   completedAt?: number;
 }
 
-export interface WanI2VParams {
-  duration: number;
-  numInferenceSteps: number;
-  guidance: number;
-}
-
 export interface VideoGenParams {
   model: VideoModel;
   duration: number;

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -27,6 +27,8 @@ export interface StudioAction {
 
 export type VideoModel = "wan-i2v" | "ltx-i2v";
 
+export type UprezModel = "uprez" | "nvidia-uprez";
+
 export type StudioJobType = "wan-i2v" | "ltx-i2v" | "uprez" | "nvidia-uprez";
 
 export interface StudioJob {

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -25,7 +25,9 @@ export interface StudioAction {
   lowNoiseLoras?: LoRAConfig[];
 }
 
-export type StudioJobType = "wan-i2v" | "uprez";
+export type VideoModel = "wan-i2v" | "ltx-i2v";
+
+export type StudioJobType = "wan-i2v" | "ltx-i2v" | "uprez" | "nvidia-uprez";
 
 export interface StudioJob {
   imageId: string;
@@ -43,6 +45,13 @@ export interface StudioJob {
 }
 
 export interface WanI2VParams {
+  duration: number;
+  numInferenceSteps: number;
+  guidance: number;
+}
+
+export interface VideoGenParams {
+  model: VideoModel;
   duration: number;
   numInferenceSteps: number;
   guidance: number;

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -48,7 +48,7 @@ export interface WanI2VParams {
   guidance: number;
 }
 
-export type ImageModel = "qwen-image" | "zit-image";
+export type ImageModel = "qwen-image" | "z-image-turbo";
 
 export interface ImageGenParams {
   model: ImageModel;


### PR DESCRIPTION
## Summary
- Add model picker to studio images tab (Z Image Turbo / Qwen Image)
- Refactor `qwenParams` → `imageGenParams` with `model` field in Zustand store
- Add per-model size options (Z Image Turbo supports 8 sizes vs Qwen's 4)
- Add store migration v2→v3 for existing sessions
- Dynamic dream naming based on selected model

Pairs with worker/backend changes already on `stage` by Patrick (`z-image-turbo` algorithm).

## Test plan
- [ ] Model picker shows Z Image Turbo and Qwen Image options
- [ ] Switching model updates available size options
- [ ] Label says "Images:" not "Seeds:"
- [ ] Model selection persists on page reload
- [ ] Generating with Z Image Turbo sends `infinidream_algorithm: "z-image-turbo"` in prompt JSON
- [ ] Existing sessions migrate cleanly (no lost settings)
- [ ] All 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)