### PR TITLE
Add Creators Program invitation note to Terms of Service

### DIFF
--- a/src/components/pages/terms-of-service/terms-of-service.page.tsx
+++ b/src/components/pages/terms-of-service/terms-of-service.page.tsx
@@ -208,7 +208,7 @@ export const TermsOfServicePage: React.FC = () => {
                 </li>
               </ol>
             </li>
-            <li>
+            <li id={CCBY_ID}>
               <b>Granting Additional Rights with a CC BY License</b>
               <ol type="a">
                 <li>
@@ -225,6 +225,14 @@ export const TermsOfServicePage: React.FC = () => {
                   your Content, for both commercial and non-commercial purposes,
                   as long as proper attribution is given to you. We summarize
                   those requirements below.
+                </li>
+                <li>
+                  The ability to uncheck the CC BY option is available by
+                  invitation through our{" "}
+                  <Anchor href="https://forms.gle/JsZb4TRdw3jq65Bc8">
+                    Creators Program
+                  </Anchor>
+                  .
                 </li>
                 <li>
                   <b>AI Training and Remixing.</b> By selecting CC BY, you also
@@ -257,7 +265,7 @@ export const TermsOfServicePage: React.FC = () => {
                 </li>
               </ol>
             </li>
-            <li id={CCBY_ID}>
+            <li>
               <b>To summarize:</b>
               <CcbyTable />
             </li>


### PR DESCRIPTION
## Summary
- Add a new bullet under the CC BY section of the Terms of Service noting that the ability to uncheck CC BY is available by invitation through the Creators Program
- Link the phrase "Creators Program" to the signup form (https://forms.gle/JsZb4TRdw3jq65Bc8)
- Move the `id={CCBY_ID}` anchor from the "To summarize" item up to the "Granting Additional Rights with a CC BY License" item so deep-links land on the CC BY section itself

## Test plan
- [ ] Visit /terms-of-service and scroll to the CC BY section; verify the new bullet appears with the Creators Program link
- [ ] Click the link and confirm it opens the Google Form in a new tab
- [ ] Verify deep-links that use `#${CCBY_ID}` scroll to the CC BY section

🤖 Generated with [Claude Code](https://claude.com/claude-code)