### PR TITLE
promote Windows from prerelease on install page

### DIFF
--- a/src/components/pages/install/install.page.tsx
+++ b/src/components/pages/install/install.page.tsx
@@ -14,9 +14,8 @@ import styled from "styled-components";
 
 const SECTION_ID = "install";
 const DISPLAY_APP_VERSION = `v${APP_VERSION}`;
-const APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-${APP_VERSION}.zip`;
-const WINDOWS_PRERELEASE_VERSION = "0.14.12";
-const WINDOWS_PRERELEASE_URL = `https://github.com/e-dream-ai/client/releases/tag/${WINDOWS_PRERELEASE_VERSION}`;
+const MAC_APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-${APP_VERSION}.zip`;
+const WINDOWS_APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-windows-${APP_VERSION}-setup.exe`;
 
 const ResponsiveDownloadButton = styled(Button)`
   max-width: 100%;
@@ -32,70 +31,83 @@ const InstallSection = () => {
   const { t } = useTranslation();
   const { isMacOS } = useUserAgent();
 
-  const handleDownloadApp = () => {
-    window.open(APP_URL, "_blank");
+  const handleDownloadMac = () => {
+    window.open(MAC_APP_URL, "_blank");
   };
 
   const handleDownloadWindows = () => {
-    window.open(WINDOWS_PRERELEASE_URL, "_blank");
+    window.open(WINDOWS_APP_URL, "_blank");
   };
+
+  const macCard = (
+    <Row flexWrap={["wrap", "nowrap", "nowrap"]} key="mac">
+      <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+        <Row justifyContent="center">
+          <ResponsiveDownloadButton
+            buttonType="secondary"
+            onClick={handleDownloadMac}
+          >
+            Download for Mac
+          </ResponsiveDownloadButton>
+        </Row>
+        <Row>
+          <Text>
+            <p>
+              <em>Requirements:</em> macOS 12.4+, x86 or Apple Silicon.
+            </p>
+            <p>
+              Unzip, and drag it to your Applications folder. Run it, sign-in by
+              entering your email, then enter the code emailed to you, and close
+              the settings.
+            </p>
+          </Text>
+        </Row>
+      </Card>
+    </Row>
+  );
+
+  const windowsCard = (
+    <Row flexWrap={["wrap", "nowrap", "nowrap"]} key="windows">
+      <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+        <Row justifyContent="center">
+          <ResponsiveDownloadButton
+            buttonType="secondary"
+            onClick={handleDownloadWindows}
+          >
+            Download for Windows
+          </ResponsiveDownloadButton>
+        </Row>
+        <Row>
+          <Text>
+            <p>
+              <em>Requirements:</em> Windows 10 or later (x64).
+            </p>
+            <p>
+              Run the installer, sign-in by entering your email, then enter the
+              code emailed to you.
+            </p>
+          </Text>
+        </Row>
+      </Card>
+    </Row>
+  );
 
   return (
     <>
       <h2>{t("page.install.title")}</h2>
       <Section id={SECTION_ID}>
         <Row justifyContent="space-between" separator />
-        <Text>
-          <p>
-            <em>Requirements:</em> macOS version 12.4+, x86 or Apple Silicon.
-            Windows is available as a prerelease.
-          </p>
-          {!isMacOS && (
-            <p>
-              <b>
-                Note: this computer doesn't appear to be a Mac. If you're on
-                Windows, try the prerelease below.
-              </b>
-            </p>
-          )}
-        </Text>
-        <Row flexWrap={["wrap", "nowrap", "nowrap"]}>
-          <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
-            <Row justifyContent="center">
-              <ResponsiveDownloadButton
-                buttonType="secondary"
-                onClick={handleDownloadApp}
-              >
-                Download app and screen saver
-              </ResponsiveDownloadButton>
-            </Row>
-            <Row>
-              <Text>
-                Unzip, and drag it to your Applications folder. Run it, sign-in
-                by entering your email, then enter the code emailed to you, and
-                close the settings.
-              </Text>
-            </Row>
-          </Card>
-        </Row>
-        <Row flexWrap={["wrap", "nowrap", "nowrap"]}>
-          <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
-            <Row justifyContent="center">
-              <ResponsiveDownloadButton
-                buttonType="secondary"
-                onClick={handleDownloadWindows}
-              >
-                Download Windows prerelease
-              </ResponsiveDownloadButton>
-            </Row>
-            <Row>
-              <Text>
-                A prerelease for Windows is available. Run the installer and
-                follow the prompts to sign-in and get started.
-              </Text>
-            </Row>
-          </Card>
-        </Row>
+        {isMacOS ? (
+          <>
+            {macCard}
+            {windowsCard}
+          </>
+        ) : (
+          <>
+            {windowsCard}
+            {macCard}
+          </>
+        )}
         <Text>
           <p>
             Each time you sign-in, a fresh code is required. Never reuse the


### PR DESCRIPTION
## Summary
- Replaces the single Mac download card + Windows prerelease card with two parallel cards, each with its own requirements and install steps
- Card order is OS-aware: Mac users see the Mac card first; everyone else sees the Windows card first
- Windows now links directly to the `.exe` installer at the same version as Mac (e.g. `infinidream-windows-${APP_VERSION}-setup.exe`) instead of pointing to a hardcoded prerelease tag page

## Test plan
- [ ] On macOS, /install shows Mac card on top with "Download for Mac" button → links to the `.zip`
- [ ] On Windows (or any non-Mac), /install shows Windows card on top with "Download for Windows" button → links directly to the `.exe`
- [ ] Each card shows its own requirements line (macOS 12.4+ / Windows 10+ x64) and sign-in-by-email instructions
- [ ] Page is reachable without signing in

🤖 Generated with [Claude Code](https://claude.com/claude-code)