### PR TITLE
Deploy: email validation fix to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "styled-react-modal": "^3.1.1",
     "styled-system": "^5.1.5",
     "uuid": "^13.0.0",
+    "validator": "^13.15.35",
     "video.js": "^8.23.4",
     "yup": "^1.3.3",
     "zustand": "^5.0.9"
@@ -102,6 +103,7 @@
     "@types/styled-react-modal": "^3.1.0",
     "@types/styled-system": "^5.1.25",
     "@types/uuid": "^10.0.0",
+    "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      validator:
+        specifier: ^13.15.35
+        version: 13.15.35
       video.js:
         specifier: ^8.23.4
         version: 8.23.4
@@ -208,6 +211,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@types/validator':
+        specifier: ^13.15.10
+        version: 13.15.10
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.53.1
         version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -1775,6 +1781,9 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
   '@typescript-eslint/eslint-plugin@8.53.1':
     resolution: {integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==}
@@ -4099,6 +4108,10 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
+
   video.js@8.23.4:
     resolution: {integrity: sha512-qI0VTlYmKzEqRsz1Nppdfcaww4RSxZAq77z2oNSl3cNg2h6do5C8Ffl0KqWQ1OpD8desWXsCrde7tKJ9gGTEyQ==}
 
@@ -5988,6 +6001,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/uuid@10.0.0': {}
+
+  '@types/validator@13.15.10': {}
 
   '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8779,6 +8794,8 @@ snapshots:
       react: 18.2.0
 
   uuid@13.0.0: {}
+
+  validator@13.15.35: {}
 
   video.js@8.23.4:
     dependencies:

--- a/src/schemas/email.schema.ts
+++ b/src/schemas/email.schema.ts
@@ -1,0 +1,11 @@
+import isEmail from "validator/lib/isEmail";
+import * as yup from "yup";
+
+export const emailSchema = yup
+  .string()
+  .test(
+    "is-valid-email",
+    "Please enter a valid email address.",
+    (value) => !value || isEmail(value),
+  )
+  .required("Email is required.");

--- a/src/schemas/forgot-password.schema.ts
+++ b/src/schemas/forgot-password.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type CreatePasswordResetFormValues = {
   email: string;
@@ -6,6 +7,6 @@ export type CreatePasswordResetFormValues = {
 
 export const CreatePasswordResetSchema = yup
   .object({
-    email: yup.string().email().required(),
+    email: emailSchema,
   })
   .required();

--- a/src/schemas/invite.schema.ts
+++ b/src/schemas/invite.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type InviteByEmailFormValues = {
   email: string;
@@ -12,7 +13,7 @@ export type InviteByEmailFormValues = {
 export const InviteByEmailSchema = yup
   .object()
   .shape({
-    email: yup.string().email().required("Email is required."),
+    email: emailSchema,
     // codeLength: yup
     //   .number()
     //   .nullable()

--- a/src/schemas/login.schema.ts
+++ b/src/schemas/login.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type LoginFormValues = {
   email: string;
@@ -7,7 +8,7 @@ export type LoginFormValues = {
 
 export const LoginSchema = yup
   .object({
-    email: yup.string().email().required("Email is required."),
+    email: emailSchema,
     password: yup.string().required("Password is required."),
   })
   .required();
@@ -18,7 +19,7 @@ export type MagicLoginFormValues = {
 
 export const MagicLoginSchema = yup
   .object({
-    email: yup.string().email().required("Email is required."),
+    email: emailSchema,
   })
   .required();
 

--- a/src/schemas/magic.schema.ts
+++ b/src/schemas/magic.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type MagicFormValues = {
   email: string;
@@ -7,7 +8,7 @@ export type MagicFormValues = {
 
 export const MagicSchema = yup
   .object({
-    email: yup.string().email().required("Email is required."),
+    email: emailSchema,
     code: yup.string().length(6).required("Code is required."),
   })
   .required();

--- a/src/schemas/signup.schema.ts
+++ b/src/schemas/signup.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type SignupFormValues = {
   email: string;
@@ -44,7 +45,7 @@ export const confirmPasswordSchemaProperty = yup
 
 export const getSignupSchema = (isSignupCodeActive: boolean) =>
   yup.object({
-    email: yup.string().email().required("Email is required."),
+    email: emailSchema,
     firstName: yup.string().required().max(50),
     lastName: yup.string().required().max(50),
     // password: passwordSchemaProperty,

--- a/src/schemas/verify-email.schema.ts
+++ b/src/schemas/verify-email.schema.ts
@@ -1,4 +1,5 @@
 import * as yup from "yup";
+import { emailSchema } from "./email.schema";
 
 export type VerifyEmailRequestValues = {
   username: string;
@@ -12,7 +13,7 @@ export type VerifyEmailFormValues = {
 
 export const VerifyEmailSchema = yup
   .object({
-    email: yup.string().email().required(),
+    email: emailSchema,
     code: yup.string().length(6).required(),
   })
   .required();


### PR DESCRIPTION
Promotes stage to main to deploy the email validation fix from #609.

## Includes
- #609 — Fix email validation to reject malformed domains (e.g. `user@gmailcom`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)