### PR TITLE
fix: disable Vite sourcemaps in production builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,5 +72,6 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    sourcemap: false,
   },
 });


### PR DESCRIPTION
## Summary
- Disables sourcemaps in Vite production builds (`sourcemap: false`) to reduce bundle size and avoid exposing source code in deployed builds.

## Test plan
- [ ] Verify `pnpm run build` completes without sourcemap files in `dist/`
- [ ] Confirm no `.map` files are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)