### PR TITLE
Studio Flow: default "Uprez All" to Standard Uprez (split button)

### DIFF
--- a/src/components/pages/studio/components/flow-action-bar.styled.tsx
+++ b/src/components/pages/studio/components/flow-action-bar.styled.tsx
@@ -46,6 +46,26 @@ export const UprezDropdown = styled.div`
   display: inline-block;
 `;
 
+// Split button: a primary action fused with a caret that opens the dropdown.
+// The main part runs the default model; the caret lets you pick the other one.
+export const SplitButtonGroup = styled.div`
+  display: inline-flex;
+  align-items: stretch;
+`;
+
+export const SplitMainButton = styled(ActionButton)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+`;
+
+export const SplitCaretButton = styled(ActionButton)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  padding-left: 11px;
+  padding-right: 11px;
+`;
+
 export const DropdownMenu = styled.div`
   position: absolute;
   bottom: 100%;

--- a/src/components/pages/studio/components/flow-action-bar.tsx
+++ b/src/components/pages/studio/components/flow-action-bar.tsx
@@ -11,6 +11,9 @@ import {
   ActionBarContainer,
   ActionButton,
   UprezDropdown,
+  SplitButtonGroup,
+  SplitMainButton,
+  SplitCaretButton,
   DropdownMenu,
   DropdownItem,
   UprezProgressButton,
@@ -18,6 +21,10 @@ import {
   UprezDivider,
   UprezDoneBadge,
 } from "./flow-action-bar.styled";
+
+// Default model for the one-click "Uprez All" action. The caret menu still
+// exposes both models for an explicit choice.
+const DEFAULT_UPREZ_MODEL: UprezModel = "uprez";
 
 export function FlowActionBar() {
   const {
@@ -200,24 +207,34 @@ export function FlowActionBar() {
             </UprezButtonContent>
           </ActionButton>
         ) : (
-          <ActionButton
-            $accent
-            onClick={() => setUprezDropdownOpen(!uprezDropdownOpen)}
-          >
-            <UprezButtonContent>
-              <span>Uprez All</span>
+          <SplitButtonGroup>
+            <SplitMainButton
+              $accent
+              onClick={() => handleUprezAll(DEFAULT_UPREZ_MODEL)}
+            >
+              <UprezButtonContent>
+                <span>Uprez All</span>
+              </UprezButtonContent>
+            </SplitMainButton>
+            <SplitCaretButton
+              $accent
+              aria-label="Choose upscale model"
+              aria-haspopup="menu"
+              aria-expanded={uprezDropdownOpen}
+              onClick={() => setUprezDropdownOpen(!uprezDropdownOpen)}
+            >
               <span aria-hidden>&#9662;</span>
-            </UprezButtonContent>
-          </ActionButton>
+            </SplitCaretButton>
+          </SplitButtonGroup>
         )}
 
         {uprezDropdownOpen && !showProgressButton && (
           <DropdownMenu>
+            <DropdownItem onClick={() => handleUprezAll("uprez")}>
+              Standard Uprez (default)
+            </DropdownItem>
             <DropdownItem onClick={() => handleUprezAll("nvidia-uprez")}>
               Nvidia Super Resolution
-            </DropdownItem>
-            <DropdownItem onClick={() => handleUprezAll("uprez")}>
-              Standard Uprez
             </DropdownItem>
           </DropdownMenu>
         )}


### PR DESCRIPTION
## What

In Studio **Flow** mode, the upscale control previously had **no default** — "Uprez All" only opened a dropdown that forced an explicit model choice.

This makes "Uprez All" a **split button**:

- **Clicking the main "Uprez All" label** immediately runs the default model, **Standard Uprez** (`uprez`).
- **Clicking the caret `▾`** opens the menu to pick either model. The menu now lists **Standard Uprez (default)** first, then **Nvidia Super Resolution**.

```
[ Uprez All | ▾ ]
  Uprez All  -> runs Standard Uprez now
  ▾          -> menu: Standard Uprez (default) / Nvidia Super Resolution
```

The in-flight ("Upscaling") and completed ("Upscaled") button states are unchanged.

## Files

- `flow-action-bar.styled.tsx` — added `SplitButtonGroup` / `SplitMainButton` / `SplitCaretButton` (fused styling with a single divider).
- `flow-action-bar.tsx` — `DEFAULT_UPREZ_MODEL = "uprez"`; split-button JSX with aria attributes on the caret (`aria-haspopup`, `aria-expanded`, label); reordered/labeled menu items.

## Verification

Type-check and lint pass. No unit tests exist for this presentational component; verified manually in local Flow mode that the main button runs Standard Uprez and the caret still offers both models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)