### PR TITLE
feat(flow): add LoRA dropdown to transition settings

### DIFF
--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { useFlowStore } from "@/stores/flow.store";
 import { useShallow } from "zustand/react/shallow";
-import type { VideoModel } from "@/types/studio.types";
+import type { VideoModel, LoRAConfig } from "@/types/studio.types";
 import { ACTION_PRESETS } from "@/components/pages/studio/constants/action-presets";
 import {
   getAllowedDurationsForActions,
@@ -53,6 +53,7 @@ export function TransitionSettingsPanel({
     globalModel,
     globalNumInferenceSteps,
     globalGuidance,
+    globalLora,
   } = useFlowStore(
     useShallow((s) => ({
       transitions: s.transitions,
@@ -65,6 +66,7 @@ export function TransitionSettingsPanel({
       globalModel: s.globalModel,
       globalNumInferenceSteps: s.globalNumInferenceSteps,
       globalGuidance: s.globalGuidance,
+      globalLora: s.globalLora,
     })),
   );
 
@@ -77,6 +79,7 @@ export function TransitionSettingsPanel({
     (s) => s.setGlobalNumInferenceSteps,
   );
   const setGlobalGuidance = useFlowStore((s) => s.setGlobalGuidance);
+  const setGlobalLora = useFlowStore((s) => s.setGlobalLora);
   const setTransitionOverride = useFlowStore((s) => s.setTransitionOverride);
   const clearTransitionOverride = useFlowStore(
     (s) => s.clearTransitionOverride,
@@ -122,6 +125,49 @@ export function TransitionSettingsPanel({
     if (!action) return getAllowedDurationsForActions([], currentModel);
     return getAllowedDurationsForActions([action], currentModel);
   }, [currentPresetId, currentModel]);
+
+  // Extract available LoRA options for the current model from preset packs.
+  // Each unique LoRA (by path) becomes a selectable option.
+  const loraOptions = useMemo(() => {
+    const options: Array<{
+      label: string;
+      key: string;
+      highNoiseLoras: LoRAConfig[];
+      lowNoiseLoras: LoRAConfig[];
+    }> = [];
+    const seen = new Set<string>();
+
+    for (const pack of ACTION_PRESETS) {
+      if (pack.model !== currentModel && pack.model !== "all") continue;
+      for (const action of pack.actions) {
+        if (!action.highNoiseLoras?.length) continue;
+        const path = action.highNoiseLoras[0].path;
+        if (seen.has(path)) continue;
+        seen.add(path);
+        // Derive a short label from the action's prompt (first clause before comma)
+        const label = action.prompt.split(",")[0].trim();
+        options.push({
+          label,
+          key: path,
+          highNoiseLoras: action.highNoiseLoras,
+          lowNoiseLoras: action.lowNoiseLoras ?? [],
+        });
+      }
+    }
+    return options;
+  }, [currentModel]);
+
+  // Determine current effective LoRA: per-transition override > global > preset > none.
+  // Returns the LoRA path key for matching against dropdown options.
+  const currentLoraKey = useMemo(() => {
+    const override = selectedTransition?.loraOverride ?? globalLora;
+    if (override?.length) return override[0].path;
+    const presetAction = resolvePresetAction(currentPresetId);
+    if (presetAction?.highNoiseLoras?.length) {
+      return presetAction.highNoiseLoras[0].path;
+    }
+    return "";
+  }, [selectedTransition?.loraOverride, globalLora, currentPresetId]);
 
   type FieldMap = {
     presetOverride: string;
@@ -183,6 +229,15 @@ export function TransitionSettingsPanel({
         setValue("promptOverride", action.prompt);
       }
 
+      // Clear any explicit LoRA override so the preset's LoRA takes effect
+      if (isPerTransition && selectedTransitionIndex !== null) {
+        setTransitionOverride(selectedTransitionIndex, {
+          loraOverride: undefined,
+        });
+      } else {
+        setGlobalLora(undefined);
+      }
+
       // Clamp duration if needed
       const newAllowed = presetName
         ? getAllowedDurationsForActions(action ? [action] : [], currentModel)
@@ -192,7 +247,15 @@ export function TransitionSettingsPanel({
         setValue("durationOverride", clamped);
       }
     },
-    [setValue, currentModel, currentDuration],
+    [
+      setValue,
+      currentModel,
+      currentDuration,
+      isPerTransition,
+      selectedTransitionIndex,
+      setTransitionOverride,
+      setGlobalLora,
+    ],
   );
 
   const handleModelChange = useCallback(
@@ -207,6 +270,15 @@ export function TransitionSettingsPanel({
         }
       }
 
+      // Clear LoRA override — LoRAs are model-specific
+      if (isPerTransition && selectedTransitionIndex !== null) {
+        setTransitionOverride(selectedTransitionIndex, {
+          loraOverride: undefined,
+        });
+      } else {
+        setGlobalLora(undefined);
+      }
+
       // Clamp duration to new model's allowed values
       const action = resolvePresetAction(currentPresetId);
       const newAllowed = action
@@ -217,7 +289,61 @@ export function TransitionSettingsPanel({
         setValue("durationOverride", clamped);
       }
     },
-    [setValue, currentPresetId, currentDuration],
+    [
+      setValue,
+      currentPresetId,
+      currentDuration,
+      isPerTransition,
+      selectedTransitionIndex,
+      setTransitionOverride,
+      setGlobalLora,
+    ],
+  );
+
+  const handleLoraChange = useCallback(
+    (loraKey: string) => {
+      const loraOption = loraKey
+        ? loraOptions.find((o) => o.key === loraKey)
+        : undefined;
+
+      // Update store: set or clear the LoRA override
+      if (isPerTransition && selectedTransitionIndex !== null) {
+        setTransitionOverride(selectedTransitionIndex, {
+          loraOverride: loraOption?.highNoiseLoras,
+        });
+      } else {
+        setGlobalLora(loraOption?.highNoiseLoras);
+      }
+
+      // LoRA changes may constrain duration (LoRA presets often limit to shorter durations).
+      // Build a representative action for duration clamping, overlaying the new LoRA
+      // onto the current preset action (same pattern as handlePresetChange/handleModelChange).
+      const baseAction = resolvePresetAction(currentPresetId);
+      const clampAction = loraOption
+        ? {
+            prompt: baseAction?.prompt ?? "",
+            highNoiseLoras: loraOption.highNoiseLoras,
+          }
+        : baseAction;
+      const newAllowed = clampAction
+        ? getAllowedDurationsForActions([clampAction], currentModel)
+        : getAllowedDurationsForActions([], currentModel);
+      const clamped = clampDurationToAllowed(currentDuration, newAllowed);
+      if (clamped !== currentDuration) {
+        setValue("durationOverride", clamped);
+      }
+    },
+    [
+      isPerTransition,
+      selectedTransitionIndex,
+      setTransitionOverride,
+      setGlobalLora,
+      loraOptions,
+      currentPresetId,
+      currentModel,
+      currentDuration,
+      setValue,
+    ],
   );
 
   // When no preset is selected, the prompt drives the generation —
@@ -370,6 +496,23 @@ export function TransitionSettingsPanel({
                   <option value="wan-i2v">Wan I2V</option>
                 </Select>
               </FieldGroup>
+
+              {loraOptions.length > 0 && (
+                <FieldGroup>
+                  <FieldLabel>LoRA</FieldLabel>
+                  <Select
+                    value={currentLoraKey}
+                    onChange={(e) => handleLoraChange(e.target.value)}
+                  >
+                    <option value="">None</option>
+                    {loraOptions.map((o) => (
+                      <option key={o.key} value={o.key}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </Select>
+                </FieldGroup>
+              )}
             </FieldRow>
 
             <AdvancedToggle onClick={() => setAdvancedOpen(!advancedOpen)}>

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -30,6 +30,7 @@ export function useFlowGeneration() {
         globalModel: store.globalModel,
         globalNumInferenceSteps: store.globalNumInferenceSteps,
         globalGuidance: store.globalGuidance,
+        globalLora: store.globalLora,
       });
 
       const fromKf = store.keyframes.find(

--- a/src/components/pages/studio/utils/__tests__/resolve-flow-settings.test.ts
+++ b/src/components/pages/studio/utils/__tests__/resolve-flow-settings.test.ts
@@ -30,6 +30,7 @@ describe("resolveEffectiveSettings", () => {
     globalModel: "wan-i2v" as const,
     globalNumInferenceSteps: 30,
     globalGuidance: 5.0,
+    globalLora: undefined,
   };
 
   it("uses global settings when transition has no overrides", () => {
@@ -101,5 +102,52 @@ describe("resolveEffectiveSettings", () => {
     };
     const settings = resolveEffectiveSettings(transition, globalSettings);
     expect(settings.action.prompt).toBe("my custom prompt");
+  });
+
+  it("globalLora overrides preset LoRAs", () => {
+    const customLora = [{ path: "custom-lora.safetensors", scale: 0.8 }];
+    const transition: FlowTransition = {
+      fromKeyframeId: "a",
+      toKeyframeId: "b",
+      status: "idle",
+    };
+    const settings = resolveEffectiveSettings(transition, {
+      ...globalSettings,
+      globalLora: customLora,
+    });
+    expect(settings.action.highNoiseLoras).toEqual(customLora);
+  });
+
+  it("transition loraOverride overrides globalLora", () => {
+    const globalLoraConfig = [{ path: "global-lora.safetensors", scale: 0.5 }];
+    const transitionLoraConfig = [
+      { path: "transition-lora.safetensors", scale: 1.0 },
+    ];
+    const transition: FlowTransition = {
+      fromKeyframeId: "a",
+      toKeyframeId: "b",
+      status: "idle",
+      loraOverride: transitionLoraConfig,
+    };
+    const settings = resolveEffectiveSettings(transition, {
+      ...globalSettings,
+      globalLora: globalLoraConfig,
+    });
+    expect(settings.action.highNoiseLoras).toEqual(transitionLoraConfig);
+  });
+
+  it("falls through to preset LoRAs when globalLora is undefined", () => {
+    const transition: FlowTransition = {
+      fromKeyframeId: "a",
+      toKeyframeId: "b",
+      status: "idle",
+    };
+    const settings = resolveEffectiveSettings(transition, {
+      ...globalSettings,
+      globalLora: undefined,
+    });
+    // Camera Basics preset's first action has LoRAs (zoom in)
+    expect(settings.action.highNoiseLoras!.length).toBeGreaterThan(0);
+    expect(settings.action.highNoiseLoras![0].path).toContain("zoom_in");
   });
 });

--- a/src/components/pages/studio/utils/resolve-flow-settings.ts
+++ b/src/components/pages/studio/utils/resolve-flow-settings.ts
@@ -1,4 +1,8 @@
-import type { StudioAction, VideoModel } from "@/types/studio.types";
+import type {
+  StudioAction,
+  VideoModel,
+  LoRAConfig,
+} from "@/types/studio.types";
 import type { FlowTransition } from "@/types/flow.types";
 import {
   ACTION_PRESETS,
@@ -26,6 +30,7 @@ interface GlobalSettings {
   globalModel: VideoModel;
   globalNumInferenceSteps: number;
   globalGuidance: number;
+  globalLora: LoRAConfig[] | undefined;
 }
 
 interface EffectiveSettings {
@@ -54,27 +59,29 @@ export function resolveEffectiveSettings(
     transition.numInferenceStepsOverride ?? global.globalNumInferenceSteps;
   const guidance = transition.guidanceOverride ?? global.globalGuidance;
 
-  // Resolve preset → StudioAction
+  // Resolve LoRAs: per-transition override > global override > preset > none
   let action: Pick<StudioAction, "prompt" | "highNoiseLoras" | "lowNoiseLoras">;
 
-  if (transition.loraOverride) {
-    // Explicit LoRA override — use it directly
+  const explicitLora = transition.loraOverride ?? global.globalLora;
+  if (explicitLora) {
+    // Explicit LoRA override — look up matching preset action for lowNoiseLoras
+    const presetAction = resolvePresetAction(presetId);
+    const matchesPreset =
+      presetAction?.highNoiseLoras?.[0]?.path === explicitLora[0]?.path;
     action = {
       prompt,
-      highNoiseLoras: transition.loraOverride,
-      lowNoiseLoras: [],
+      highNoiseLoras: explicitLora,
+      lowNoiseLoras: matchesPreset ? presetAction!.lowNoiseLoras ?? [] : [],
     };
   } else {
     const presetAction = resolvePresetAction(presetId);
     if (presetAction) {
-      // Use preset's LoRAs, but override prompt if specified
       action = {
         prompt,
         highNoiseLoras: presetAction.highNoiseLoras ?? [],
         lowNoiseLoras: presetAction.lowNoiseLoras ?? [],
       };
     } else {
-      // No preset — bare prompt, no LoRAs
       action = { prompt, highNoiseLoras: [], lowNoiseLoras: [] };
     }
   }

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -5,7 +5,7 @@ import type {
   FlowTransition,
   TransitionStatus,
 } from "@/types/flow.types";
-import type { VideoModel } from "@/types/studio.types";
+import type { VideoModel, LoRAConfig } from "@/types/studio.types";
 
 const LOOP_KEYFRAME_ID = "__loop__";
 
@@ -48,6 +48,7 @@ type FlowStoreState = {
   globalModel: VideoModel;
   globalNumInferenceSteps: number;
   globalGuidance: number;
+  globalLora: LoRAConfig[] | undefined;
 
   // Phase 1 — transitions
   transitions: FlowTransition[];
@@ -63,6 +64,7 @@ type FlowStoreState = {
   setGlobalModel: (model: VideoModel) => void;
   setGlobalNumInferenceSteps: (steps: number) => void;
   setGlobalGuidance: (guidance: number) => void;
+  setGlobalLora: (lora: LoRAConfig[] | undefined) => void;
   setTransitionOverride: (
     index: number,
     overrides: Partial<FlowTransition>,
@@ -93,6 +95,7 @@ const PHASE_1_DEFAULTS = {
   globalModel: "ltx-i2v" as VideoModel,
   globalNumInferenceSteps: 30,
   globalGuidance: 5.0,
+  globalLora: undefined as LoRAConfig[] | undefined,
   transitions: [] as FlowTransition[],
   selectedTransitionIndex: null as number | null,
   settingsExpanded: false,
@@ -221,6 +224,7 @@ export const useFlowStore = create<FlowStoreState>()(
       setGlobalNumInferenceSteps: (steps) =>
         set({ globalNumInferenceSteps: steps }),
       setGlobalGuidance: (guidance) => set({ globalGuidance: guidance }),
+      setGlobalLora: (lora) => set({ globalLora: lora }),
 
       // Phase 1 — transition actions
       setTransitionOverride: (index, overrides) =>
@@ -370,6 +374,7 @@ export const useFlowStore = create<FlowStoreState>()(
         globalModel: state.globalModel,
         globalNumInferenceSteps: state.globalNumInferenceSteps,
         globalGuidance: state.globalGuidance,
+        globalLora: state.globalLora,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

- Adds a LoRA dropdown to the expanded transition settings panel, closing a gap between the design spec and the shipped Phase 1 implementation
- Users can pick a camera LoRA independently of the preset, in both global and per-transition modes
- LoRA options are extracted from existing `ACTION_PRESETS` and filtered by the currently selected model

## Changes

**Store** (`flow.store.ts`): `globalLora` state + `setGlobalLora` action, included in persistence and reset

**Resolution** (`resolve-flow-settings.ts`): Priority chain: `loraOverride` (per-transition) > `globalLora` > preset LoRAs > none. Preserves `lowNoiseLoras` when explicit LoRA matches a preset action.

**Settings panel** (`transition-settings-panel.tsx`):
- LoRA `<Select>` in expanded section alongside Model dropdown
- Only renders when LoRA options exist for the current model
- Model change and preset change clear LoRA overrides (LoRAs are model-specific)
- Duration clamping on LoRA change (same pattern as preset/model handlers)

**Tests**: 3 new tests for the globalLora priority chain

## Test plan

- [ ] Expand transition settings, verify LoRA dropdown appears next to Model
- [ ] Select LTX 2.3 → should show Static Camera, Dolly In/Out, Jib Up/Down
- [ ] Switch to Wan I2V → should show Zoom In/Out, Pan L/R, Tilt Up/Down, Orbit
- [ ] Pick a LoRA, then switch models → LoRA should clear
- [ ] Pick a preset → LoRA should show the preset's LoRA
- [ ] Override LoRA after picking preset → override should stick
- [ ] Pick a different preset → LoRA override should clear (preset's LoRA takes effect)
- [ ] Generate a transition with a LoRA selected → verify the API payload includes `high_noise_loras`
- [ ] Per-transition mode: override LoRA on one transition, verify others use global

🤖 Generated with [Claude Code](https://claude.com/claude-code)