### PR TITLE
feat: fullscreen studio layout + save to playlist

### DIFF
--- a/src/components/pages/studio/components/flow-action-bar.tsx
+++ b/src/components/pages/studio/components/flow-action-bar.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useMemo } from "react";
-import { toast } from "react-toastify";
 import Bugsnag from "@bugsnag/js";
 import { Loader2, Check } from "lucide-react";
 import { useFlowStore } from "@/stores/flow.store";
@@ -7,6 +6,7 @@ import { useShallow } from "zustand/react/shallow";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import type { UprezModel } from "@/types/studio.types";
+import { SaveToPlaylistModal } from "./save-to-playlist-modal";
 import {
   ActionBarContainer,
   ActionButton,
@@ -45,6 +45,7 @@ export function FlowActionBar() {
 
   const [uprezDropdownOpen, setUprezDropdownOpen] = useState(false);
   const [isUprezzing, setIsUprezzing] = useState(false);
+  const [showSaveModal, setShowSaveModal] = useState(false);
 
   const hasResults = transitions.some((t) => t.status === "processed");
 
@@ -156,7 +157,7 @@ export function FlowActionBar() {
   }, [setPreviewLightboxOpen]);
 
   const handleSaveToPlaylist = useCallback(() => {
-    toast.info("Coming soon — Save to Playlist will be available in Phase 2");
+    setShowSaveModal(true);
   }, []);
 
   if (!hasResults) return null;
@@ -174,75 +175,80 @@ export function FlowActionBar() {
   const showProgressButton = isUprezzing || running;
 
   return (
-    <ActionBarContainer>
-      <ActionButton onClick={handlePreviewAll}>Preview All</ActionButton>
+    <>
+      <ActionBarContainer>
+        <ActionButton onClick={handlePreviewAll}>Preview All</ActionButton>
 
-      <UprezDropdown>
-        {showProgressButton ? (
-          <UprezProgressButton
-            $percent={uprezState.percent}
-            aria-live="polite"
-            aria-label={`Upscaling ${uprezState.done} of ${
-              uprezState.total
-            }, ${Math.round(uprezState.percent)} percent`}
-          >
-            <UprezButtonContent>
-              <Loader2 size={13} strokeWidth={2.4} className="spin" />
-              <span>Upscaling</span>
-              <UprezDivider />
-              <span>
-                {uprezState.done}/{uprezState.total}
-              </span>
-            </UprezButtonContent>
-          </UprezProgressButton>
-        ) : allDone ? (
-          <ActionButton
-            $accent
-            onClick={() => setUprezDropdownOpen(!uprezDropdownOpen)}
-          >
-            <UprezButtonContent>
-              <Check size={13} strokeWidth={2.8} />
-              <span>Upscaled</span>
-              <UprezDoneBadge>{uprezState.done}</UprezDoneBadge>
-            </UprezButtonContent>
-          </ActionButton>
-        ) : (
-          <SplitButtonGroup>
-            <SplitMainButton
-              $accent
-              onClick={() => handleUprezAll(DEFAULT_UPREZ_MODEL)}
+        <UprezDropdown>
+          {showProgressButton ? (
+            <UprezProgressButton
+              $percent={uprezState.percent}
+              aria-live="polite"
+              aria-label={`Upscaling ${uprezState.done} of ${
+                uprezState.total
+              }, ${Math.round(uprezState.percent)} percent`}
             >
               <UprezButtonContent>
-                <span>Uprez All</span>
+                <Loader2 size={13} strokeWidth={2.4} className="spin" />
+                <span>Upscaling</span>
+                <UprezDivider />
+                <span>
+                  {uprezState.done}/{uprezState.total}
+                </span>
               </UprezButtonContent>
-            </SplitMainButton>
-            <SplitCaretButton
+            </UprezProgressButton>
+          ) : allDone ? (
+            <ActionButton
               $accent
-              aria-label="Choose upscale model"
-              aria-haspopup="menu"
-              aria-expanded={uprezDropdownOpen}
               onClick={() => setUprezDropdownOpen(!uprezDropdownOpen)}
             >
-              <span aria-hidden>&#9662;</span>
-            </SplitCaretButton>
-          </SplitButtonGroup>
-        )}
+              <UprezButtonContent>
+                <Check size={13} strokeWidth={2.8} />
+                <span>Upscaled</span>
+                <UprezDoneBadge>{uprezState.done}</UprezDoneBadge>
+              </UprezButtonContent>
+            </ActionButton>
+          ) : (
+            <SplitButtonGroup>
+              <SplitMainButton
+                $accent
+                onClick={() => handleUprezAll(DEFAULT_UPREZ_MODEL)}
+              >
+                <UprezButtonContent>
+                  <span>Uprez All</span>
+                </UprezButtonContent>
+              </SplitMainButton>
+              <SplitCaretButton
+                $accent
+                aria-label="Choose upscale model"
+                aria-haspopup="menu"
+                aria-expanded={uprezDropdownOpen}
+                onClick={() => setUprezDropdownOpen(!uprezDropdownOpen)}
+              >
+                <span aria-hidden>&#9662;</span>
+              </SplitCaretButton>
+            </SplitButtonGroup>
+          )}
 
-        {uprezDropdownOpen && !showProgressButton && (
-          <DropdownMenu>
-            <DropdownItem onClick={() => handleUprezAll("uprez")}>
-              Standard Uprez (default)
-            </DropdownItem>
-            <DropdownItem onClick={() => handleUprezAll("nvidia-uprez")}>
-              Nvidia Super Resolution
-            </DropdownItem>
-          </DropdownMenu>
-        )}
-      </UprezDropdown>
+          {uprezDropdownOpen && !showProgressButton && (
+            <DropdownMenu>
+              <DropdownItem onClick={() => handleUprezAll("uprez")}>
+                Standard Uprez (default)
+              </DropdownItem>
+              <DropdownItem onClick={() => handleUprezAll("nvidia-uprez")}>
+                Nvidia Super Resolution
+              </DropdownItem>
+            </DropdownMenu>
+          )}
+        </UprezDropdown>
 
-      <ActionButton onClick={handleSaveToPlaylist}>
-        Save to Playlist
-      </ActionButton>
-    </ActionBarContainer>
+        <ActionButton onClick={handleSaveToPlaylist}>
+          Save to Playlist
+        </ActionButton>
+      </ActionBarContainer>
+      {showSaveModal && (
+        <SaveToPlaylistModal onClose={() => setShowSaveModal(false)} />
+      )}
+    </>
   );
 }

--- a/src/components/pages/studio/components/save-to-playlist-modal.styled.tsx
+++ b/src/components/pages/studio/components/save-to-playlist-modal.styled.tsx
@@ -1,0 +1,183 @@
+import styled from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+export const ModalContent = styled.div`
+  background: ${FLOW.bgCard};
+  border: 1px solid ${FLOW.border};
+  border-radius: 12px;
+  width: 90%;
+  max-width: 480px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid ${FLOW.border};
+`;
+
+export const ModalTitle = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${FLOW.text};
+  font-family: ${FLOW.fontFamily};
+`;
+
+export const CloseButton = styled.button`
+  background: none;
+  border: none;
+  color: ${FLOW.textDim};
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: color 0.2s;
+
+  &:hover {
+    color: ${FLOW.text};
+  }
+`;
+
+export const ModalBody = styled.div`
+  padding: 1.25rem;
+  overflow-y: auto;
+  flex: 1;
+`;
+
+export const ModeToggleRow = styled.div`
+  display: flex;
+  background: ${FLOW.bg};
+  border: 1px solid ${FLOW.border};
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+  margin-bottom: 1rem;
+`;
+
+export const ModeTab = styled.button<{ $active: boolean }>`
+  flex: 1;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ${FLOW.fontFamily};
+  color: ${(p) => (p.$active ? FLOW.text : FLOW.textMuted)};
+  background: ${(p) => (p.$active ? FLOW.bgElevated : "transparent")};
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    color: ${FLOW.text};
+  }
+`;
+
+export const NameInput = styled.input`
+  width: 100%;
+  background: ${FLOW.bgInput};
+  border: 1px solid ${FLOW.border};
+  border-radius: 6px;
+  padding: 9px 12px;
+  color: ${FLOW.text};
+  font-size: 14px;
+  font-family: ${FLOW.fontFamily};
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: ${FLOW.accent};
+  }
+`;
+
+export const PlaylistList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+`;
+
+export const PlaylistItem = styled.button<{ $selected: boolean }>`
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: ${(p) => (p.$selected ? FLOW.accentDim : "transparent")};
+  border: 1px solid ${(p) => (p.$selected ? FLOW.accent : FLOW.border)};
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: ${(p) => (p.$selected ? FLOW.accent : FLOW.textDim)};
+  font-size: 13px;
+  font-family: ${FLOW.fontFamily};
+  cursor: pointer;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
+`;
+
+export const Summary = styled.p`
+  font-size: 12px;
+  color: ${FLOW.textMuted};
+  margin-top: 1rem;
+`;
+
+export const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid ${FLOW.border};
+`;
+
+export const CancelButton = styled.button`
+  background: transparent;
+  border: 1px solid ${FLOW.border};
+  color: ${FLOW.textDim};
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ${FLOW.fontFamily};
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
+`;
+
+export const SaveButton = styled.button`
+  background: ${FLOW.accent};
+  color: ${FLOW.bg};
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: ${FLOW.fontFamily};
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover:not(:disabled) {
+    background: #e0b45e;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/pages/studio/components/save-to-playlist-modal.styled.tsx
+++ b/src/components/pages/studio/components/save-to-playlist-modal.styled.tsx
@@ -1,5 +1,16 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import { FLOW } from "@/constants/flow-theme.constants";
+
+const spin = keyframes`
+  to { transform: rotate(360deg); }
+`;
+
+export const SpinningIcon = styled.span`
+  display: inline-flex;
+  svg {
+    animation: ${spin} 1.4s linear infinite;
+  }
+`;
 
 export const ModalOverlay = styled.div`
   position: fixed;

--- a/src/components/pages/studio/components/save-to-playlist-modal.tsx
+++ b/src/components/pages/studio/components/save-to-playlist-modal.tsx
@@ -24,6 +24,7 @@ import {
   ModalFooter,
   CancelButton,
   SaveButton,
+  SpinningIcon,
 } from "./save-to-playlist-modal.styled";
 
 interface Props {
@@ -126,7 +127,7 @@ export const SaveToPlaylistModal: React.FC<Props> = ({ onClose }) => {
   ]);
 
   return (
-    <ModalOverlay onClick={onClose}>
+    <ModalOverlay onClick={isSaving ? undefined : onClose}>
       <ModalContent onClick={(e) => e.stopPropagation()}>
         <ModalHeader>
           <ModalTitle>Save to Playlist</ModalTitle>
@@ -185,11 +186,9 @@ export const SaveToPlaylistModal: React.FC<Props> = ({ onClose }) => {
           </CancelButton>
           <SaveButton onClick={handleSave} disabled={!canSave || isSaving}>
             {isSaving ? (
-              <Loader2
-                size={14}
-                strokeWidth={2.4}
-                style={{ animation: "spin 1.4s linear infinite" }}
-              />
+              <SpinningIcon>
+                <Loader2 size={14} strokeWidth={2.4} />
+              </SpinningIcon>
             ) : (
               "Save"
             )}

--- a/src/components/pages/studio/components/save-to-playlist-modal.tsx
+++ b/src/components/pages/studio/components/save-to-playlist-modal.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useCallback } from "react";
+import { toast } from "react-toastify";
+import { Loader2 } from "lucide-react";
+import Bugsnag from "@bugsnag/js";
+import { useFlowStore } from "@/stores/flow.store";
+import { useShallow } from "zustand/react/shallow";
+import { useCreatePlaylist } from "@/api/playlist/mutation/useCreatePlaylist";
+import { useAddPlaylistItem } from "@/api/playlist/mutation/useAddPlaylistItem";
+import { useUserPlaylists } from "../hooks/useUserPlaylists";
+import { ROUTES } from "@/constants/routes.constants";
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  CloseButton,
+  ModalBody,
+  ModeToggleRow,
+  ModeTab,
+  NameInput,
+  PlaylistList,
+  PlaylistItem,
+  Summary,
+  ModalFooter,
+  CancelButton,
+  SaveButton,
+} from "./save-to-playlist-modal.styled";
+
+interface Props {
+  onClose: () => void;
+}
+
+export const SaveToPlaylistModal: React.FC<Props> = ({ onClose }) => {
+  const { transitions } = useFlowStore(
+    useShallow((s) => ({ transitions: s.transitions })),
+  );
+
+  const completedTransitions = transitions.filter(
+    (t) => t.status === "processed" && t.dreamUuid,
+  );
+
+  const [mode, setMode] = useState<"new" | "existing">("new");
+  const [playlistName, setPlaylistName] = useState(
+    `Studio Flow — ${new Date().toISOString().slice(0, 10)}`,
+  );
+  const [selectedPlaylistId, setSelectedPlaylistId] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+
+  const { playlists, addPlaylistToCache } = useUserPlaylists();
+  const createPlaylist = useCreatePlaylist();
+  const addPlaylistItem = useAddPlaylistItem();
+
+  const canSave =
+    completedTransitions.length > 0 &&
+    (mode === "new"
+      ? playlistName.trim().length > 0
+      : selectedPlaylistId !== "");
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    setIsSaving(true);
+    const total = completedTransitions.length;
+    setProgress({ current: 0, total });
+
+    try {
+      let playlistUUID: string;
+      let finalName: string;
+
+      if (mode === "new") {
+        const result = await createPlaylist.mutateAsync({
+          name: playlistName.trim(),
+        });
+        const playlist = result.data?.playlist;
+        if (!playlist) throw new Error("No playlist in response");
+        playlistUUID = playlist.uuid;
+        finalName = playlist.name;
+        addPlaylistToCache({ uuid: playlist.uuid, name: playlist.name });
+      } else {
+        playlistUUID = selectedPlaylistId;
+        finalName =
+          playlists.find((p) => p.uuid === selectedPlaylistId)?.name ??
+          "playlist";
+      }
+
+      for (let i = 0; i < completedTransitions.length; i++) {
+        setProgress({ current: i + 1, total });
+        await addPlaylistItem.mutateAsync({
+          playlistUUID,
+          values: {
+            type: "dream",
+            uuid: completedTransitions[i].dreamUuid!,
+          },
+        });
+      }
+
+      toast.success(
+        <span>
+          Saved {total} transition{total !== 1 ? "s" : ""} to{" "}
+          <a
+            href={`${ROUTES.VIEW_PLAYLIST}/${playlistUUID}`}
+            style={{ color: "inherit", textDecoration: "underline" }}
+          >
+            {finalName}
+          </a>
+        </span>,
+      );
+      onClose();
+    } catch (err) {
+      Bugsnag.notify(err as Error);
+      toast.error("Failed to save — please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    canSave,
+    mode,
+    playlistName,
+    selectedPlaylistId,
+    completedTransitions,
+    createPlaylist,
+    addPlaylistItem,
+    addPlaylistToCache,
+    playlists,
+    onClose,
+  ]);
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <ModalHeader>
+          <ModalTitle>Save to Playlist</ModalTitle>
+          <CloseButton onClick={onClose}>&times;</CloseButton>
+        </ModalHeader>
+
+        <ModalBody>
+          <ModeToggleRow>
+            <ModeTab $active={mode === "new"} onClick={() => setMode("new")}>
+              New Playlist
+            </ModeTab>
+            <ModeTab
+              $active={mode === "existing"}
+              onClick={() => setMode("existing")}
+            >
+              Existing Playlist
+            </ModeTab>
+          </ModeToggleRow>
+
+          {mode === "new" ? (
+            <NameInput
+              value={playlistName}
+              onChange={(e) => setPlaylistName(e.target.value)}
+              placeholder="Playlist name"
+              autoFocus
+            />
+          ) : (
+            <PlaylistList>
+              {playlists.length === 0 && (
+                <Summary>No playlists found. Create a new one instead.</Summary>
+              )}
+              {playlists.map((pl) => (
+                <PlaylistItem
+                  key={pl.uuid}
+                  $selected={selectedPlaylistId === pl.uuid}
+                  onClick={() => setSelectedPlaylistId(pl.uuid)}
+                >
+                  {pl.name}
+                </PlaylistItem>
+              ))}
+            </PlaylistList>
+          )}
+
+          <Summary>
+            {isSaving
+              ? `Adding ${progress.current} of ${progress.total}...`
+              : `Adding ${completedTransitions.length} transition${
+                  completedTransitions.length !== 1 ? "s" : ""
+                }`}
+          </Summary>
+        </ModalBody>
+
+        <ModalFooter>
+          <CancelButton onClick={onClose} disabled={isSaving}>
+            Cancel
+          </CancelButton>
+          <SaveButton onClick={handleSave} disabled={!canSave || isSaving}>
+            {isSaving ? (
+              <Loader2
+                size={14}
+                strokeWidth={2.4}
+                style={{ animation: "spin 1.4s linear infinite" }}
+              />
+            ) : (
+              "Save"
+            )}
+          </SaveButton>
+        </ModalFooter>
+      </ModalContent>
+    </ModalOverlay>
+  );
+};

--- a/src/components/pages/studio/studio.layout.tsx
+++ b/src/components/pages/studio/studio.layout.tsx
@@ -1,10 +1,9 @@
 // src/components/pages/studio/studio.layout.tsx
 import { useEffect } from "react";
 import ReactGA from "react-ga4";
-import Providers, { withProviders } from "@/providers/providers";
 import { StudioPage } from "./studio.page";
 
-const StudioLayout = () => {
+export const StudioLayout = () => {
   useEffect(() => {
     ReactGA.send({
       hitType: "pageview",
@@ -14,7 +13,3 @@ const StudioLayout = () => {
 
   return <StudioPage />;
 };
-
-export const StudioLayoutWithProviders = withProviders(...Providers)(
-  StudioLayout,
-);

--- a/src/components/pages/studio/studio.layout.tsx
+++ b/src/components/pages/studio/studio.layout.tsx
@@ -1,0 +1,20 @@
+// src/components/pages/studio/studio.layout.tsx
+import { useEffect } from "react";
+import ReactGA from "react-ga4";
+import Providers, { withProviders } from "@/providers/providers";
+import { StudioPage } from "./studio.page";
+
+const StudioLayout = () => {
+  useEffect(() => {
+    ReactGA.send({
+      hitType: "pageview",
+      page: window.location.pathname + window.location.search,
+    });
+  }, []);
+
+  return <StudioPage />;
+};
+
+export const StudioLayoutWithProviders = withProviders(...Providers)(
+  StudioLayout,
+);

--- a/src/components/pages/studio/studio.page.styled.tsx
+++ b/src/components/pages/studio/studio.page.styled.tsx
@@ -2,48 +2,92 @@ import styled from "styled-components";
 import { FLOW } from "@/constants/flow-theme.constants";
 
 export const StudioContainer = styled.div<{ $dragOver?: boolean }>`
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.5rem;
-  min-height: calc(100vh - 80px);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: ${FLOW.bg};
   transition: outline-color 0.2s;
   outline: 2px solid transparent;
   outline-offset: -2px;
-  border-radius: 12px;
 
   ${(props) =>
     props.$dragOver &&
     `
-    outline-color: ${props.theme.colorPrimary};
+    outline-color: ${FLOW.accent};
   `}
 `;
 
 export const StudioHeader = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1.5rem;
+  padding: 12px 20px;
+  border-bottom: 1px solid ${FLOW.border};
+  gap: 16px;
+  flex-shrink: 0;
+`;
+
+export const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: ${FLOW.radiusSm};
+  border: 1px solid ${FLOW.border};
+  background: transparent;
+  color: ${FLOW.textDim};
+  cursor: pointer;
+  transition: all 0.2s;
+  flex-shrink: 0;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
 `;
 
 export const StudioTitle = styled.h1`
-  font-size: 1.5rem;
+  font-size: 1.125rem;
   font-weight: 600;
-  color: ${(props) => props.theme.textPrimaryColor};
+  color: ${FLOW.text};
+  font-family: ${FLOW.fontFamily};
+`;
+
+export const HeaderSpacer = styled.div`
+  flex: 1;
 `;
 
 export const NewSessionButton = styled.button`
   background: transparent;
-  border: 1px solid #555;
-  color: #aaa;
+  border: 1px solid ${FLOW.border};
+  color: ${FLOW.textDim};
   padding: 0.375rem 0.75rem;
   border-radius: 6px;
   font-size: 0.8125rem;
+  font-family: ${FLOW.fontFamily};
   cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
+`;
+
+export const StudioBody = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.5rem;
 `;
 
 export const ModeToggle = styled.div`
   display: flex;
   background: ${FLOW.bg};
+  border: 1px solid ${FLOW.border};
   border-radius: 8px;
   padding: 3px;
   gap: 2px;

--- a/src/components/pages/studio/studio.page.styled.tsx
+++ b/src/components/pages/studio/studio.page.styled.tsx
@@ -75,13 +75,17 @@ export const NewSessionButton = styled.button`
   }
 `;
 
-export const StudioBody = styled.div`
+export const StudioBody = styled.div<{ $constrain?: boolean }>`
   flex: 1;
   overflow-y: auto;
-  max-width: 1200px;
   width: 100%;
-  margin: 0 auto;
-  padding: 1.5rem;
+  ${(props) =>
+    props.$constrain &&
+    `
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.5rem;
+  `}
 `;
 
 export const ModeToggle = styled.div`

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -155,7 +155,7 @@ export const StudioPage: React.FC = () => {
         )}
       </StudioHeader>
 
-      <StudioBody>
+      <StudioBody $constrain={mode === "batch"}>
         <Suspense fallback={null}>
           {mode === "flow" && <FlowBuilder />}
           {mode === "batch" && (

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -1,8 +1,12 @@
 import React, { lazy, Suspense, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
+import Bugsnag from "@bugsnag/js";
 import { useStudioStore } from "@/stores/studio.store";
 import { useStudioModeStore } from "@/stores/studio-mode.store";
 import { useFlowStore } from "@/stores/flow.store";
+import { ROUTES } from "@/constants/routes.constants";
 import { StudioTabs } from "./components/studio-tabs";
 import { useStudioJobProgress } from "./hooks/useStudioJobProgress";
 import { useFileDropUpload } from "./hooks/useFileDropUpload";
@@ -11,7 +15,10 @@ import {
   StudioContainer,
   StudioHeader,
   StudioTitle,
+  BackButton,
+  HeaderSpacer,
   NewSessionButton,
+  StudioBody,
   ModeToggle,
   ModeButton,
 } from "./studio.page.styled";
@@ -29,10 +36,13 @@ const ResultsTab = lazy(() =>
   import("./components/results-tab").then((m) => ({ default: m.ResultsTab })),
 );
 const FlowBuilder = lazy(() =>
-  import("./components/flow-builder").then((m) => ({ default: m.FlowBuilder })),
+  import("./components/flow-builder").then((m) => ({
+    default: m.FlowBuilder,
+  })),
 );
 
 export const StudioPage: React.FC = () => {
+  const navigate = useNavigate();
   const mode = useStudioModeStore((s) => s.mode);
   const setMode = useStudioModeStore((s) => s.setMode);
 
@@ -47,6 +57,14 @@ export const StudioPage: React.FC = () => {
   const updateImage = useStudioStore((s) => s.updateImage);
   const addKeyframe = useFlowStore((s) => s.addKeyframe);
   const uploadDream = useUploadImageDream();
+
+  const handleBack = useCallback(() => {
+    if (window.history.length > 1) {
+      navigate(-1);
+    } else {
+      navigate(ROUTES.REMOTE_CONTROL);
+    }
+  }, [navigate]);
 
   const handleStudioDrop = useCallback(
     async (files: File[]) => {
@@ -73,7 +91,7 @@ export const StudioPage: React.FC = () => {
               name: result.name,
             });
           } catch (err) {
-            console.error("Failed to upload image:", err);
+            Bugsnag.notify(err as Error);
             updateImage(placeholderUuid, { status: "failed" });
           } finally {
             URL.revokeObjectURL(blobUrl);
@@ -88,7 +106,7 @@ export const StudioPage: React.FC = () => {
               name: result.name,
             });
           } catch (err) {
-            console.error("Failed to upload keyframe:", err);
+            Bugsnag.notify(err as Error);
           }
         }
       }
@@ -114,6 +132,9 @@ export const StudioPage: React.FC = () => {
   return (
     <StudioContainer $dragOver={isDragOver} {...dropHandlers}>
       <StudioHeader>
+        <BackButton onClick={handleBack} aria-label="Go back">
+          <ArrowLeft size={16} />
+        </BackButton>
         <StudioTitle>Studio</StudioTitle>
         <ModeToggle>
           <ModeButton $active={mode === "flow"} onClick={() => setMode("flow")}>
@@ -126,6 +147,7 @@ export const StudioPage: React.FC = () => {
             Batch (Advanced)
           </ModeButton>
         </ModeToggle>
+        <HeaderSpacer />
         {mode === "batch" && hasContent && (
           <NewSessionButton onClick={handleNewSession}>
             New Session
@@ -133,18 +155,20 @@ export const StudioPage: React.FC = () => {
         )}
       </StudioHeader>
 
-      <Suspense fallback={null}>
-        {mode === "flow" && <FlowBuilder />}
-        {mode === "batch" && (
-          <>
-            <StudioTabs />
-            {activeTab === "images" && <ImagesTab />}
-            {activeTab === "actions" && <ActionsTab />}
-            {activeTab === "generate" && <GenerateTab />}
-            {activeTab === "results" && <ResultsTab />}
-          </>
-        )}
-      </Suspense>
+      <StudioBody>
+        <Suspense fallback={null}>
+          {mode === "flow" && <FlowBuilder />}
+          {mode === "batch" && (
+            <>
+              <StudioTabs />
+              {activeTab === "images" && <ImagesTab />}
+              {activeTab === "actions" && <ActionsTab />}
+              {activeTab === "generate" && <GenerateTab />}
+              {activeTab === "results" && <ResultsTab />}
+            </>
+          )}
+        </Suspense>
+      </StudioBody>
     </StudioContainer>
   );
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -32,7 +32,7 @@ import { SignupPage } from "@/components/pages/signup/signup.page";
 import PublicRoute from "@/routes/public-route";
 import PlaylistsFeedPage from "@/components/pages/playlist-feed/playlist-feed";
 import PlaygroundPage from "@/components/pages/playground/playground.page";
-import { StudioLayoutWithProviders } from "@/components/pages/studio/studio.layout";
+import { StudioLayout } from "@/components/pages/studio/studio.layout";
 import NotFoundPage from "@/components/pages/not-found/not-found.page";
 import UnsubscribePage from "@/components/pages/unsubscribe/unsubscribe.page";
 import { useEffect } from "react";
@@ -83,6 +83,11 @@ export const RootElement = () => {
 
 const RootElementWithProviders = withProviders(...Providers)(RootElement);
 const NotFoundPageWithProviders = withProviders(...Providers)(NotFoundPage);
+const StudioRouteWithProviders = withProviders(...Providers)(() => (
+  <ProtectedRoute allowedRoles={[ROLES.CREATOR_GROUP, ROLES.ADMIN_GROUP]}>
+    <StudioLayout />
+  </ProtectedRoute>
+));
 
 export const router = createBrowserRouter([
   {
@@ -366,11 +371,7 @@ export const router = createBrowserRouter([
   },
   {
     path: ROUTES.STUDIO,
-    element: (
-      <ProtectedRoute allowedRoles={[ROLES.CREATOR_GROUP, ROLES.ADMIN_GROUP]}>
-        <StudioLayoutWithProviders />
-      </ProtectedRoute>
-    ),
+    element: <StudioRouteWithProviders />,
     errorElement: <NotFoundPageWithProviders />,
   },
 ]);

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -32,7 +32,7 @@ import { SignupPage } from "@/components/pages/signup/signup.page";
 import PublicRoute from "@/routes/public-route";
 import PlaylistsFeedPage from "@/components/pages/playlist-feed/playlist-feed";
 import PlaygroundPage from "@/components/pages/playground/playground.page";
-import { StudioPage } from "@/components/pages/studio/studio.page";
+import { StudioLayoutWithProviders } from "@/components/pages/studio/studio.layout";
 import NotFoundPage from "@/components/pages/not-found/not-found.page";
 import UnsubscribePage from "@/components/pages/unsubscribe/unsubscribe.page";
 import { useEffect } from "react";
@@ -113,16 +113,6 @@ export const router = createBrowserRouter([
         element: (
           <ProtectedRoute allowedRoles={[ROLES.ADMIN_GROUP]}>
             <PlaygroundPage />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: ROUTES.STUDIO,
-        element: (
-          <ProtectedRoute
-            allowedRoles={[ROLES.CREATOR_GROUP, ROLES.ADMIN_GROUP]}
-          >
-            <StudioPage />
           </ProtectedRoute>
         ),
       },
@@ -373,6 +363,15 @@ export const router = createBrowserRouter([
         element: <TermsOfServicePage />,
       },
     ],
+  },
+  {
+    path: ROUTES.STUDIO,
+    element: (
+      <ProtectedRoute allowedRoles={[ROLES.CREATOR_GROUP, ROLES.ADMIN_GROUP]}>
+        <StudioLayoutWithProviders />
+      </ProtectedRoute>
+    ),
+    errorElement: <NotFoundPageWithProviders />,
   },
 ]);
 


### PR DESCRIPTION
## Summary

- **Fullscreen Studio:** Moved `/studio` route out of `RootElement` into its own top-level route with a chromeless `StudioLayout` wrapper — no header, footer, or player tray. Added back arrow with guarded navigation (history-aware fallback to `/rc`).
- **Save to Playlist:** Replaced "Coming soon" toast with a modal that creates a new playlist or selects an existing one, then bulk-adds completed transition dreams sequentially with per-item progress feedback.
- **Review fixes:** Guarded backdrop click during save, fixed Loader2 spin animation (styled-components keyframe), removed max-width constraint on flow mode for true fullscreen canvas.

## Test plan

- [ ] Navigate to `/studio` directly — renders fullscreen, no header/footer
- [ ] Click back arrow — goes to previous page (or `/rc` if no history)
- [ ] Toggle Flow / Batch (Advanced) — both modes render correctly
- [ ] In flow mode: keyframe strip fills available width (no 1200px cap)
- [ ] Generate transitions, click "Save to Playlist" — modal opens
- [ ] Create new playlist with pre-filled name — items added with progress ("Adding 3 of 8...")
- [ ] Switch to "Existing Playlist" tab — shows user's playlists, select one
- [ ] Success toast shows playlist link, modal closes
- [ ] Click backdrop during save — modal stays open (not dismissible while saving)
- [ ] Save button shows spinning loader during save

🤖 Generated with [Claude Code](https://claude.com/claude-code)