### PR TITLE
Studio Flow: force LTX, add negative prompt field

### DIFF
--- a/src/components/pages/studio/components/transition-gap.tsx
+++ b/src/components/pages/studio/components/transition-gap.tsx
@@ -19,6 +19,7 @@ function hasOverrides(t: FlowTransition): boolean {
   return !!(
     t.presetOverride ||
     t.promptOverride ||
+    t.negativePromptOverride ||
     t.durationOverride !== undefined ||
     t.modelOverride ||
     t.loraOverride ||

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -49,8 +49,8 @@ export function TransitionSettingsPanel({
     settingsExpanded,
     globalPresetId,
     globalPrompt,
+    globalNegativePrompt,
     globalDuration,
-    globalModel,
     globalNumInferenceSteps,
     globalGuidance,
     globalLora,
@@ -62,8 +62,8 @@ export function TransitionSettingsPanel({
       settingsExpanded: s.settingsExpanded,
       globalPresetId: s.globalPresetId,
       globalPrompt: s.globalPrompt,
+      globalNegativePrompt: s.globalNegativePrompt,
       globalDuration: s.globalDuration,
-      globalModel: s.globalModel,
       globalNumInferenceSteps: s.globalNumInferenceSteps,
       globalGuidance: s.globalGuidance,
       globalLora: s.globalLora,
@@ -73,8 +73,10 @@ export function TransitionSettingsPanel({
   // Actions are stable refs — individual selectors are cheaper than useShallow.
   const setGlobalPreset = useFlowStore((s) => s.setGlobalPreset);
   const setGlobalPrompt = useFlowStore((s) => s.setGlobalPrompt);
+  const setGlobalNegativePrompt = useFlowStore(
+    (s) => s.setGlobalNegativePrompt,
+  );
   const setGlobalDuration = useFlowStore((s) => s.setGlobalDuration);
-  const setGlobalModel = useFlowStore((s) => s.setGlobalModel);
   const setGlobalNumInferenceSteps = useFlowStore(
     (s) => s.setGlobalNumInferenceSteps,
   );
@@ -99,9 +101,12 @@ export function TransitionSettingsPanel({
   // Effective values (override > global)
   const currentPresetId = selectedTransition?.presetOverride ?? globalPresetId;
   const currentPrompt = selectedTransition?.promptOverride ?? globalPrompt;
+  const currentNegativePrompt =
+    selectedTransition?.negativePromptOverride ?? globalNegativePrompt;
   const currentDuration =
     selectedTransition?.durationOverride ?? globalDuration;
-  const currentModel = selectedTransition?.modelOverride ?? globalModel;
+  // LTX is the only working model — generation is hardwired to it.
+  const currentModel: VideoModel = "ltx-i2v";
   const currentSteps =
     selectedTransition?.numInferenceStepsOverride ?? globalNumInferenceSteps;
   const currentGuidance =
@@ -172,8 +177,8 @@ export function TransitionSettingsPanel({
   type FieldMap = {
     presetOverride: string;
     promptOverride: string;
+    negativePromptOverride: string;
     durationOverride: number;
-    modelOverride: VideoModel;
     numInferenceStepsOverride: number;
     guidanceOverride: number;
   };
@@ -192,11 +197,11 @@ export function TransitionSettingsPanel({
         case "promptOverride":
           setGlobalPrompt(value as string);
           break;
+        case "negativePromptOverride":
+          setGlobalNegativePrompt(value as string);
+          break;
         case "durationOverride":
           setGlobalDuration(value as number);
-          break;
-        case "modelOverride":
-          setGlobalModel(value as VideoModel);
           break;
         case "numInferenceStepsOverride":
           setGlobalNumInferenceSteps(value as number);
@@ -212,8 +217,8 @@ export function TransitionSettingsPanel({
       setTransitionOverride,
       setGlobalPreset,
       setGlobalPrompt,
+      setGlobalNegativePrompt,
       setGlobalDuration,
-      setGlobalModel,
       setGlobalNumInferenceSteps,
       setGlobalGuidance,
     ],
@@ -250,48 +255,6 @@ export function TransitionSettingsPanel({
     [
       setValue,
       currentModel,
-      currentDuration,
-      isPerTransition,
-      selectedTransitionIndex,
-      setTransitionOverride,
-      setGlobalLora,
-    ],
-  );
-
-  const handleModelChange = useCallback(
-    (model: VideoModel) => {
-      setValue("modelOverride", model);
-
-      // Check if current preset is valid for new model
-      if (currentPresetId) {
-        const pack = ACTION_PRESETS.find((p) => p.name === currentPresetId);
-        if (pack && pack.model !== "all" && pack.model !== model) {
-          setValue("presetOverride", "");
-        }
-      }
-
-      // Clear LoRA override — LoRAs are model-specific
-      if (isPerTransition && selectedTransitionIndex !== null) {
-        setTransitionOverride(selectedTransitionIndex, {
-          loraOverride: undefined,
-        });
-      } else {
-        setGlobalLora(undefined);
-      }
-
-      // Clamp duration to new model's allowed values
-      const action = resolvePresetAction(currentPresetId);
-      const newAllowed = action
-        ? getAllowedDurationsForActions([action], model)
-        : getAllowedDurationsForActions([], model);
-      const clamped = clampDurationToAllowed(currentDuration, newAllowed);
-      if (clamped !== currentDuration) {
-        setValue("durationOverride", clamped);
-      }
-    },
-    [
-      setValue,
-      currentPresetId,
       currentDuration,
       isPerTransition,
       selectedTransitionIndex,
@@ -482,20 +445,18 @@ export function TransitionSettingsPanel({
               />
             </FieldGroup>
 
-            <FieldRow>
-              <FieldGroup>
-                <FieldLabel>Model</FieldLabel>
-                <Select
-                  value={currentModel}
-                  onChange={(e) =>
-                    handleModelChange(e.target.value as VideoModel)
-                  }
-                >
-                  <option value="ltx-i2v">LTX 2.3</option>
-                  <option value="wan-i2v">Wan I2V</option>
-                </Select>
-              </FieldGroup>
+            <FieldGroup>
+              <FieldLabel>Negative Prompt</FieldLabel>
+              <PromptTextarea
+                value={currentNegativePrompt}
+                placeholder="Describe what to avoid..."
+                onChange={(e) =>
+                  setValue("negativePromptOverride", e.target.value)
+                }
+              />
+            </FieldGroup>
 
+            <FieldRow>
               {loraOptions.length > 0 && (
                 <FieldGroup>
                   <FieldLabel>LoRA</FieldLabel>

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -26,6 +26,7 @@ export function useFlowGeneration() {
       const settings = resolveEffectiveSettings(transition, {
         globalPresetId: store.globalPresetId,
         globalPrompt: store.globalPrompt,
+        globalNegativePrompt: store.globalNegativePrompt,
         globalDuration: store.globalDuration,
         globalModel: store.globalModel,
         globalNumInferenceSteps: store.globalNumInferenceSteps,
@@ -49,13 +50,11 @@ export function useFlowGeneration() {
       const toKf = store.keyframes.find(
         (kf) => kf.id === transition.toKeyframeId,
       );
-      const endImageRef =
-        settings.model === "ltx-i2v" && toKf
-          ? toKf.dreamUuid || toKf.imageUrl
-          : undefined;
+      // LTX is the only working model — always generate i2v with an end frame.
+      const endImageRef = toKf ? toKf.dreamUuid || toKf.imageUrl : undefined;
 
       const algoParams = buildVideoAlgoParams({
-        model: settings.model,
+        model: "ltx-i2v",
         action: settings.action,
         imageUuid: imageRef,
         endImageUuid: endImageRef,
@@ -63,6 +62,7 @@ export function useFlowGeneration() {
         duration: settings.duration,
         numInferenceSteps: settings.numInferenceSteps,
         guidance: settings.guidance,
+        negativePrompt: settings.negativePrompt,
       });
       const name = `${fromKf.name || "frame"} → ${toKf?.name || "frame"}`;
 

--- a/src/components/pages/studio/utils/__tests__/resolve-flow-settings.test.ts
+++ b/src/components/pages/studio/utils/__tests__/resolve-flow-settings.test.ts
@@ -26,6 +26,7 @@ describe("resolveEffectiveSettings", () => {
   const globalSettings = {
     globalPresetId: "Camera Basics",
     globalPrompt: "global prompt",
+    globalNegativePrompt: "global negative",
     globalDuration: 5,
     globalModel: "wan-i2v" as const,
     globalNumInferenceSteps: 30,
@@ -42,6 +43,7 @@ describe("resolveEffectiveSettings", () => {
     const settings = resolveEffectiveSettings(transition, globalSettings);
     expect(settings.presetId).toBe("Camera Basics");
     expect(settings.prompt).toBe("global prompt");
+    expect(settings.negativePrompt).toBe("global negative");
     expect(settings.duration).toBe(5);
     expect(settings.model).toBe("wan-i2v");
     expect(settings.numInferenceSteps).toBe(30);
@@ -55,12 +57,14 @@ describe("resolveEffectiveSettings", () => {
       status: "idle",
       presetOverride: "Organic",
       promptOverride: "override prompt",
+      negativePromptOverride: "override negative",
       durationOverride: 10,
       modelOverride: "ltx-i2v",
     };
     const settings = resolveEffectiveSettings(transition, globalSettings);
     expect(settings.presetId).toBe("Organic");
     expect(settings.prompt).toBe("override prompt");
+    expect(settings.negativePrompt).toBe("override negative");
     expect(settings.duration).toBe(10);
     expect(settings.model).toBe("ltx-i2v");
     expect(settings.numInferenceSteps).toBe(30);

--- a/src/components/pages/studio/utils/build-video-algo-params.test.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.test.ts
@@ -139,6 +139,42 @@ describe("buildVideoAlgoParams", () => {
     expect(result).not.toHaveProperty("low_noise_loras");
   });
 
+  it("includes negative_prompt for ltx-i2v when provided", () => {
+    const result = buildVideoAlgoParams({
+      model: "ltx-i2v",
+      action: makeAction(),
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+      negativePrompt: "blurry, distorted, watermark",
+    });
+
+    expect(result).toEqual({
+      infinidream_algorithm: "ltx-i2v",
+      prompt: "slow zoom in",
+      source_dream_uuid: "img-uuid",
+      duration: 5,
+      negative_prompt: "blurry, distorted, watermark",
+    });
+  });
+
+  it("omits negative_prompt when blank or whitespace-only", () => {
+    const result = buildVideoAlgoParams({
+      model: "ltx-i2v",
+      action: makeAction(),
+      imageUuid: "img-uuid",
+      imageSize: "1280*720",
+      duration: 5,
+      numInferenceSteps: 30,
+      guidance: 5.0,
+      negativePrompt: "   ",
+    });
+
+    expect(result).not.toHaveProperty("negative_prompt");
+  });
+
   it("defaults imageSize to 1280*720 when empty for wan-i2v", () => {
     const result = buildVideoAlgoParams({
       model: "wan-i2v",

--- a/src/components/pages/studio/utils/build-video-algo-params.ts
+++ b/src/components/pages/studio/utils/build-video-algo-params.ts
@@ -10,6 +10,7 @@ interface BuildVideoAlgoParamsInput {
   duration: number;
   numInferenceSteps: number;
   guidance: number;
+  negativePrompt?: string;
 }
 
 export const buildVideoAlgoParams = ({
@@ -21,8 +22,10 @@ export const buildVideoAlgoParams = ({
   duration,
   numInferenceSteps,
   guidance,
+  negativePrompt,
 }: BuildVideoAlgoParamsInput): Record<string, unknown> => {
   const hasLoras = hasActionLoras(action);
+  const trimmedNegative = negativePrompt?.trim();
 
   if (model === "ltx-i2v") {
     // Worker handles steps/guidance internally (8+3 steps, cfg 1.0).
@@ -33,6 +36,9 @@ export const buildVideoAlgoParams = ({
       source_dream_uuid: imageUuid,
       duration,
     };
+    if (trimmedNegative) {
+      params.negative_prompt = trimmedNegative;
+    }
     if (endImageUuid) {
       params.end_source_uuid = endImageUuid;
     }
@@ -43,7 +49,7 @@ export const buildVideoAlgoParams = ({
   }
 
   if (hasLoras) {
-    return {
+    const params: Record<string, unknown> = {
       infinidream_algorithm: "wan-i2v-lora",
       prompt: action.prompt,
       image: imageUuid,
@@ -54,9 +60,13 @@ export const buildVideoAlgoParams = ({
       high_noise_loras: action.highNoiseLoras ?? [],
       low_noise_loras: action.lowNoiseLoras ?? [],
     };
+    if (trimmedNegative) {
+      params.negative_prompt = trimmedNegative;
+    }
+    return params;
   }
 
-  return {
+  const params: Record<string, unknown> = {
     infinidream_algorithm: "wan-i2v",
     prompt: action.prompt,
     image: imageUuid,
@@ -65,4 +75,8 @@ export const buildVideoAlgoParams = ({
     num_inference_steps: numInferenceSteps,
     guidance,
   };
+  if (trimmedNegative) {
+    params.negative_prompt = trimmedNegative;
+  }
+  return params;
 };

--- a/src/components/pages/studio/utils/resolve-flow-settings.ts
+++ b/src/components/pages/studio/utils/resolve-flow-settings.ts
@@ -26,6 +26,7 @@ export function resolvePresetAction(
 interface GlobalSettings {
   globalPresetId: string;
   globalPrompt: string;
+  globalNegativePrompt: string;
   globalDuration: number;
   globalModel: VideoModel;
   globalNumInferenceSteps: number;
@@ -36,6 +37,7 @@ interface GlobalSettings {
 interface EffectiveSettings {
   presetId: string;
   prompt: string;
+  negativePrompt: string;
   duration: number;
   model: VideoModel;
   numInferenceSteps: number;
@@ -53,6 +55,8 @@ export function resolveEffectiveSettings(
 ): EffectiveSettings {
   const presetId = transition.presetOverride ?? global.globalPresetId;
   const prompt = transition.promptOverride ?? global.globalPrompt;
+  const negativePrompt =
+    transition.negativePromptOverride ?? global.globalNegativePrompt;
   const duration = transition.durationOverride ?? global.globalDuration;
   const model = transition.modelOverride ?? global.globalModel;
   const numInferenceSteps =
@@ -89,6 +93,7 @@ export function resolveEffectiveSettings(
   return {
     presetId,
     prompt,
+    negativePrompt,
     duration,
     model,
     numInferenceSteps,

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -362,6 +362,7 @@ describe("Phase 1: transitions", () => {
       const s = useFlowStore.getState();
       expect(s.globalPresetId).toBe("");
       expect(s.globalPrompt).toBe("");
+      expect(s.globalNegativePrompt).toBe("");
       expect(s.globalDuration).toBe(5);
       expect(s.globalModel).toBe("ltx-i2v");
       expect(s.globalNumInferenceSteps).toBe(30);
@@ -374,6 +375,7 @@ describe("Phase 1: transitions", () => {
       const store = useFlowStore.getState();
       store.setGlobalPreset("Organic");
       store.setGlobalPrompt("gentle drift");
+      store.setGlobalNegativePrompt("blurry, distorted");
       store.setGlobalDuration(8);
       store.setGlobalModel("wan-i2v");
       store.setGlobalNumInferenceSteps(20);
@@ -382,6 +384,7 @@ describe("Phase 1: transitions", () => {
       const s = useFlowStore.getState();
       expect(s.globalPresetId).toBe("Organic");
       expect(s.globalPrompt).toBe("gentle drift");
+      expect(s.globalNegativePrompt).toBe("blurry, distorted");
       expect(s.globalDuration).toBe(8);
       expect(s.globalModel).toBe("wan-i2v");
       expect(s.globalNumInferenceSteps).toBe(20);

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -44,6 +44,7 @@ type FlowStoreState = {
   // Phase 1 — global transition settings
   globalPresetId: string;
   globalPrompt: string;
+  globalNegativePrompt: string;
   globalDuration: number;
   globalModel: VideoModel;
   globalNumInferenceSteps: number;
@@ -61,6 +62,7 @@ type FlowStoreState = {
   // Phase 1 — actions
   setGlobalPreset: (id: string) => void;
   setGlobalPrompt: (prompt: string) => void;
+  setGlobalNegativePrompt: (prompt: string) => void;
   setGlobalDuration: (duration: number) => void;
   setGlobalModel: (model: VideoModel) => void;
   setGlobalNumInferenceSteps: (steps: number) => void;
@@ -93,6 +95,7 @@ type FlowStoreState = {
 const PHASE_1_DEFAULTS = {
   globalPresetId: "",
   globalPrompt: "",
+  globalNegativePrompt: "",
   globalDuration: 5,
   globalModel: "ltx-i2v" as VideoModel,
   globalNumInferenceSteps: 30,
@@ -222,6 +225,8 @@ export const useFlowStore = create<FlowStoreState>()(
       ...PHASE_1_DEFAULTS,
       setGlobalPreset: (id) => set({ globalPresetId: id }),
       setGlobalPrompt: (prompt) => set({ globalPrompt: prompt }),
+      setGlobalNegativePrompt: (prompt) =>
+        set({ globalNegativePrompt: prompt }),
       setGlobalDuration: (duration) => set({ globalDuration: duration }),
       setGlobalModel: (model) => set({ globalModel: model }),
       setGlobalNumInferenceSteps: (steps) =>
@@ -332,13 +337,21 @@ export const useFlowStore = create<FlowStoreState>()(
     }),
     {
       name: "flow-session",
-      version: 2,
+      version: 3,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version < 2) {
           return {
             ...state,
             ...PHASE_1_DEFAULTS,
+          };
+        }
+        if (version < 3) {
+          // Negative prompt added; force LTX since it's the only working model.
+          return {
+            ...state,
+            globalNegativePrompt: "",
+            globalModel: "ltx-i2v",
           };
         }
         return state;
@@ -374,6 +387,7 @@ export const useFlowStore = create<FlowStoreState>()(
         transitions: state.transitions,
         globalPresetId: state.globalPresetId,
         globalPrompt: state.globalPrompt,
+        globalNegativePrompt: state.globalNegativePrompt,
         globalDuration: state.globalDuration,
         globalModel: state.globalModel,
         globalNumInferenceSteps: state.globalNumInferenceSteps,

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -34,6 +34,7 @@ export interface FlowTransition {
   // Per-transition overrides (undefined = use global)
   presetOverride?: string; // PresetPack name
   promptOverride?: string;
+  negativePromptOverride?: string;
   durationOverride?: number; // seconds
   modelOverride?: VideoModel;
   numInferenceStepsOverride?: number;


### PR DESCRIPTION
## What

On the Studio page's **Flow** mode (the default `/studio` view):

- **Removed the LTX/Wan model picker** from the transition settings ("Customize") panel and hardwired generation to `ltx-i2v` — the only working model. The LoRA selector is kept.
- **Added a Negative Prompt field** directly below the Prompt field, with a global value plus per-transition override (mirroring how the existing Prompt field works).
- **Wired it into the job params** — `negative_prompt` is added to the dream's algo params (only when non-blank). That's the param the LTX engine already consumes (`engines/scripts/run_ltx_i2v_batch.py`), so it flows through `POST /v1/dream` → `ltxi2v` queue unchanged.

## Files

- `transition-settings-panel.tsx` — drop Model picker + dead `handleModelChange`; effective model is fixed `ltx-i2v`; add Negative Prompt textarea.
- `useFlowGeneration.ts` — always build `ltx-i2v` params (and always pass the end keyframe); pass `negativePrompt`.
- `flow.store.ts` — `globalNegativePrompt` state/setter/persist; persist **v3** migration seeds the field and forces any stale `globalModel` back to `ltx-i2v`.
- `flow.types.ts`, `resolve-flow-settings.ts`, `transition-gap.tsx` — thread the negative prompt + per-transition override.
- `build-video-algo-params.ts` — emit `negative_prompt` for all model branches when present.

## Tests

Type-check, lint, and the studio unit tests all pass (48 tests across `build-video-algo-params`, `resolve-flow-settings`, `flow.store`). Added coverage for `negative_prompt` emission/omission and the new global/override field.

## Manual verification

Ran backend + frontend locally against staging; in `/studio` Flow mode → Customize, the Model dropdown is gone and the Negative Prompt field sits below Prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)