### PR TITLE
feat: Linux download box on install page

### DIFF
--- a/src/components/pages/install/install.page.tsx
+++ b/src/components/pages/install/install.page.tsx
@@ -8,6 +8,12 @@ import Text from "@/components/shared/text/text";
 import usePWAInstall from "@/hooks/usePWAInstall";
 import useUserAgent from "@/hooks/useUserAgent";
 import { APP_VERSION } from "@/version";
+import {
+  faApple,
+  faLinux,
+  faWindows,
+} from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -16,6 +22,7 @@ const SECTION_ID = "install";
 const DISPLAY_APP_VERSION = `v${APP_VERSION}`;
 const MAC_APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-${APP_VERSION}.zip`;
 const WINDOWS_APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-windows-${APP_VERSION}-setup.exe`;
+const LINUX_APP_URL = `https://github.com/e-dream-ai/client/releases/download/${APP_VERSION}/infinidream-${APP_VERSION}-x86_64.AppImage`;
 
 const ResponsiveDownloadButton = styled(Button)`
   max-width: 100%;
@@ -27,9 +34,22 @@ const ResponsiveDownloadButton = styled(Button)`
   height: 100%;
 `;
 
+const PlatformCard = styled(Card)`
+  position: relative;
+`;
+
+const PlatformIcon = styled.div`
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  font-size: 2.25rem;
+  line-height: 1;
+  color: ${(props) => props.theme.textAccentColor};
+`;
+
 const InstallSection = () => {
   const { t } = useTranslation();
-  const { isMacOS } = useUserAgent();
+  const { isMacOS, isLinux } = useUserAgent();
 
   const handleDownloadMac = () => {
     window.open(MAC_APP_URL, "_blank");
@@ -39,9 +59,16 @@ const InstallSection = () => {
     window.open(WINDOWS_APP_URL, "_blank");
   };
 
+  const handleDownloadLinux = () => {
+    window.open(LINUX_APP_URL, "_blank");
+  };
+
   const macCard = (
     <Row flexWrap={["wrap", "nowrap", "nowrap"]} key="mac">
-      <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+      <PlatformCard flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+        <PlatformIcon>
+          <FontAwesomeIcon icon={faApple} />
+        </PlatformIcon>
         <Row justifyContent="center">
           <ResponsiveDownloadButton
             buttonType="secondary"
@@ -62,13 +89,16 @@ const InstallSection = () => {
             </p>
           </Text>
         </Row>
-      </Card>
+      </PlatformCard>
     </Row>
   );
 
   const windowsCard = (
     <Row flexWrap={["wrap", "nowrap", "nowrap"]} key="windows">
-      <Card flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+      <PlatformCard flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+        <PlatformIcon>
+          <FontAwesomeIcon icon={faWindows} />
+        </PlatformIcon>
         <Row justifyContent="center">
           <ResponsiveDownloadButton
             buttonType="secondary"
@@ -88,26 +118,55 @@ const InstallSection = () => {
             </p>
           </Text>
         </Row>
-      </Card>
+      </PlatformCard>
     </Row>
   );
+
+  const linuxCard = (
+    <Row flexWrap={["wrap", "nowrap", "nowrap"]} key="linux">
+      <PlatformCard flex="auto" mt={3} px={[2, 3, 4]} py={4}>
+        <PlatformIcon>
+          <FontAwesomeIcon icon={faLinux} />
+        </PlatformIcon>
+        <Row justifyContent="center">
+          <ResponsiveDownloadButton
+            buttonType="secondary"
+            onClick={handleDownloadLinux}
+          >
+            Download for Linux
+          </ResponsiveDownloadButton>
+        </Row>
+        <Row>
+          <Text>
+            <p>
+              <em>Requirements:</em> Linux x86_64 with Vulkan support.
+            </p>
+            <p>
+              Make the{" "}
+              <Anchor target="_blank" href="https://appimage.org/">
+                AppImage
+              </Anchor>{" "}
+              executable (<code>chmod +x</code>) and run it. Sign-in by entering
+              your email, then enter the code emailed to you.
+            </p>
+          </Text>
+        </Row>
+      </PlatformCard>
+    </Row>
+  );
+
+  const orderedCards = isMacOS
+    ? [macCard, windowsCard, linuxCard]
+    : isLinux
+      ? [linuxCard, windowsCard, macCard]
+      : [windowsCard, macCard, linuxCard];
 
   return (
     <>
       <h2>{t("page.install.title")}</h2>
       <Section id={SECTION_ID}>
         <Row justifyContent="space-between" separator />
-        {isMacOS ? (
-          <>
-            {macCard}
-            {windowsCard}
-          </>
-        ) : (
-          <>
-            {windowsCard}
-            {macCard}
-          </>
-        )}
+        {orderedCards}
         <Text>
           <p>
             Each time you sign-in, a fresh code is required. Never reuse the

--- a/src/hooks/useUserAgent.ts
+++ b/src/hooks/useUserAgent.ts
@@ -13,6 +13,7 @@ export default function useUserAgent() {
   const [userAgent, setUserAgent] = useState<string | null>(null);
   const [isIOS, setIsIOS] = useState<boolean | null>(null);
   const [isMacOS, setIsMacOS] = useState<boolean | null>(null);
+  const [isLinux, setIsLinux] = useState<boolean | null>(null);
   const [isStandalone, setIsStandalone] = useState<boolean | null>(null);
   const [userAgentString, setUserAgentString] = useState<string | null>(null);
 
@@ -52,6 +53,8 @@ export default function useUserAgent() {
       setIsMobile(!!isMobile);
       const isMacOS = userAgentString.match(/Mac/i);
       setIsMacOS(!!isMacOS);
+      const isLinux = !isAndroid && userAgentString.match(/Linux/i);
+      setIsLinux(!!isLinux);
 
       // Check if app is installed (if it's installed we wont show the prompt)
       if (window.matchMedia("(display-mode: standalone)").matches) {
@@ -60,5 +63,13 @@ export default function useUserAgent() {
     }
   }, []);
 
-  return { isMobile, userAgent, isIOS, isMacOS, isStandalone, userAgentString };
+  return {
+    isMobile,
+    userAgent,
+    isIOS,
+    isMacOS,
+    isLinux,
+    isStandalone,
+    userAgentString,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds a Linux (AppImage) download card to `/install` next to Mac and Windows
- Each card now shows the platform brand icon (Apple/Windows/Linux) in the top-left, sized 2.25rem and colored with `theme.textAccentColor`
- Card ordering surfaces the detected OS first (Mac → mac/win/linux, Linux → linux/win/mac, otherwise win/mac/linux)
- Extends `useUserAgent` with `isLinux` (UA contains `Linux` and not `Android`)
- "AppImage" links to https://appimage.org/

Linux artifact URL pattern: `infinidream-\${APP_VERSION}-x86_64.AppImage` in the `e-dream-ai/client` releases.

## Test plan
- [ ] Open `/install` on macOS — Mac card first, Linux card present, icons visible top-left
- [ ] Open `/install` on Windows — Windows card first, Linux card present
- [ ] Open `/install` on Linux — Linux card first
- [ ] Click "Download for Linux" → new tab to the AppImage in the latest client release
- [ ] Click the "AppImage" link → new tab to appimage.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)