### PR TITLE
Update prompt for Abstract action preset (to stage)

### DIFF
--- a/src/components/pages/studio/constants/action-presets.ts
+++ b/src/components/pages/studio/constants/action-presets.ts
@@ -198,7 +198,11 @@ export const ACTION_PRESETS: PresetPack[] = [
     name: "Abstract",
     model: "all",
     actions: [
-      { prompt: "The scene transitions through a continuous, viscous metamorphosis, forms dissolving and rebuilding from within as though the material itself is alive. Shape bleeds into shape with cellular fluidity - no cut, no dissolve, no opacity ramp - only the slow-pressure pull of one state becoming another. Camera holds locked and still throughout. The transformation drives forward with organic inevitability, each intermediate state a coherent world briefly passing through.", enabled: true },
+      {
+        prompt:
+          "The scene transitions through a continuous, viscous metamorphosis, forms dissolving and rebuilding from within as though the material itself is alive. Shape bleeds into shape with cellular fluidity - no cut, no dissolve, no opacity ramp - only the slow-pressure pull of one state becoming another. Camera holds locked and still throughout. The transformation drives forward with organic inevitability, each intermediate state a coherent world briefly passing through.",
+        enabled: true,
+      },
       { prompt: "color shift, gradual hue rotation", enabled: true },
       { prompt: "kaleidoscope spin, symmetrical rotation", enabled: true },
       { prompt: "fractal zoom, infinite recursive detail", enabled: true },

--- a/src/components/pages/studio/constants/action-presets.ts
+++ b/src/components/pages/studio/constants/action-presets.ts
@@ -198,7 +198,7 @@ export const ACTION_PRESETS: PresetPack[] = [
     name: "Abstract",
     model: "all",
     actions: [
-      { prompt: "morph and flow, organic transformation", enabled: true },
+      { prompt: "The scene transitions through a continuous, viscous metamorphosis, forms dissolving and rebuilding from within as though the material itself is alive. Shape bleeds into shape with cellular fluidity - no cut, no dissolve, no opacity ramp - only the slow-pressure pull of one state becoming another. Camera holds locked and still throughout. The transformation drives forward with organic inevitability, each intermediate state a coherent world briefly passing through.", enabled: true },
       { prompt: "color shift, gradual hue rotation", enabled: true },
       { prompt: "kaleidoscope spin, symmetrical rotation", enabled: true },
       { prompt: "fractal zoom, infinite recursive detail", enabled: true },

--- a/src/components/pages/view-dream/view-dream.page.tsx
+++ b/src/components/pages/view-dream/view-dream.page.tsx
@@ -413,7 +413,12 @@ const ViewDreamPage: React.FC = () => {
   }, [dream?.prompt]);
 
   const isCancellableAlgorithm = useMemo(() => {
-    const cancellableAlgorithms = ["animatediff", "deforum", "uprez"];
+    const cancellableAlgorithms = [
+      "animatediff",
+      "deforum",
+      "uprez",
+      "nvidia-uprez",
+    ];
     return cancellableAlgorithms.includes(dreamAlgorithm);
   }, [dreamAlgorithm]);
 


### PR DESCRIPTION
Updates the prompt for the Abstract action preset (LTX).

Same change as #635 by @jaygidwitz, targeting \`stage\` instead of \`main\`.

Reference: https://claude.ai/share/74557cc2-404f-406c-9f83-4f94f714c4fb