### PR TITLE
fix(flow): close functional gaps in flow builder

### DIFF
--- a/src/components/pages/studio/components/flow-action-bar.tsx
+++ b/src/components/pages/studio/components/flow-action-bar.tsx
@@ -25,12 +25,14 @@ export function FlowActionBar() {
     keyframes,
     setTransitionUprez,
     updateTransitionUprezStatus,
+    setPreviewLightboxOpen,
   } = useFlowStore(
     useShallow((s) => ({
       transitions: s.transitions,
       keyframes: s.keyframes,
       setTransitionUprez: s.setTransitionUprez,
       updateTransitionUprezStatus: s.updateTransitionUprezStatus,
+      setPreviewLightboxOpen: s.setPreviewLightboxOpen,
     })),
   );
 
@@ -143,8 +145,8 @@ export function FlowActionBar() {
   );
 
   const handlePreviewAll = useCallback(() => {
-    toast.info("Coming soon — Preview All will be available in Phase 2");
-  }, []);
+    setPreviewLightboxOpen(true);
+  }, [setPreviewLightboxOpen]);
 
   const handleSaveToPlaylist = useCallback(() => {
     toast.info("Coming soon — Save to Playlist will be available in Phase 2");

--- a/src/components/pages/studio/components/flow-preview.tsx
+++ b/src/components/pages/studio/components/flow-preview.tsx
@@ -35,7 +35,14 @@ function pad(n: number) {
 }
 
 export function FlowPreview() {
-  const transitions = useFlowStore(useShallow((s) => s.transitions));
+  const { transitions, previewLightboxOpen, setPreviewLightboxOpen } =
+    useFlowStore(
+      useShallow((s) => ({
+        transitions: s.transitions,
+        previewLightboxOpen: s.previewLightboxOpen,
+        setPreviewLightboxOpen: s.setPreviewLightboxOpen,
+      })),
+    );
 
   const completedUuids = useMemo(
     () =>
@@ -66,7 +73,6 @@ export function FlowPreview() {
   );
 
   const [rawIndex, setCurrentIndex] = useState(0);
-  const [lightboxOpen, setLightboxOpen] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -92,20 +98,20 @@ export function FlowPreview() {
   // Escape closes the lightbox; ←/→ navigate when the preview is focused.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (lightboxOpen && e.key === "Escape") {
-        setLightboxOpen(false);
+      if (previewLightboxOpen && e.key === "Escape") {
+        setPreviewLightboxOpen(false);
         return;
       }
       if (segmentCount < 2) return;
       const active = document.activeElement;
       const inWrapper = active && wrapperRef.current?.contains(active as Node);
-      if (!inWrapper && !lightboxOpen) return;
+      if (!inWrapper && !previewLightboxOpen) return;
       if (e.key === "ArrowRight") goTo(currentIndex + 1);
       else if (e.key === "ArrowLeft") goTo(currentIndex - 1);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [lightboxOpen, segmentCount, currentIndex, goTo]);
+  }, [previewLightboxOpen, segmentCount, currentIndex, goTo]);
 
   if (segmentCount === 0) return null;
 
@@ -120,7 +126,7 @@ export function FlowPreview() {
         <VideoWrapper
           ref={wrapperRef}
           tabIndex={0}
-          onClick={() => setLightboxOpen(true)}
+          onClick={() => setPreviewLightboxOpen(true)}
         >
           <video
             key={currentUrl}
@@ -182,10 +188,10 @@ export function FlowPreview() {
         <ClickHint>Click to expand</ClickHint>
       </PreviewContainer>
 
-      {lightboxOpen &&
+      {previewLightboxOpen &&
         createPortal(
           <LightboxOverlay
-            onClick={() => setLightboxOpen(false)}
+            onClick={() => setPreviewLightboxOpen(false)}
             role="dialog"
             aria-modal="true"
             aria-label="Video preview"

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -13,7 +13,7 @@ import {
   horizontalListSortingStrategy,
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
-import { useFlowStore } from "@/stores/flow.store";
+import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
 import { KeyframeCard } from "./keyframe-card";
 import { TransitionGapEnhanced } from "./transition-gap";
 import { FlowReset } from "./flow-reset";
@@ -65,7 +65,7 @@ export const KeyframeStrip: React.FC<Props> = ({
     return [
       ...rawKeyframes,
       {
-        id: "__loop__",
+        id: LOOP_KEYFRAME_ID,
         keyframeUuid: first.keyframeUuid,
         dreamUuid: first.dreamUuid,
         imageUrl: first.imageUrl,

--- a/src/components/pages/studio/components/transition-gap.tsx
+++ b/src/components/pages/studio/components/transition-gap.tsx
@@ -21,7 +21,9 @@ function hasOverrides(t: FlowTransition): boolean {
     t.promptOverride ||
     t.durationOverride !== undefined ||
     t.modelOverride ||
-    t.loraOverride
+    t.loraOverride ||
+    t.numInferenceStepsOverride !== undefined ||
+    t.guidanceOverride !== undefined
   );
 }
 

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -238,13 +238,15 @@ export function TransitionSettingsPanel({
   // Don't show if fewer than 2 keyframes
   if (keyframes.length < 2) return null;
 
-  // Transition header info
+  // Transition header info — __loop__ maps back to the first keyframe
+  const findName = (id: string | undefined) =>
+    id === "__loop__"
+      ? keyframes[0]?.name
+      : keyframes.find((kf) => kf.id === id)?.name;
   const fromName =
-    selectedTransition &&
-    keyframes.find((kf) => kf.id === selectedTransition.fromKeyframeId)?.name;
+    selectedTransition && findName(selectedTransition.fromKeyframeId);
   const toName =
-    selectedTransition &&
-    keyframes.find((kf) => kf.id === selectedTransition.toKeyframeId)?.name;
+    selectedTransition && findName(selectedTransition.toKeyframeId);
 
   const isComplete = selectedTransition?.status === "processed";
 

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
-import { useFlowStore } from "@/stores/flow.store";
+import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
 import { useShallow } from "zustand/react/shallow";
 import type { VideoModel } from "@/types/studio.types";
 import { ACTION_PRESETS } from "@/components/pages/studio/constants/action-presets";
@@ -240,7 +240,7 @@ export function TransitionSettingsPanel({
 
   // Transition header info — __loop__ maps back to the first keyframe
   const findName = (id: string | undefined) =>
-    id === "__loop__"
+    id === LOOP_KEYFRAME_ID
       ? keyframes[0]?.name
       : keyframes.find((kf) => kf.id === id)?.name;
   const fromName =

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -55,6 +55,7 @@ type FlowStoreState = {
   // Phase 1 — UI state
   selectedTransitionIndex: number | null;
   settingsExpanded: boolean;
+  previewLightboxOpen: boolean;
 
   // Phase 1 — actions
   setGlobalPreset: (id: string) => void;
@@ -70,6 +71,7 @@ type FlowStoreState = {
   clearTransitionOverride: (index: number) => void;
   selectTransition: (index: number | null) => void;
   setSettingsExpanded: (expanded: boolean) => void;
+  setPreviewLightboxOpen: (open: boolean) => void;
   updateTransitionStatus: (
     index: number,
     status: TransitionStatus,
@@ -96,6 +98,7 @@ const PHASE_1_DEFAULTS = {
   transitions: [] as FlowTransition[],
   selectedTransitionIndex: null as number | null,
   settingsExpanded: false,
+  previewLightboxOpen: false,
 };
 
 /**
@@ -251,6 +254,7 @@ export const useFlowStore = create<FlowStoreState>()(
 
       selectTransition: (index) => set({ selectedTransitionIndex: index }),
       setSettingsExpanded: (expanded) => set({ settingsExpanded: expanded }),
+      setPreviewLightboxOpen: (open) => set({ previewLightboxOpen: open }),
 
       updateTransitionStatus: (index, status, progress) =>
         set((s) => {

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/types/flow.types";
 import type { VideoModel } from "@/types/studio.types";
 
-const LOOP_KEYFRAME_ID = "__loop__";
+export const LOOP_KEYFRAME_ID = "__loop__";
 
 /** Derive the display keyframes list, appending a synthetic loop frame when enabled. */
 function buildKeyframesWithLoop(


### PR DESCRIPTION
## Summary
- **Preview All**: wires the button to open FlowPreview's lightbox via shared store state (replaces "Coming soon" toast)
- **hasOverrides**: adds `numInferenceStepsOverride` and `guidanceOverride` checks so transition gaps correctly show configured state
- **Loop keyframe name**: resolves `__loop__` ID to first keyframe's name in transition settings header ("Editing: A → B")
- **Keyframe linking**: confirmed safe to defer — `startKeyframe`/`endKeyframe` fields are nullable and not user-facing in flow mode yet

## Test plan
- [ ] Add 3+ keyframes, enable loop, select the last transition → header should show "Editing: [last] → [first name]"
- [ ] Generate a few transitions, click "Preview All" → lightbox opens with video playback
- [ ] Set per-transition inference steps or guidance override → gap indicator should show configured state (solid line + duration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)