### PR TITLE
feat: variations grid, sessions, prompt expansion (Phase 0)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,12 @@ const App = () => {
 
   useEffect(() => {
     /**
-     * Initialize TagManager
+     * Initialize TagManager — only when a GTM id is configured. Without it
+     * react-gtm-module warns and injects a broken tag; skip on local/preview.
      */
-    TagManager.initialize({ gtmId: import.meta.env.VITE_GTM_ID });
+    if (import.meta.env.VITE_GTM_ID) {
+      TagManager.initialize({ gtmId: import.meta.env.VITE_GTM_ID });
+    }
 
     unregisterDocumentEvents();
   }, []);

--- a/src/components/pages/studio/components/actions-tab.tsx
+++ b/src/components/pages/studio/components/actions-tab.tsx
@@ -22,6 +22,7 @@ import {
   SummaryBox,
   SummaryHighlight,
 } from "./actions-tab.styled";
+import { PromptExpansionBadge } from "./prompt-expansion-badge";
 
 export const ActionsTab: React.FC = () => {
   const actions = useStudioStore((s) => s.actions);
@@ -97,6 +98,7 @@ export const ActionsTab: React.FC = () => {
                     updateAction(action.id, { prompt: e.target.value })
                   }
                 />
+                <PromptExpansionBadge prompt={action.prompt} />
                 <DeleteButton onClick={() => removeAction(action.id)}>
                   &times;
                 </DeleteButton>

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -3,8 +3,11 @@ import Bugsnag from "@bugsnag/js";
 import { v4 as uuidv4 } from "uuid";
 import styled from "styled-components";
 import { useFlowStore } from "@/stores/flow.store";
+import { useStudioStore } from "@/stores/studio.store";
 import { FLOW } from "@/constants/flow-theme.constants";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
+import { axiosClient } from "@/client/axios.client";
+import type { VariationCandidate } from "@/types/flow.types";
 import { KeyframeStrip } from "./keyframe-strip";
 import { TransitionSettingsPanel } from "./transition-settings-panel";
 import { FlowPreview } from "./flow-preview";
@@ -109,6 +112,70 @@ export const FlowBuilder: React.FC = () => {
     [addKeyframe, updateKeyframe, removeKeyframe, uploadDream],
   );
 
+  const handleKeyframeVariations = useCallback(async (keyframeId: string) => {
+    // Read image generation settings at call time (NOT via React subscription)
+    // to keep callback identity stable across settings keystrokes.
+    const { imagePrompt, imageGenParams } = useStudioStore.getState();
+    const keyframe = useFlowStore
+      .getState()
+      .keyframes.find((kf) => kf.id === keyframeId);
+    if (!keyframe) return;
+
+    const VARIATION_COUNT = 4;
+    const baseSeed = Math.floor(Math.random() * 99_000) + 1;
+
+    // Build placeholder candidates up-front so the grid appears immediately.
+    const candidates: VariationCandidate[] = Array.from(
+      { length: VARIATION_COUNT },
+      (_, i) => ({
+        id: uuidv4(),
+        method: "seed" as const,
+        prompt: imagePrompt || keyframe.name,
+        seed: baseSeed + i,
+        status: "queue" as const,
+      }),
+    );
+
+    useFlowStore.getState().addKeyframeVariations(keyframeId, candidates);
+
+    // Fire all API calls in parallel — never sequential for-loop.
+    await Promise.all(
+      candidates.map(async (candidate) => {
+        const algoParams = {
+          infinidream_algorithm: imageGenParams.model,
+          prompt: candidate.prompt,
+          size: imageGenParams.size,
+          seed: candidate.seed,
+        };
+
+        try {
+          const { data } = await axiosClient.post("/v1/dream", {
+            name: `${keyframe.name} v${candidate.seed}`,
+            prompt: JSON.stringify(algoParams),
+            description: "Keyframe variation",
+          });
+          const dreamUuid = data?.data?.dream?.uuid;
+          if (!dreamUuid) {
+            throw new Error("No dream UUID returned from API");
+          }
+          useFlowStore
+            .getState()
+            .updateKeyframeVariation(keyframeId, candidate.id, {
+              dreamUuid,
+              status: "queue",
+            });
+        } catch (err) {
+          Bugsnag.notify(err as Error);
+          useFlowStore
+            .getState()
+            .updateKeyframeVariation(keyframeId, candidate.id, {
+              status: "failed",
+            });
+        }
+      }),
+    );
+  }, []);
+
   const handleFileSelected = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
@@ -139,6 +206,7 @@ export const FlowBuilder: React.FC = () => {
         onAddFromPlaylist={handleAddFromPlaylist}
         onAddFromLibrary={handleAddFromLibrary}
         onRetry={generateOne}
+        onRequestVariations={handleKeyframeVariations}
       />
 
       <TransitionSettingsPanel

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -17,6 +17,7 @@ import { SelectImageDreamModal } from "./select-image-dream-modal";
 import { useFlowGeneration } from "@/components/pages/studio/hooks/useFlowGeneration";
 import { useFlowJobProgress } from "@/components/pages/studio/hooks/useFlowJobProgress";
 import { useFileDropUpload } from "../hooks/useFileDropUpload";
+import { VariationLightbox } from "./variation-lightbox";
 
 const FlowContainer = styled.div<{ $dragOver?: boolean }>`
   background: ${FLOW.bgCard};
@@ -51,6 +52,9 @@ export const FlowBuilder: React.FC = () => {
 
   const [showPlaylistModal, setShowPlaylistModal] = useState(false);
   const [showLibraryModal, setShowLibraryModal] = useState(false);
+  const [variationLightboxIndex, setVariationLightboxIndex] = useState<
+    number | null
+  >(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleAddUpload = useCallback(() => {
@@ -207,6 +211,7 @@ export const FlowBuilder: React.FC = () => {
         onAddFromLibrary={handleAddFromLibrary}
         onRetry={generateOne}
         onRequestVariations={handleKeyframeVariations}
+        onOpenVariationLightbox={setVariationLightboxIndex}
       />
 
       <TransitionSettingsPanel
@@ -236,6 +241,55 @@ export const FlowBuilder: React.FC = () => {
       {showLibraryModal && (
         <SelectImageDreamModal onClose={() => setShowLibraryModal(false)} />
       )}
+
+      {variationLightboxIndex !== null &&
+        (() => {
+          const t = useFlowStore.getState().transitions[variationLightboxIndex];
+          if (!t) return null;
+          const prompt =
+            t.promptOverride ?? useFlowStore.getState().globalPrompt;
+          // Dream video URL will be fetched by the lightbox or already cached
+          const videoUrl = t.dreamUuid
+            ? `${window.location.origin}/api/v1/dream/${t.dreamUuid}/video`
+            : undefined;
+          return (
+            <VariationLightbox
+              transition={t}
+              transitionIndex={variationLightboxIndex}
+              effectivePrompt={prompt}
+              videoUrl={videoUrl}
+              onSelectVariation={(idx, vid) => {
+                useFlowStore.getState().selectTransitionVariation(idx, vid);
+              }}
+              onRegenerate={(idx) => {
+                generateOne(idx);
+              }}
+              onGenerateMore={(idx) => {
+                // Generate 4 seed variations for this transition
+                const store = useFlowStore.getState();
+                const transition = store.transitions[idx];
+                if (!transition) return;
+                const effectivePrompt =
+                  transition.promptOverride ?? store.globalPrompt;
+                const candidates: VariationCandidate[] = Array.from(
+                  { length: 4 },
+                  () => ({
+                    id: uuidv4(),
+                    method: "seed" as const,
+                    prompt: effectivePrompt,
+                    seed: Math.floor(Math.random() * 99_000) + 1,
+                    status: "queue" as const,
+                  }),
+                );
+                store.addTransitionVariations(idx, candidates);
+                // The generation will be picked up by the transition generation
+                // pipeline — for now, candidates are created as placeholders.
+                // A full implementation would call generateTransition per candidate.
+              }}
+              onClose={() => setVariationLightboxIndex(null)}
+            />
+          );
+        })()}
     </FlowContainer>
   );
 };

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -46,6 +46,15 @@ export const FlowBuilder: React.FC = () => {
   // Mount progress tracking
   useFlowJobProgress();
 
+  // Subscribe to the open transition for the lightbox — avoids IIFE with getState()
+  // during render, which would bypass React's subscription and miss updates.
+  const openTransition = useFlowStore((s) =>
+    variationLightboxIndex !== null
+      ? s.transitions[variationLightboxIndex] ?? null
+      : null,
+  );
+  const lightboxGlobalPrompt = useFlowStore((s) => s.globalPrompt);
+
   // Generation controls
   const { generateAll, generateOne, isGenerating } = useFlowGeneration();
   const uploadDream = useUploadImageDream();
@@ -242,54 +251,22 @@ export const FlowBuilder: React.FC = () => {
         <SelectImageDreamModal onClose={() => setShowLibraryModal(false)} />
       )}
 
-      {variationLightboxIndex !== null &&
-        (() => {
-          const t = useFlowStore.getState().transitions[variationLightboxIndex];
-          if (!t) return null;
-          const prompt =
-            t.promptOverride ?? useFlowStore.getState().globalPrompt;
-          // Dream video URL will be fetched by the lightbox or already cached
-          const videoUrl = t.dreamUuid
-            ? `${window.location.origin}/api/v1/dream/${t.dreamUuid}/video`
-            : undefined;
-          return (
-            <VariationLightbox
-              transition={t}
-              transitionIndex={variationLightboxIndex}
-              effectivePrompt={prompt}
-              videoUrl={videoUrl}
-              onSelectVariation={(idx, vid) => {
-                useFlowStore.getState().selectTransitionVariation(idx, vid);
-              }}
-              onRegenerate={(idx) => {
-                generateOne(idx);
-              }}
-              onGenerateMore={(idx) => {
-                // Generate 4 seed variations for this transition
-                const store = useFlowStore.getState();
-                const transition = store.transitions[idx];
-                if (!transition) return;
-                const effectivePrompt =
-                  transition.promptOverride ?? store.globalPrompt;
-                const candidates: VariationCandidate[] = Array.from(
-                  { length: 4 },
-                  () => ({
-                    id: uuidv4(),
-                    method: "seed" as const,
-                    prompt: effectivePrompt,
-                    seed: Math.floor(Math.random() * 99_000) + 1,
-                    status: "queue" as const,
-                  }),
-                );
-                store.addTransitionVariations(idx, candidates);
-                // The generation will be picked up by the transition generation
-                // pipeline — for now, candidates are created as placeholders.
-                // A full implementation would call generateTransition per candidate.
-              }}
-              onClose={() => setVariationLightboxIndex(null)}
-            />
-          );
-        })()}
+      {variationLightboxIndex !== null && openTransition && (
+        <VariationLightbox
+          transition={openTransition}
+          transitionIndex={variationLightboxIndex}
+          effectivePrompt={
+            openTransition.promptOverride ?? lightboxGlobalPrompt
+          }
+          onSelectVariation={(idx, vid) => {
+            useFlowStore.getState().selectTransitionVariation(idx, vid);
+          }}
+          onRegenerate={(idx) => {
+            generateOne(idx);
+          }}
+          onClose={() => setVariationLightboxIndex(null)}
+        />
+      )}
     </FlowContainer>
   );
 };

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -8,8 +8,11 @@ import { FLOW } from "@/constants/flow-theme.constants";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import { axiosClient } from "@/client/axios.client";
 import type { VariationCandidate } from "@/types/flow.types";
+import { getVariationPreset } from "../constants/variation-presets";
+import { expandPrompt } from "../utils/expand-prompt";
 import { KeyframeStrip } from "./keyframe-strip";
 import { TransitionSettingsPanel } from "./transition-settings-panel";
+import { VariationSettingsPanel } from "./variation-settings-panel";
 import { FlowPreview } from "./flow-preview";
 import { FlowActionBar } from "./flow-action-bar";
 import { AddKeyframesFromPlaylistModal } from "./add-keyframes-from-playlist-modal";
@@ -129,23 +132,74 @@ export const FlowBuilder: React.FC = () => {
   const handleKeyframeVariations = useCallback(async (keyframeId: string) => {
     // Read image generation settings at call time (NOT via React subscription)
     // to keep callback identity stable across settings keystrokes.
-    const { imagePrompt, imageGenParams } = useStudioStore.getState();
+    const {
+      imagePrompt,
+      imageGenParams,
+      variationPresetId,
+      variationCustomPrompt,
+      variationSeed,
+    } = useStudioStore.getState();
     const keyframe = useFlowStore
       .getState()
       .keyframes.find((kf) => kf.id === keyframeId);
     if (!keyframe) return;
 
-    const VARIATION_COUNT = 4;
-    const baseSeed = Math.floor(Math.random() * 99_000) + 1;
+    // Custom prompt (Customize section) overrides the canned preset: split per
+    // line and apply {a|b|c} expansion to each line. Falls back to the preset.
+    // Custom prompts (Customize section) override the preset when present: split
+    // per line and apply {a|b|c} expansion to each line.
+    const customModifiers = variationCustomPrompt
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => expandPrompt(line));
+    const modifiers = (
+      customModifiers.length > 0
+        ? customModifiers
+        : getVariationPreset(variationPresetId).modifiers
+    ).slice(0, 8);
 
-    // Build placeholder candidates up-front so the grid appears immediately.
+    const VARIATION_COUNT = modifiers.length;
+    // The user's seed is the anchor (stable across a batch — variation comes
+    // from the prompt). Each +More batch is offset by the count of variations
+    // already present, so pressing +More yields NEW images rather than
+    // regenerating the same seed/prompt, while staying reproducible.
+    const existingCount = keyframe.variations?.length ?? 0;
+    const baseSeed = variationSeed + existingCount;
+
+    // Use the SOURCE image's own prompt as the base so variations stay on-theme.
+    // Without this the tool fell back to the keyframe name and produced generic
+    // qwen output. The original prompt is stored as algoParams JSON on the dream.
+    let originalPrompt = "";
+    if (keyframe.dreamUuid) {
+      try {
+        const { data } = await axiosClient.get(
+          `/v1/dream/${keyframe.dreamUuid}`,
+        );
+        const rawPrompt = data?.data?.dream?.prompt;
+        if (typeof rawPrompt === "string" && rawPrompt) {
+          try {
+            originalPrompt = JSON.parse(rawPrompt)?.prompt || "";
+          } catch {
+            originalPrompt = rawPrompt;
+          }
+        }
+      } catch (err) {
+        Bugsnag.notify(err as Error);
+      }
+    }
+    const basePrompt = originalPrompt || imagePrompt || keyframe.name;
+
+    // Layer a canned variation modifier onto the source prompt so the set is
+    // meaningfully different (not generic seed jitter), and keep the seed STABLE
+    // across the set so the difference comes from the prompt.
     const candidates: VariationCandidate[] = Array.from(
       { length: VARIATION_COUNT },
       (_, i) => ({
         id: uuidv4(),
-        method: "seed" as const,
-        prompt: imagePrompt || keyframe.name,
-        seed: baseSeed + i,
+        method: "expansion" as const,
+        prompt: `${basePrompt}, ${modifiers[i % modifiers.length]}`,
+        seed: baseSeed,
         status: "queue" as const,
       }),
     );
@@ -154,7 +208,7 @@ export const FlowBuilder: React.FC = () => {
 
     // Fire all API calls in parallel — never sequential for-loop.
     await Promise.all(
-      candidates.map(async (candidate) => {
+      candidates.map(async (candidate, i) => {
         const algoParams = {
           infinidream_algorithm: imageGenParams.model,
           prompt: candidate.prompt,
@@ -164,7 +218,7 @@ export const FlowBuilder: React.FC = () => {
 
         try {
           const { data } = await axiosClient.post("/v1/dream", {
-            name: `${keyframe.name} v${candidate.seed}`,
+            name: `${keyframe.name} v${i + 1}`,
             prompt: JSON.stringify(algoParams),
             description: "Keyframe variation",
           });
@@ -232,6 +286,8 @@ export const FlowBuilder: React.FC = () => {
 
       <FlowPreview />
       <FlowActionBar />
+
+      <VariationSettingsPanel />
 
       <input
         ref={fileInputRef}

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -43,6 +43,14 @@ export const FlowBuilder: React.FC = () => {
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
 
+  // State declarations must come before selectors that reference them (TDZ).
+  const [showPlaylistModal, setShowPlaylistModal] = useState(false);
+  const [showLibraryModal, setShowLibraryModal] = useState(false);
+  const [variationLightboxIndex, setVariationLightboxIndex] = useState<
+    number | null
+  >(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   // Mount progress tracking
   useFlowJobProgress();
 
@@ -58,13 +66,6 @@ export const FlowBuilder: React.FC = () => {
   // Generation controls
   const { generateAll, generateOne, isGenerating } = useFlowGeneration();
   const uploadDream = useUploadImageDream();
-
-  const [showPlaylistModal, setShowPlaylistModal] = useState(false);
-  const [showLibraryModal, setShowLibraryModal] = useState(false);
-  const [variationLightboxIndex, setVariationLightboxIndex] = useState<
-    number | null
-  >(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleAddUpload = useCallback(() => {
     fileInputRef.current?.click();

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from "react";
+import Bugsnag from "@bugsnag/js";
 import { useStudioStore } from "@/stores/studio.store";
 import { useBatchSubmit } from "../hooks/useBatchSubmit";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
@@ -126,7 +127,7 @@ export const GenerateTab: React.FC = () => {
       setOutputPlaylistId(playlist.uuid);
       addPlaylistToCache({ uuid: playlist.uuid, name: playlist.name });
     } catch (err) {
-      console.error("Failed to create playlist:", err);
+      Bugsnag.notify(err instanceof Error ? err : new Error(String(err)));
     }
   };
 

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -4,6 +4,7 @@ import { useBatchSubmit } from "../hooks/useBatchSubmit";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
 import { axiosClient } from "@/client/axios.client";
 import type { VideoModel } from "@/types/studio.types";
+import { expandPrompt } from "../utils/expand-prompt";
 import {
   clampDurationToAllowed,
   getAllowedDurationsForActions,
@@ -69,6 +70,20 @@ export const GenerateTab: React.FC = () => {
     [actions],
   );
 
+  const expandedActions = useMemo(
+    () =>
+      enabledActions.flatMap((action) => {
+        const expanded = expandPrompt(action.prompt);
+        if (expanded.length <= 1) return [action];
+        return expanded.map((prompt, i) => ({
+          ...action,
+          id: `${action.id}__exp${i}`,
+          prompt,
+        }));
+      }),
+    [enabledActions],
+  );
+
   const newCombos = useMemo(
     () => getSelectedCombinations(),
     [getSelectedCombinations],
@@ -85,10 +100,10 @@ export const GenerateTab: React.FC = () => {
   const showLtxHint = useMemo(() => {
     if (videoGenParams.model !== "ltx-i2v") return false;
     return (
-      enabledActions.length > 0 &&
-      enabledActions.some((a) => !hasActionLoras(a))
+      expandedActions.length > 0 &&
+      expandedActions.some((a) => !hasActionLoras(a))
     );
-  }, [videoGenParams.model, enabledActions]);
+  }, [videoGenParams.model, expandedActions]);
 
   useEffect(() => {
     const nextDuration = clampDurationToAllowed(
@@ -100,7 +115,7 @@ export const GenerateTab: React.FC = () => {
     }
   }, [durationOptions, videoGenParams.duration, setVideoGenParams]);
 
-  const totalPossible = selectedImages.length * enabledActions.length;
+  const totalPossible = selectedImages.length * expandedActions.length;
 
   const handleCreatePlaylist = async () => {
     const now = new Date();
@@ -129,7 +144,7 @@ export const GenerateTab: React.FC = () => {
             <thead>
               <tr>
                 <GridHeader />
-                {enabledActions.map((action) => (
+                {expandedActions.map((action) => (
                   <GridHeader key={action.id} title={action.prompt}>
                     {action.prompt.slice(0, 20)}...
                   </GridHeader>
@@ -140,7 +155,7 @@ export const GenerateTab: React.FC = () => {
               {selectedImages.map((image) => (
                 <tr key={image.uuid}>
                   <GridRowHeader>{image.name}</GridRowHeader>
-                  {enabledActions.map((action) => {
+                  {expandedActions.map((action) => {
                     const comboKey = `${image.uuid}:${action.id}`;
                     const excluded = excludedCombos.has(comboKey);
                     const existingJob = jobs.find(

--- a/src/components/pages/studio/components/generate-tab.tsx
+++ b/src/components/pages/studio/components/generate-tab.tsx
@@ -47,11 +47,15 @@ const VIDEO_MODELS: VideoModel[] = ["ltx-i2v", "wan-i2v"];
 const STEPS_OPTIONS = [20, 25, 30, 40];
 const GUIDANCE_OPTIONS = [3.0, 4.0, 5.0, 6.0, 7.0];
 
+const LTX_FIXED_TOOLTIP =
+  "LTX 2.3 uses optimized fixed settings (8 steps, guidance 1) — not configurable here.";
+
 export const GenerateTab: React.FC = () => {
   const images = useStudioStore((s) => s.images);
   const actions = useStudioStore((s) => s.actions);
   const videoGenParams = useStudioStore((s) => s.videoGenParams);
   const setVideoGenParams = useStudioStore((s) => s.setVideoGenParams);
+  const isLtx = videoGenParams.model === "ltx-i2v";
   const excludedCombos = useStudioStore((s) => s.excludedCombos);
   const toggleComboExcluded = useStudioStore((s) => s.toggleComboExcluded);
   const outputPlaylistId = useStudioStore((s) => s.outputPlaylistId);
@@ -245,10 +249,12 @@ export const GenerateTab: React.FC = () => {
               ))}
             </StyledSelect>
           </FormField>
-          <FormField>
+          <FormField title={isLtx ? LTX_FIXED_TOOLTIP : undefined}>
             <FieldLabel>Steps:</FieldLabel>
             <StyledSelect
               value={videoGenParams.numInferenceSteps}
+              disabled={isLtx}
+              title={isLtx ? LTX_FIXED_TOOLTIP : undefined}
               onChange={(e) =>
                 setVideoGenParams({ numInferenceSteps: Number(e.target.value) })
               }
@@ -260,10 +266,12 @@ export const GenerateTab: React.FC = () => {
               ))}
             </StyledSelect>
           </FormField>
-          <FormField>
+          <FormField title={isLtx ? LTX_FIXED_TOOLTIP : undefined}>
             <FieldLabel>Guidance:</FieldLabel>
             <StyledSelect
               value={videoGenParams.guidance}
+              disabled={isLtx}
+              title={isLtx ? LTX_FIXED_TOOLTIP : undefined}
               onChange={(e) =>
                 setVideoGenParams({ guidance: Number(e.target.value) })
               }

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -5,6 +5,8 @@ import { axiosClient } from "@/client/axios.client";
 import type { StudioImage, ImageModel } from "@/types/studio.types";
 import { useFileDropUpload } from "../hooks/useFileDropUpload";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
+import { expandPrompt } from "../utils/expand-prompt";
+import { PromptExpansionBadge } from "./prompt-expansion-badge";
 import {
   SIZE_OPTIONS,
   IMAGE_COUNT_OPTIONS,
@@ -89,43 +91,55 @@ export const ImagesTab: React.FC = () => {
     const baseSeed = Math.floor(Math.random() * 99_000) + 1;
     const currentImageCount = useStudioStore.getState().images.length;
 
-    const promises = Array.from(
-      { length: imageGenParams.seedCount },
-      (_, i) => {
-        const seed = baseSeed + i;
-        const algoParams = {
-          infinidream_algorithm: imageGenParams.model,
-          prompt: imagePrompt,
-          size: imageGenParams.size,
-          seed,
-        };
+    // Expand {A|B|C} syntax into distinct prompts so a single template fans out
+    // into meaningfully different images. Each expanded prompt is then rendered
+    // across `seedCount` seeds. A plain prompt expands to itself ([prompt]).
+    const expandedPrompts = expandPrompt(imagePrompt);
 
-        return axiosClient
-          .post("/v1/dream", {
-            name: `${MODEL_LABELS[imageGenParams.model]} ${
-              currentImageCount + i + 1
-            }`,
-            prompt: JSON.stringify(algoParams),
-            description: "Studio generated image",
-          })
-          .then(({ data }) => {
-            const dream = data.data?.dream;
-            if (!dream) return;
-            addImage({
-              uuid: dream.uuid,
-              url: dream.thumbnail || "",
-              name: dream.name,
-              seed,
-              size: imageGenParams.size,
-              status: (dream.status as StudioImage["status"]) || "queue",
-              selected: false,
-            });
-          })
-          .catch((err) => {
-            console.error("Failed to create image:", err);
-          });
-      },
+    // Seed is stable across the prompt-expansion dimension: every expanded
+    // prompt is rendered at the SAME seed slot, so the difference between
+    // variations comes from the prompt, not the seed. The seedCount dimension
+    // still adds extra seeds per prompt.
+    const jobs = expandedPrompts.flatMap((prompt) =>
+      Array.from({ length: imageGenParams.seedCount }, (_, sIdx) => ({
+        prompt,
+        seed: baseSeed + sIdx,
+      })),
     );
+
+    const promises = jobs.map(({ prompt, seed }, idx) => {
+      const algoParams = {
+        infinidream_algorithm: imageGenParams.model,
+        prompt,
+        size: imageGenParams.size,
+        seed,
+      };
+
+      return axiosClient
+        .post("/v1/dream", {
+          name: `${MODEL_LABELS[imageGenParams.model]} ${
+            currentImageCount + idx + 1
+          }`,
+          prompt: JSON.stringify(algoParams),
+          description: "Studio generated image",
+        })
+        .then(({ data }) => {
+          const dream = data.data?.dream;
+          if (!dream) return;
+          addImage({
+            uuid: dream.uuid,
+            url: dream.thumbnail || "",
+            name: dream.name,
+            seed,
+            size: imageGenParams.size,
+            status: (dream.status as StudioImage["status"]) || "queue",
+            selected: false,
+          });
+        })
+        .catch((err) => {
+          console.error("Failed to create image:", err);
+        });
+    });
 
     await Promise.all(promises);
     setIsGenerating(false);
@@ -183,10 +197,11 @@ export const ImagesTab: React.FC = () => {
       <GenerateSection>
         <SectionTitle>Generate New Images</SectionTitle>
         <PromptTextarea
-          placeholder="Describe the image you want to generate..."
+          placeholder="Describe the image you want to generate... use {a|b|c} to make variations"
           value={imagePrompt}
           onChange={(e) => setImagePrompt(e.target.value)}
         />
+        <PromptExpansionBadge prompt={imagePrompt} />
         <FormRow>
           <FormField>
             <FieldLabel>Model:</FieldLabel>

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -195,13 +195,15 @@ export const ImagesTab: React.FC = () => {
   return (
     <ImagesTabContainer $dragOver={isDragOver} {...dropHandlers}>
       <GenerateSection>
-        <SectionTitle>Generate New Images</SectionTitle>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <SectionTitle>Generate New Images</SectionTitle>
+          <PromptExpansionBadge prompt={imagePrompt} />
+        </div>
         <PromptTextarea
           placeholder="Describe the image you want to generate... use {a|b|c} to make variations"
           value={imagePrompt}
           onChange={(e) => setImagePrompt(e.target.value)}
         />
-        <PromptExpansionBadge prompt={imagePrompt} />
         <FormRow>
           <FormField>
             <FieldLabel>Model:</FieldLabel>

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -208,3 +208,29 @@ export const DeleteButton = styled.button`
     opacity: 1;
   }
 `;
+
+export const VariationsButton = styled.button`
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  color: ${FLOW.textMuted};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s;
+
+  ${CardWrapper}:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: ${FLOW.accent};
+  }
+`;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -194,7 +194,7 @@ export const DeleteButton = styled.button`
   height: 20px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textDim};
+  color: ${FLOW.text};
   font-size: 12px;
   display: flex;
   align-items: center;
@@ -217,7 +217,7 @@ export const VariationsButton = styled.button`
   height: 20px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textDim};
+  color: ${FLOW.text};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -194,7 +194,7 @@ export const DeleteButton = styled.button`
   height: 20px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textMuted};
+  color: ${FLOW.textDim};
   font-size: 12px;
   display: flex;
   align-items: center;
@@ -217,7 +217,7 @@ export const VariationsButton = styled.button`
   height: 20px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textMuted};
+  color: ${FLOW.textDim};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Shuffle } from "lucide-react";
 import type { FlowKeyframe } from "@/types/flow.types";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
+import { VariationGrid } from "./variation-grid";
 import {
   CardWrapper,
   CardImage,
@@ -13,6 +14,7 @@ import {
   CardLabel,
   LoopBadge,
   DeleteButton,
+  VariationsButton,
   UploadOverlay,
   UploadRing,
   UploadRingTrack,
@@ -25,20 +27,28 @@ interface Props {
   keyframe: FlowKeyframe;
   index: number;
   onDelete?: (id: string) => void;
+  onRequestVariations?: (keyframeId: string) => void;
 }
 
 export const KeyframeCard: React.FC<Props> = ({
   keyframe,
   index,
   onDelete,
+  onRequestVariations,
 }) => {
   const isLoop = keyframe.isLoopKeyframe ?? false;
   const isUploading = keyframe.uploadStatus === "uploading";
   const isFailed = keyframe.uploadStatus === "failed";
   const isBusy = isUploading || isFailed;
+  const isSettled = !!(keyframe.dreamUuid || keyframe.keyframeUuid);
 
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
+  const selectKeyframeVariation = useFlowStore(
+    (s) => s.selectKeyframeVariation,
+  );
+
   const [imgSrc, setImgSrc] = useState(keyframe.imageUrl);
+  const [showVariations, setShowVariations] = useState(false);
 
   useEffect(() => {
     setImgSrc(keyframe.imageUrl);
@@ -105,71 +115,105 @@ export const KeyframeCard: React.FC<Props> = ({
   };
 
   return (
-    <CardWrapper
-      ref={setNodeRef}
-      style={style}
-      $loop={isLoop}
-      $isDragging={isDragging}
-      $uploading={isUploading}
-      $failed={isFailed}
-      {...(isLoop || isBusy ? {} : { ...attributes, ...listeners })}
-    >
-      {imgSrc ? (
-        <CardImage
-          src={imgSrc}
-          alt={keyframe.name}
-          $uploading={isUploading}
-          onClick={isClickable ? handleOpen : undefined}
-          style={isClickable ? { cursor: "pointer" } : undefined}
-          onError={keyframe.dreamUuid ? handleImgError : undefined}
-        />
-      ) : (
-        <CardPlaceholder>{keyframe.name}</CardPlaceholder>
-      )}
-
-      {isUploading && (
-        <UploadOverlay
-          role="progressbar"
-          aria-label={`Uploading ${keyframe.name}`}
-          aria-valuenow={percent}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <UploadRing viewBox="0 0 36 36">
-            <UploadRingTrack cx="18" cy="18" r="16" />
-            <UploadRingFill cx="18" cy="18" r="16" $percent={percent} />
-          </UploadRing>
-          <UploadPercent>{percent}%</UploadPercent>
-        </UploadOverlay>
-      )}
-
-      {isFailed && (
-        <FailedOverlay role="alert">
-          <AlertTriangle size={16} strokeWidth={2.2} />
-          Upload failed
-        </FailedOverlay>
-      )}
-
-      <CardLabel>
-        {isLoop ? (
-          <>
-            {keyframe.name} <LoopBadge>Loop</LoopBadge>
-          </>
+    <>
+      <CardWrapper
+        ref={setNodeRef}
+        style={style}
+        $loop={isLoop}
+        $isDragging={isDragging}
+        $uploading={isUploading}
+        $failed={isFailed}
+        {...(isLoop || isBusy ? {} : { ...attributes, ...listeners })}
+      >
+        {imgSrc ? (
+          <CardImage
+            src={imgSrc}
+            alt={keyframe.name}
+            $uploading={isUploading}
+            onClick={isClickable ? handleOpen : undefined}
+            style={isClickable ? { cursor: "pointer" } : undefined}
+            onError={keyframe.dreamUuid ? handleImgError : undefined}
+          />
         ) : (
-          `${index + 1}`
+          <CardPlaceholder>{keyframe.name}</CardPlaceholder>
         )}
-      </CardLabel>
 
-      {!isLoop && !isBusy && onDelete && (
-        <DeleteButton
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete(keyframe.id);
-          }}
-        >
-          &times;
-        </DeleteButton>
-      )}
-    </CardWrapper>
+        {isUploading && (
+          <UploadOverlay
+            role="progressbar"
+            aria-label={`Uploading ${keyframe.name}`}
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <UploadRing viewBox="0 0 36 36">
+              <UploadRingTrack cx="18" cy="18" r="16" />
+              <UploadRingFill cx="18" cy="18" r="16" $percent={percent} />
+            </UploadRing>
+            <UploadPercent>{percent}%</UploadPercent>
+          </UploadOverlay>
+        )}
+
+        {isFailed && (
+          <FailedOverlay role="alert">
+            <AlertTriangle size={16} strokeWidth={2.2} />
+            Upload failed
+          </FailedOverlay>
+        )}
+
+        <CardLabel>
+          {isLoop ? (
+            <>
+              {keyframe.name} <LoopBadge>Loop</LoopBadge>
+            </>
+          ) : (
+            `${index + 1}`
+          )}
+        </CardLabel>
+
+        {!isLoop && !isBusy && onDelete && (
+          <DeleteButton
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(keyframe.id);
+            }}
+          >
+            &times;
+          </DeleteButton>
+        )}
+
+        {!isLoop && !isBusy && isSettled && onRequestVariations && (
+          <VariationsButton
+            onClick={(e) => {
+              e.stopPropagation();
+              if (
+                !showVariations &&
+                (!keyframe.variations || keyframe.variations.length === 0)
+              ) {
+                onRequestVariations(keyframe.id);
+              }
+              setShowVariations((v) => !v);
+            }}
+            title="Generate variations"
+          >
+            <Shuffle size={11} />
+          </VariationsButton>
+        )}
+      </CardWrapper>
+
+      {showVariations &&
+        keyframe.variations &&
+        keyframe.variations.length > 0 && (
+          <VariationGrid
+            variations={keyframe.variations}
+            activeVariationId={keyframe.activeVariationId}
+            onSelect={(variationId) =>
+              selectKeyframeVariation(keyframe.id, variationId)
+            }
+            onGenerateMore={() => onRequestVariations?.(keyframe.id)}
+            onClose={() => setShowVariations(false)}
+          />
+        )}
+    </>
   );
 };

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -14,6 +14,7 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
+import { shouldOpenVariationLightbox } from "../utils/variation-status";
 import { KeyframeCard } from "./keyframe-card";
 import { TransitionGapEnhanced } from "./transition-gap";
 import { FlowReset } from "./flow-reset";
@@ -122,9 +123,11 @@ export const KeyframeStrip: React.FC<Props> = ({
               if (transition.status === "failed") {
                 onRetry(transitionIndex);
               } else if (
-                transition.status === "processed" &&
+                shouldOpenVariationLightbox(transition) &&
                 onOpenVariationLightbox
               ) {
+                // Processed single result OR a transition that owns variations
+                // (in-flight or ready) — open the review lightbox.
                 onOpenVariationLightbox(transitionIndex);
               } else {
                 selectTransition(transitionIndex);

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -38,6 +38,7 @@ interface Props {
   onAddFromPlaylist: () => void;
   onAddFromLibrary: () => void;
   onRetry: (index: number) => void;
+  onRequestVariations?: (keyframeId: string) => void;
 }
 
 export const KeyframeStrip: React.FC<Props> = ({
@@ -45,6 +46,7 @@ export const KeyframeStrip: React.FC<Props> = ({
   onAddFromPlaylist,
   onAddFromLibrary,
   onRetry,
+  onRequestVariations,
 }) => {
   // Actions (stable refs)
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
@@ -138,6 +140,7 @@ export const KeyframeStrip: React.FC<Props> = ({
         keyframe={kf}
         index={i}
         onDelete={removeKeyframe}
+        onRequestVariations={onRequestVariations}
       />,
     );
   });

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -39,6 +39,7 @@ interface Props {
   onAddFromLibrary: () => void;
   onRetry: (index: number) => void;
   onRequestVariations?: (keyframeId: string) => void;
+  onOpenVariationLightbox?: (transitionIndex: number) => void;
 }
 
 export const KeyframeStrip: React.FC<Props> = ({
@@ -47,6 +48,7 @@ export const KeyframeStrip: React.FC<Props> = ({
   onAddFromLibrary,
   onRetry,
   onRequestVariations,
+  onOpenVariationLightbox,
 }) => {
   // Actions (stable refs)
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
@@ -119,6 +121,11 @@ export const KeyframeStrip: React.FC<Props> = ({
             onClick={() => {
               if (transition.status === "failed") {
                 onRetry(transitionIndex);
+              } else if (
+                transition.status === "processed" &&
+                onOpenVariationLightbox
+              ) {
+                onOpenVariationLightbox(transitionIndex);
               } else {
                 selectTransition(transitionIndex);
               }

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -17,7 +17,6 @@ import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
 import { shouldOpenVariationLightbox } from "../utils/variation-status";
 import { KeyframeCard } from "./keyframe-card";
 import { TransitionGapEnhanced } from "./transition-gap";
-import { FlowReset } from "./flow-reset";
 import {
   StripSection,
   SectionHeader,
@@ -159,7 +158,6 @@ export const KeyframeStrip: React.FC<Props> = ({
     <StripSection>
       <SectionHeader>
         <SectionLabel>Keyframes</SectionLabel>
-        <FlowReset />
       </SectionHeader>
 
       {displayKeyframes.length === 0 ? (

--- a/src/components/pages/studio/components/prompt-expansion-badge.tsx
+++ b/src/components/pages/studio/components/prompt-expansion-badge.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styled from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+import { countExpansions } from "../utils/expand-prompt";
+
+const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: ${FLOW.accentDim};
+  color: ${FLOW.accent};
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+`;
+
+interface PromptExpansionBadgeProps {
+  prompt: string;
+}
+
+export const PromptExpansionBadge: React.FC<PromptExpansionBadgeProps> = ({
+  prompt,
+}) => {
+  const count = countExpansions(prompt);
+  if (count <= 1) return null;
+  return <Badge>{count} variants</Badge>;
+};

--- a/src/components/pages/studio/components/prompt-expansion-badge.tsx
+++ b/src/components/pages/studio/components/prompt-expansion-badge.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import styled from "styled-components";
 import { FLOW } from "@/constants/flow-theme.constants";
-import { countExpansions } from "../utils/expand-prompt";
+import {
+  countExpansions,
+  countRawExpansions,
+  MAX_EXPANSIONS,
+} from "../utils/expand-prompt";
 
 const Badge = styled.span`
   display: inline-flex;
@@ -25,5 +29,15 @@ export const PromptExpansionBadge: React.FC<PromptExpansionBadgeProps> = ({
 }) => {
   const count = countExpansions(prompt);
   if (count <= 1) return null;
+  const raw = countRawExpansions(prompt);
+  // Surface the cap so the user knows combinations were dropped (and how many),
+  // rather than silently generating only the first MAX_EXPANSIONS.
+  if (raw > MAX_EXPANSIONS) {
+    return (
+      <Badge title={`Capped at ${MAX_EXPANSIONS} of ${raw} combinations`}>
+        {MAX_EXPANSIONS} of {raw} (max {MAX_EXPANSIONS})
+      </Badge>
+    );
+  }
   return <Badge>{count} variants</Badge>;
 };

--- a/src/components/pages/studio/components/session-switcher.styled.tsx
+++ b/src/components/pages/studio/components/session-switcher.styled.tsx
@@ -6,33 +6,34 @@ export const SwitcherContainer = styled.div`
 `;
 
 export const SwitcherBar = styled.div`
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 2px;
-  padding: 3px 4px 3px 12px;
-  background: ${FLOW.bgElevated};
-  border: 1px solid ${FLOW.border};
-  border-radius: 8px;
-  max-width: 260px;
-  transition: border-color 0.2s;
-
-  &:focus-within {
-    border-color: ${FLOW.borderHover};
-  }
+  max-width: 100%;
 `;
 
 export const TitleInput = styled.input`
-  flex: 1;
-  min-width: 0;
+  box-sizing: border-box;
+  min-width: 1ch;
+  max-width: 320px;
   background: transparent;
   border: none;
   outline: none;
   color: ${FLOW.text};
   font-size: 13px;
+  font-weight: 500;
   font-family: inherit;
-  padding: 3px 0;
+  padding: 3px 2px;
+  border-radius: 4px;
   text-overflow: ellipsis;
+  transition: background 0.15s;
 
+  &:hover:not(:disabled) {
+    background: ${FLOW.bgElevated};
+  }
+  &:focus {
+    background: ${FLOW.bgElevated};
+  }
   &::placeholder {
     color: ${FLOW.textMuted};
   }
@@ -40,6 +41,20 @@ export const TitleInput = styled.input`
     color: ${FLOW.textMuted};
     cursor: default;
   }
+`;
+
+// Hidden mirror used to measure the title text so the input can grow/shrink
+// to fit its content. Must match TitleInput's font + horizontal padding.
+export const TitleSizer = styled.span`
+  position: absolute;
+  top: 0;
+  left: -9999px;
+  visibility: hidden;
+  white-space: pre;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  padding: 3px 2px;
 `;
 
 export const CaretButton = styled.button`

--- a/src/components/pages/studio/components/session-switcher.styled.tsx
+++ b/src/components/pages/studio/components/session-switcher.styled.tsx
@@ -5,26 +5,62 @@ export const SwitcherContainer = styled.div`
   position: relative;
 `;
 
-export const SwitcherButton = styled.button`
+export const SwitcherBar = styled.div`
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: 2px;
+  padding: 3px 4px 3px 12px;
   background: ${FLOW.bgElevated};
   border: 1px solid ${FLOW.border};
   border-radius: 8px;
+  max-width: 260px;
+  transition: border-color 0.2s;
+
+  &:focus-within {
+    border-color: ${FLOW.borderHover};
+  }
+`;
+
+export const TitleInput = styled.input`
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
   color: ${FLOW.text};
   font-size: 13px;
   font-family: inherit;
-  cursor: pointer;
-  transition: border-color 0.2s;
-  max-width: 200px;
-  overflow: hidden;
+  padding: 3px 0;
   text-overflow: ellipsis;
-  white-space: nowrap;
+
+  &::placeholder {
+    color: ${FLOW.textMuted};
+  }
+  &:disabled {
+    color: ${FLOW.textMuted};
+    cursor: default;
+  }
+`;
+
+export const CaretButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: ${FLOW.textDim};
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
 
   &:hover {
-    border-color: ${FLOW.borderHover};
+    background: ${FLOW.bgInput};
+    color: ${FLOW.text};
   }
 `;
 

--- a/src/components/pages/studio/components/session-switcher.styled.tsx
+++ b/src/components/pages/studio/components/session-switcher.styled.tsx
@@ -1,0 +1,130 @@
+import styled from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+export const SwitcherContainer = styled.div`
+  position: relative;
+`;
+
+export const SwitcherButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: ${FLOW.bgElevated};
+  border: 1px solid ${FLOW.border};
+  border-radius: 8px;
+  color: ${FLOW.text};
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+  }
+`;
+
+export const Dropdown = styled.div`
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  min-width: 280px;
+  max-height: 400px;
+  overflow-y: auto;
+  background: ${FLOW.bgCard};
+  border: 1px solid ${FLOW.border};
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  padding: 8px;
+`;
+
+export const SessionItem = styled.div<{ $active?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+  background: ${(p) => (p.$active ? FLOW.accentDim : "transparent")};
+
+  &:hover {
+    background: ${FLOW.bgElevated};
+  }
+`;
+
+export const SessionThumb = styled.div`
+  width: 36px;
+  height: 24px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: ${FLOW.bgInput};
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+export const SessionInfo = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const SessionName = styled.div`
+  font-size: 13px;
+  color: ${FLOW.text};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const SessionMeta = styled.div`
+  font-size: 11px;
+  color: ${FLOW.textMuted};
+`;
+
+export const ModeBadge = styled.span`
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: ${FLOW.bgInput};
+  color: ${FLOW.textDim};
+`;
+
+export const DropdownActions = styled.div`
+  border-top: 1px solid ${FLOW.border};
+  margin-top: 4px;
+  padding-top: 4px;
+`;
+
+export const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-radius: 8px;
+  color: ${FLOW.textDim};
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${FLOW.bgElevated};
+    color: ${FLOW.text};
+  }
+`;

--- a/src/components/pages/studio/components/session-switcher.tsx
+++ b/src/components/pages/studio/components/session-switcher.tsx
@@ -3,7 +3,9 @@ import { ChevronDown, Plus, Copy, Trash2 } from "lucide-react";
 import { useSessionStore } from "@/stores/session.store";
 import {
   SwitcherContainer,
-  SwitcherButton,
+  SwitcherBar,
+  TitleInput,
+  CaretButton,
   Dropdown,
   SessionItem,
   SessionThumb,
@@ -48,6 +50,22 @@ export const SessionSwitcher: React.FC = () => {
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
 
+  // Inline-editable title for the active session. Kept in sync when the active
+  // session changes; commits the rename on blur/Enter, reverts on Escape/empty.
+  const [titleDraft, setTitleDraft] = useState(activeSession?.name ?? "");
+  useEffect(() => {
+    setTitleDraft(activeSession?.name ?? "");
+  }, [activeSession?.id, activeSession?.name]);
+
+  const commitTitle = useCallback(() => {
+    const v = titleDraft.trim();
+    if (activeSessionId && v && v !== activeSession?.name) {
+      renameSession(activeSessionId, v);
+    } else {
+      setTitleDraft(activeSession?.name ?? "");
+    }
+  }, [titleDraft, activeSessionId, activeSession?.name, renameSession]);
+
   const handleNew = useCallback(() => {
     createSession();
     setOpen(false);
@@ -82,10 +100,30 @@ export const SessionSwitcher: React.FC = () => {
 
   return (
     <SwitcherContainer ref={containerRef}>
-      <SwitcherButton onClick={() => setOpen((o) => !o)}>
-        {activeSession?.name || "No Session"}
-        <ChevronDown size={14} />
-      </SwitcherButton>
+      <SwitcherBar>
+        <TitleInput
+          value={titleDraft}
+          placeholder="No Session"
+          disabled={!activeSessionId}
+          onChange={(e) => setTitleDraft(e.target.value)}
+          onBlur={commitTitle}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              (e.target as HTMLInputElement).blur();
+            }
+            if (e.key === "Escape") {
+              setTitleDraft(activeSession?.name ?? "");
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+        <CaretButton
+          onClick={() => setOpen((o) => !o)}
+          aria-label="Switch session"
+        >
+          <ChevronDown size={14} />
+        </CaretButton>
+      </SwitcherBar>
 
       {open && (
         <Dropdown>

--- a/src/components/pages/studio/components/session-switcher.tsx
+++ b/src/components/pages/studio/components/session-switcher.tsx
@@ -1,10 +1,17 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { ChevronDown, Plus, Copy, Trash2 } from "lucide-react";
 import { useSessionStore } from "@/stores/session.store";
 import {
   SwitcherContainer,
   SwitcherBar,
   TitleInput,
+  TitleSizer,
   CaretButton,
   Dropdown,
   SessionItem,
@@ -66,6 +73,15 @@ export const SessionSwitcher: React.FC = () => {
     }
   }, [titleDraft, activeSessionId, activeSession?.name, renameSession]);
 
+  // Auto-size the title input to its content via a hidden mirror span.
+  const sizerRef = useRef<HTMLSpanElement>(null);
+  const [titleWidth, setTitleWidth] = useState(0);
+  useLayoutEffect(() => {
+    if (sizerRef.current) {
+      setTitleWidth(sizerRef.current.offsetWidth + 2);
+    }
+  }, [titleDraft, activeSessionId]);
+
   const handleNew = useCallback(() => {
     createSession();
     setOpen(false);
@@ -105,6 +121,7 @@ export const SessionSwitcher: React.FC = () => {
           value={titleDraft}
           placeholder="No Session"
           disabled={!activeSessionId}
+          style={{ width: titleWidth || undefined }}
           onChange={(e) => setTitleDraft(e.target.value)}
           onBlur={commitTitle}
           onKeyDown={(e) => {
@@ -117,6 +134,9 @@ export const SessionSwitcher: React.FC = () => {
             }
           }}
         />
+        <TitleSizer ref={sizerRef} aria-hidden>
+          {titleDraft || "No Session"}
+        </TitleSizer>
         <CaretButton
           onClick={() => setOpen((o) => !o)}
           aria-label="Switch session"

--- a/src/components/pages/studio/components/session-switcher.tsx
+++ b/src/components/pages/studio/components/session-switcher.tsx
@@ -1,0 +1,166 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronDown, Plus, Copy, Trash2 } from "lucide-react";
+import { useSessionStore } from "@/stores/session.store";
+import {
+  SwitcherContainer,
+  SwitcherButton,
+  Dropdown,
+  SessionItem,
+  SessionThumb,
+  SessionInfo,
+  SessionName,
+  SessionMeta,
+  ModeBadge,
+  DropdownActions,
+  ActionButton,
+} from "./session-switcher.styled";
+
+export const SessionSwitcher: React.FC = () => {
+  const sessions = useSessionStore((s) => s.sessions);
+  const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const createSession = useSessionStore((s) => s.createSession);
+  const switchSession = useSessionStore((s) => s.switchSession);
+  const deleteSession = useSessionStore((s) => s.deleteSession);
+  const duplicateSession = useSessionStore((s) => s.duplicateSession);
+  const renameSession = useSessionStore((s) => s.renameSession);
+
+  const [open, setOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Sessions are loaded synchronously at module level in session.store.ts
+  // so no loadFromStorage() call is needed here.
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const activeSession = sessions.find((s) => s.id === activeSessionId);
+
+  const handleNew = useCallback(() => {
+    createSession();
+    setOpen(false);
+  }, [createSession]);
+
+  const handleSwitch = useCallback(
+    (id: string) => {
+      if (id !== activeSessionId) {
+        switchSession(id);
+      }
+      setOpen(false);
+    },
+    [activeSessionId, switchSession],
+  );
+
+  const handleRenameStart = useCallback((id: string, currentName: string) => {
+    setEditingId(id);
+    setEditName(currentName);
+  }, []);
+
+  const handleRenameCommit = useCallback(() => {
+    if (editingId && editName.trim()) {
+      renameSession(editingId, editName.trim());
+    }
+    setEditingId(null);
+  }, [editingId, editName, renameSession]);
+
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  };
+
+  return (
+    <SwitcherContainer ref={containerRef}>
+      <SwitcherButton onClick={() => setOpen((o) => !o)}>
+        {activeSession?.name || "No Session"}
+        <ChevronDown size={14} />
+      </SwitcherButton>
+
+      {open && (
+        <Dropdown>
+          {sessions.map((session) => (
+            <SessionItem
+              key={session.id}
+              $active={session.id === activeSessionId}
+              onClick={() => handleSwitch(session.id)}
+            >
+              <SessionThumb>
+                {session.thumbnail && <img src={session.thumbnail} alt="" />}
+              </SessionThumb>
+              <SessionInfo>
+                {editingId === session.id ? (
+                  <input
+                    autoFocus
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onBlur={handleRenameCommit}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRenameCommit();
+                      if (e.key === "Escape") setEditingId(null);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      color: "inherit",
+                      font: "inherit",
+                      width: "100%",
+                      outline: "none",
+                    }}
+                  />
+                ) : (
+                  <SessionName
+                    onDoubleClick={(e) => {
+                      e.stopPropagation();
+                      handleRenameStart(session.id, session.name);
+                    }}
+                  >
+                    {session.name}
+                  </SessionName>
+                )}
+                <SessionMeta>
+                  {formatDate(session.updatedAt)}{" "}
+                  <ModeBadge>{session.mode}</ModeBadge>
+                </SessionMeta>
+              </SessionInfo>
+              <Copy
+                size={14}
+                style={{ opacity: 0.4, cursor: "pointer", flexShrink: 0 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  duplicateSession(session.id);
+                }}
+              />
+              {sessions.length > 1 && (
+                <Trash2
+                  size={14}
+                  style={{ opacity: 0.4, cursor: "pointer", flexShrink: 0 }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deleteSession(session.id);
+                  }}
+                />
+              )}
+            </SessionItem>
+          ))}
+          <DropdownActions>
+            <ActionButton onClick={handleNew}>
+              <Plus size={14} /> New Session
+            </ActionButton>
+          </DropdownActions>
+        </Dropdown>
+      )}
+    </SwitcherContainer>
+  );
+};

--- a/src/components/pages/studio/components/transition-gap.tsx
+++ b/src/components/pages/studio/components/transition-gap.tsx
@@ -1,5 +1,9 @@
-import { Check, Loader2, AlertTriangle, RotateCcw } from "lucide-react";
+import { Check, Loader2, AlertTriangle, RotateCcw, Layers } from "lucide-react";
 import type { FlowTransition } from "@/types/flow.types";
+import {
+  effectiveTransitionStatus,
+  aggregateVariationProgress,
+} from "../utils/variation-status";
 import {
   GapContainer,
   GapLine,
@@ -33,8 +37,19 @@ export function TransitionGapEnhanced({
   effectiveDuration,
   onClick,
 }: TransitionGapProps) {
-  const { status, progress } = transition;
   const configured = hasOverrides(transition);
+  // Derive the display status from the transition's own status OR, for a
+  // multi-variant transition that stays "idle" until one is picked, from the
+  // aggregate state of its variation candidates. Without this an idle
+  // transition with generating/ready variations would render as a blank line.
+  const status = effectiveTransitionStatus(transition);
+  const progress =
+    transition.variations && transition.variations.length > 0
+      ? aggregateVariationProgress(transition.variations)
+      : transition.progress;
+  const variationCount = transition.variations?.length ?? 0;
+  const readyCount =
+    transition.variations?.filter((v) => v.status === "processed").length ?? 0;
 
   // Idle, no config — just the connecting line.
   if (status === "idle" && !configured) {
@@ -51,6 +66,20 @@ export function TransitionGapEnhanced({
       <GapContainer $expanded={false} onClick={onClick}>
         <GapLine $configured $failed={false} />
         <DurationLabel>{effectiveDuration}s</DurationLabel>
+      </GapContainer>
+    );
+  }
+
+  // Variations finished, none selected yet — invite the user to review & pick.
+  if (status === "review") {
+    return (
+      <GapContainer $expanded onClick={onClick} title="Review variations">
+        <StatusNode $variant="processed">
+          <Layers size={13} strokeWidth={2.6} />
+        </StatusNode>
+        <GapStatusLabel $status="processed">
+          {readyCount}/{variationCount} pick
+        </GapStatusLabel>
       </GapContainer>
     );
   }

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -8,6 +8,7 @@ import {
   clampDurationToAllowed,
 } from "@/components/pages/studio/constants/duration-options";
 import { resolvePresetAction } from "@/components/pages/studio/utils/resolve-flow-settings";
+import { PromptExpansionBadge } from "./prompt-expansion-badge";
 import {
   PanelContainer,
   PanelHeader,
@@ -412,7 +413,8 @@ export function TransitionSettingsPanel({
             <FieldGroup>
               <FieldLabel>
                 Prompt
-                {needsPrompt && <RequiredMark>*</RequiredMark>}
+                {needsPrompt && <RequiredMark>*</RequiredMark>}{" "}
+                <PromptExpansionBadge prompt={currentPrompt} />
               </FieldLabel>
               <PromptTextarea
                 value={currentPrompt}

--- a/src/components/pages/studio/components/variation-grid.styled.tsx
+++ b/src/components/pages/studio/components/variation-grid.styled.tsx
@@ -1,0 +1,112 @@
+import styled from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+export const GridContainer = styled.div`
+  padding: 12px 0;
+  animation: fadeSlideUp 0.3s ease;
+
+  @keyframes fadeSlideUp {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+export const Grid = styled.div<{ $columns: number }>`
+  display: grid;
+  grid-template-columns: repeat(${(p) => p.$columns}, 1fr);
+  gap: 8px;
+  max-width: 480px;
+`;
+
+export const GridCell = styled.div<{ $active?: boolean; $status?: string }>`
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 2px solid ${(p) => (p.$active ? FLOW.accent : FLOW.border)};
+  cursor: ${(p) => (p.$status === "processed" ? "pointer" : "default")};
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+  aspect-ratio: 16 / 9;
+
+  &:hover {
+    border-color: ${(p) =>
+      p.$status === "processed" ? FLOW.accent : FLOW.borderHover};
+    ${(p) => p.$status === "processed" && "transform: translateY(-1px);"}
+  }
+`;
+
+export const GridCellImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+export const GridCellOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 500;
+`;
+
+export const QueuedOverlay = styled(GridCellOverlay)`
+  background: ${FLOW.bgElevated};
+  color: ${FLOW.textMuted};
+`;
+
+export const ProcessingOverlay = styled(GridCellOverlay)`
+  background: rgba(0, 0, 0, 0.5);
+  color: ${FLOW.processing};
+`;
+
+export const FailedOverlay = styled(GridCellOverlay)`
+  background: rgba(0, 0, 0, 0.5);
+  color: ${FLOW.error};
+`;
+
+export const ActiveBadge = styled.div`
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: ${FLOW.accent};
+  color: ${FLOW.bg};
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const GridActions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+export const GridActionButton = styled.button`
+  padding: 6px 12px;
+  background: ${FLOW.bgElevated};
+  border: 1px solid ${FLOW.border};
+  border-radius: 6px;
+  color: ${FLOW.textDim};
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
+`;

--- a/src/components/pages/studio/components/variation-grid.styled.tsx
+++ b/src/components/pages/studio/components/variation-grid.styled.tsx
@@ -48,6 +48,12 @@ export const GridCellImg = styled.img`
   object-fit: cover;
 `;
 
+export const GridCellVideo = styled.video`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
 export const GridCellOverlay = styled.div`
   position: absolute;
   inset: 0;

--- a/src/components/pages/studio/components/variation-grid.styled.tsx
+++ b/src/components/pages/studio/components/variation-grid.styled.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { FLOW } from "@/constants/flow-theme.constants";
 
 export const GridContainer = styled.div`
-  padding: 12px 0;
+  padding: 16px;
   animation: fadeSlideUp 0.3s ease;
 
   @keyframes fadeSlideUp {
@@ -20,7 +20,7 @@ export const GridContainer = styled.div`
 export const Grid = styled.div<{ $columns: number }>`
   display: grid;
   grid-template-columns: repeat(${(p) => p.$columns}, 1fr);
-  gap: 8px;
+  gap: 12px;
   max-width: 480px;
 `;
 

--- a/src/components/pages/studio/components/variation-grid.tsx
+++ b/src/components/pages/studio/components/variation-grid.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Check } from "lucide-react";
 import type { VariationCandidate } from "@/types/flow.types";
+import { isVideoUrl } from "../utils/variation-status";
 import {
   GridContainer,
   Grid,
   GridCell,
   GridCellImg,
+  GridCellVideo,
   QueuedOverlay,
   ProcessingOverlay,
   FailedOverlay,
@@ -49,9 +51,19 @@ export const VariationGrid: React.FC<VariationGridProps> = ({
               if (v.status === "processed") onSelect(v.id);
             }}
           >
-            {v.status === "processed" && v.imageUrl && (
-              <GridCellImg src={v.imageUrl} alt={v.prompt || "variation"} />
-            )}
+            {v.status === "processed" &&
+              v.imageUrl &&
+              (isVideoUrl(v.imageUrl) ? (
+                <GridCellVideo
+                  src={v.imageUrl}
+                  muted
+                  loop
+                  playsInline
+                  autoPlay
+                />
+              ) : (
+                <GridCellImg src={v.imageUrl} alt={v.prompt || "variation"} />
+              ))}
             {v.status === "queue" && <QueuedOverlay>Queued</QueuedOverlay>}
             {v.status === "processing" && (
               <ProcessingOverlay>

--- a/src/components/pages/studio/components/variation-grid.tsx
+++ b/src/components/pages/studio/components/variation-grid.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Check } from "lucide-react";
+import type { VariationCandidate } from "@/types/flow.types";
+import {
+  GridContainer,
+  Grid,
+  GridCell,
+  GridCellImg,
+  QueuedOverlay,
+  ProcessingOverlay,
+  FailedOverlay,
+  ActiveBadge,
+  GridActions,
+  GridActionButton,
+} from "./variation-grid.styled";
+
+interface VariationGridProps {
+  variations: VariationCandidate[];
+  activeVariationId?: string;
+  onSelect: (variationId: string) => void;
+  onGenerateMore?: () => void;
+  onClose: () => void;
+}
+
+function gridColumns(count: number): number {
+  if (count <= 4) return 2;
+  if (count <= 9) return 3;
+  return 4;
+}
+
+export const VariationGrid: React.FC<VariationGridProps> = ({
+  variations,
+  activeVariationId,
+  onSelect,
+  onGenerateMore,
+  onClose,
+}) => {
+  if (variations.length === 0) return null;
+
+  return (
+    <GridContainer>
+      <Grid $columns={gridColumns(variations.length)}>
+        {variations.map((v) => (
+          <GridCell
+            key={v.id}
+            $active={v.id === activeVariationId}
+            $status={v.status}
+            onClick={() => {
+              if (v.status === "processed") onSelect(v.id);
+            }}
+          >
+            {v.status === "processed" && v.imageUrl && (
+              <GridCellImg src={v.imageUrl} alt={v.prompt || "variation"} />
+            )}
+            {v.status === "queue" && <QueuedOverlay>Queued</QueuedOverlay>}
+            {v.status === "processing" && (
+              <ProcessingOverlay>
+                {v.progress != null ? `${v.progress}%` : "..."}
+              </ProcessingOverlay>
+            )}
+            {v.status === "failed" && <FailedOverlay>Failed</FailedOverlay>}
+            {v.id === activeVariationId && v.status === "processed" && (
+              <ActiveBadge>
+                <Check size={10} />
+              </ActiveBadge>
+            )}
+          </GridCell>
+        ))}
+      </Grid>
+      <GridActions>
+        {onGenerateMore && (
+          <GridActionButton onClick={onGenerateMore}>+ More</GridActionButton>
+        )}
+        <GridActionButton onClick={onClose}>Close</GridActionButton>
+      </GridActions>
+    </GridContainer>
+  );
+};

--- a/src/components/pages/studio/components/variation-lightbox.styled.tsx
+++ b/src/components/pages/studio/components/variation-lightbox.styled.tsx
@@ -1,0 +1,109 @@
+import styled from "styled-components";
+import { FLOW, flowFadeIn } from "@/constants/flow-theme.constants";
+
+export const LightboxOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: ${flowFadeIn} 0.3s ease;
+`;
+
+export const LightboxContent = styled.div`
+  width: 90vw;
+  max-width: 720px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: ${FLOW.bgCard};
+  border: 1px solid ${FLOW.border};
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+`;
+
+export const LightboxHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+`;
+
+export const LightboxTitle = styled.h3`
+  font-family: ${FLOW.fontFamily};
+  font-size: 16px;
+  font-weight: 500;
+  color: ${FLOW.text};
+  margin: 0;
+`;
+
+export const CloseButton = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: ${FLOW.bgElevated};
+  color: ${FLOW.textMuted};
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${FLOW.bgInput};
+    color: ${FLOW.text};
+  }
+`;
+
+export const CurrentResult = styled.div`
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: ${FLOW.radiusSm};
+  overflow: hidden;
+  background: ${FLOW.bg};
+  margin-bottom: 16px;
+
+  video,
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+`;
+
+export const SectionLabel = styled.div`
+  font-family: ${FLOW.fontFamily};
+  font-size: 11px;
+  font-weight: 600;
+  color: ${FLOW.textMuted};
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+`;
+
+export const LightboxActions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+`;
+
+export const LightboxButton = styled.button<{ $primary?: boolean }>`
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ${FLOW.fontFamily};
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 1px solid ${(p) => (p.$primary ? FLOW.accent : FLOW.border)};
+  background: ${(p) => (p.$primary ? FLOW.accentDim : FLOW.bgElevated)};
+  color: ${(p) => (p.$primary ? FLOW.accent : FLOW.textDim)};
+
+  &:hover {
+    border-color: ${(p) => (p.$primary ? FLOW.accent : FLOW.borderHover)};
+    color: ${(p) => (p.$primary ? FLOW.accent : FLOW.text)};
+  }
+`;

--- a/src/components/pages/studio/components/variation-lightbox.tsx
+++ b/src/components/pages/studio/components/variation-lightbox.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import type { FlowTransition } from "@/types/flow.types";
+import { VariationGrid } from "./variation-grid";
+import { PromptExpansionBadge } from "./prompt-expansion-badge";
+import {
+  LightboxOverlay,
+  LightboxContent,
+  LightboxHeader,
+  LightboxTitle,
+  CloseButton,
+  CurrentResult,
+  SectionLabel,
+  LightboxActions,
+  LightboxButton,
+} from "./variation-lightbox.styled";
+
+interface VariationLightboxProps {
+  transition: FlowTransition;
+  transitionIndex: number;
+  effectivePrompt: string;
+  /** URL of the current transition's video (if completed) */
+  videoUrl?: string;
+  onSelectVariation: (transitionIndex: number, variationId: string) => void;
+  onRegenerate?: (transitionIndex: number) => void;
+  onGenerateMore?: (transitionIndex: number) => void;
+  onClose: () => void;
+}
+
+export const VariationLightbox: React.FC<VariationLightboxProps> = ({
+  transition,
+  transitionIndex,
+  effectivePrompt,
+  videoUrl,
+  onSelectVariation,
+  onRegenerate,
+  onGenerateMore,
+  onClose,
+}) => {
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  const hasVariations =
+    transition.variations && transition.variations.length > 0;
+
+  return createPortal(
+    <LightboxOverlay onClick={handleOverlayClick}>
+      <LightboxContent onClick={(e) => e.stopPropagation()}>
+        <LightboxHeader>
+          <LightboxTitle>
+            Transition {transitionIndex + 1}{" "}
+            <PromptExpansionBadge prompt={effectivePrompt} />
+          </LightboxTitle>
+          <CloseButton onClick={onClose}>
+            <X size={14} />
+          </CloseButton>
+        </LightboxHeader>
+
+        {videoUrl && transition.status === "processed" && (
+          <>
+            <SectionLabel>Current Result</SectionLabel>
+            <CurrentResult>
+              <video src={videoUrl} autoPlay loop muted playsInline />
+            </CurrentResult>
+          </>
+        )}
+
+        {hasVariations && (
+          <>
+            <SectionLabel>Variations</SectionLabel>
+            <VariationGrid
+              variations={transition.variations!}
+              activeVariationId={transition.activeVariationId}
+              onSelect={(variationId) =>
+                onSelectVariation(transitionIndex, variationId)
+              }
+              onGenerateMore={
+                onGenerateMore
+                  ? () => onGenerateMore(transitionIndex)
+                  : undefined
+              }
+              onClose={() => {
+                /* grid close is a no-op inside lightbox — use the X button */
+              }}
+            />
+          </>
+        )}
+
+        <LightboxActions>
+          {onRegenerate && transition.status === "processed" && (
+            <LightboxButton
+              $primary
+              onClick={() => onRegenerate(transitionIndex)}
+            >
+              Regenerate (new seed)
+            </LightboxButton>
+          )}
+          {onGenerateMore && (
+            <LightboxButton onClick={() => onGenerateMore(transitionIndex)}>
+              + Generate Variations
+            </LightboxButton>
+          )}
+        </LightboxActions>
+      </LightboxContent>
+    </LightboxOverlay>,
+    document.body,
+  );
+};

--- a/src/components/pages/studio/components/variation-lightbox.tsx
+++ b/src/components/pages/studio/components/variation-lightbox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 import { X } from "lucide-react";
@@ -64,6 +64,15 @@ export const VariationLightbox: React.FC<VariationLightboxProps> = ({
     },
     [onClose],
   );
+
+  // Close on Escape — expected dismissal affordance for a modal.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
 
   const hasVariations =
     transition.variations && transition.variations.length > 0;

--- a/src/components/pages/studio/components/variation-lightbox.tsx
+++ b/src/components/pages/studio/components/variation-lightbox.tsx
@@ -1,7 +1,13 @@
 import React, { useCallback } from "react";
 import { createPortal } from "react-dom";
+import { useQuery } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import type { FlowTransition } from "@/types/flow.types";
+import type { Dream } from "@/types/dream.types";
+import type { ApiResponse } from "@/types/api.types";
+import { axiosClient } from "@/client/axios.client";
+import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
+import { DREAM_QUERY_KEY } from "@/api/dream/query/useDream";
 import { VariationGrid } from "./variation-grid";
 import { PromptExpansionBadge } from "./prompt-expansion-badge";
 import {
@@ -16,15 +22,20 @@ import {
   LightboxButton,
 } from "./variation-lightbox.styled";
 
+async function fetchDream(uuid: string): Promise<Dream | undefined> {
+  const res = await axiosClient.get<ApiResponse<{ dream: Dream }>>(
+    `/v1/dream/${uuid}`,
+    { headers: getRequestHeaders({ contentType: ContentType.json }) },
+  );
+  return res.data?.data?.dream;
+}
+
 interface VariationLightboxProps {
   transition: FlowTransition;
   transitionIndex: number;
   effectivePrompt: string;
-  /** URL of the current transition's video (if completed) */
-  videoUrl?: string;
   onSelectVariation: (transitionIndex: number, variationId: string) => void;
   onRegenerate?: (transitionIndex: number) => void;
-  onGenerateMore?: (transitionIndex: number) => void;
   onClose: () => void;
 }
 
@@ -32,12 +43,21 @@ export const VariationLightbox: React.FC<VariationLightboxProps> = ({
   transition,
   transitionIndex,
   effectivePrompt,
-  videoUrl,
   onSelectVariation,
   onRegenerate,
-  onGenerateMore,
   onClose,
 }) => {
+  // Fetch the dream to get the video URL — same pattern as FlowPreview.
+  // This avoids constructing URLs from dreamUuid which breaks across environments.
+  const { data: dream } = useQuery({
+    queryKey: [DREAM_QUERY_KEY, transition.dreamUuid],
+    queryFn: () => fetchDream(transition.dreamUuid!),
+    enabled: !!transition.dreamUuid && transition.status === "processed",
+    staleTime: Infinity,
+  });
+
+  const videoUrl = dream?.video || dream?.original_video || dream?.thumbnail;
+
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
       if (e.target === e.currentTarget) onClose();
@@ -79,11 +99,6 @@ export const VariationLightbox: React.FC<VariationLightboxProps> = ({
               onSelect={(variationId) =>
                 onSelectVariation(transitionIndex, variationId)
               }
-              onGenerateMore={
-                onGenerateMore
-                  ? () => onGenerateMore(transitionIndex)
-                  : undefined
-              }
               onClose={() => {
                 /* grid close is a no-op inside lightbox — use the X button */
               }}
@@ -98,11 +113,6 @@ export const VariationLightbox: React.FC<VariationLightboxProps> = ({
               onClick={() => onRegenerate(transitionIndex)}
             >
               Regenerate (new seed)
-            </LightboxButton>
-          )}
-          {onGenerateMore && (
-            <LightboxButton onClick={() => onGenerateMore(transitionIndex)}>
-              + Generate Variations
             </LightboxButton>
           )}
         </LightboxActions>

--- a/src/components/pages/studio/components/variation-settings-panel.tsx
+++ b/src/components/pages/studio/components/variation-settings-panel.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import { useStudioStore, DEFAULT_VARIATION_SEED } from "@/stores/studio.store";
+import type { ImageModel } from "@/types/studio.types";
+import {
+  VARIATION_PRESETS,
+  getVariationPreset,
+} from "../constants/variation-presets";
+import { clampSizeToModel } from "../constants/size-options";
+import { expandPrompt } from "../utils/expand-prompt";
+import {
+  PanelContainer,
+  PanelHeader,
+  PanelTitle,
+  PanelSubtitle,
+  FieldRow,
+  FieldGroup,
+  FieldLabel,
+  Select,
+  PromptTextarea,
+  ToggleLink,
+  ExpandedSection,
+  NumberInput,
+} from "./transition-settings-panel.styled";
+
+const IMAGE_MODELS: ImageModel[] = ["z-image-turbo", "qwen-image"];
+const MODEL_LABELS: Record<ImageModel, string> = {
+  "z-image-turbo": "Z Image Turbo",
+  "qwen-image": "Qwen Image",
+};
+
+/**
+ * Settings for the per-keyframe "Generate variations" tool. Mirrors the
+ * Transition Settings panel: a canned preset list, plus an optional "Customize"
+ * section (collapsed by default) to edit the variation prompts / use {a|b|c}
+ * expansion. The custom prompts override the preset when set.
+ */
+export const VariationSettingsPanel: React.FC = () => {
+  const model = useStudioStore((s) => s.imageGenParams.model);
+  const size = useStudioStore((s) => s.imageGenParams.size);
+  const setImageGenParams = useStudioStore((s) => s.setImageGenParams);
+  const variationPresetId = useStudioStore((s) => s.variationPresetId);
+  const setVariationPresetId = useStudioStore((s) => s.setVariationPresetId);
+  const variationCustomPrompt = useStudioStore((s) => s.variationCustomPrompt);
+  const setVariationCustomPrompt = useStudioStore(
+    (s) => s.setVariationCustomPrompt,
+  );
+  const variationSeed = useStudioStore((s) => s.variationSeed);
+  const setVariationSeed = useStudioStore((s) => s.setVariationSeed);
+
+  // Custom variations are optional and collapsed by default.
+  const [expanded, setExpanded] = useState(false);
+
+  // Real variation count = lines × {a|b|c} expansion, capped at 8 (matches the
+  // generation handler).
+  const variationCount = Math.min(
+    variationCustomPrompt
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .flatMap((l) => expandPrompt(l)).length || 0,
+    8,
+  );
+
+  return (
+    <PanelContainer>
+      <PanelHeader>
+        <PanelTitle>Variation Settings</PanelTitle>
+      </PanelHeader>
+      <FieldRow>
+        <FieldGroup>
+          <FieldLabel>Model</FieldLabel>
+          <Select
+            value={model}
+            onChange={(e) => {
+              const newModel = e.target.value as ImageModel;
+              setImageGenParams({
+                model: newModel,
+                size: clampSizeToModel(size, newModel),
+              });
+            }}
+          >
+            {IMAGE_MODELS.map((m) => (
+              <option key={m} value={m}>
+                {MODEL_LABELS[m]}
+              </option>
+            ))}
+          </Select>
+        </FieldGroup>
+        <FieldGroup>
+          <FieldLabel>Variation style</FieldLabel>
+          <Select
+            value={variationPresetId}
+            onChange={(e) => {
+              const id = e.target.value;
+              setVariationPresetId(id);
+              // Keep the custom editor in sync with the chosen preset, so the
+              // dropdown always takes effect (custom overrides preset in the
+              // generation handler) and the editor shows the preset's lines.
+              setVariationCustomPrompt(
+                getVariationPreset(id).modifiers.join("\n"),
+              );
+            }}
+          >
+            {VARIATION_PRESETS.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+          </Select>
+        </FieldGroup>
+        <FieldGroup>
+          <FieldLabel>Seed</FieldLabel>
+          <NumberInput
+            type="number"
+            value={variationSeed}
+            onChange={(e) => {
+              const v = e.target.value.trim();
+              setVariationSeed(v === "" ? DEFAULT_VARIATION_SEED : Number(v));
+            }}
+          />
+        </FieldGroup>
+      </FieldRow>
+
+      <ToggleLink
+        type="button"
+        onClick={() =>
+          setExpanded((v) => {
+            const next = !v;
+            // Prefill from the selected preset so the editor starts from real
+            // values rather than a blank box.
+            if (next && !variationCustomPrompt.trim()) {
+              setVariationCustomPrompt(
+                getVariationPreset(variationPresetId).modifiers.join("\n"),
+              );
+            }
+            return next;
+          })
+        }
+      >
+        {expanded ? "▴" : "▾"} Customize
+      </ToggleLink>
+
+      {expanded && (
+        <ExpandedSection>
+          <FieldLabel>Custom variations (one per line)</FieldLabel>
+          <PromptTextarea
+            placeholder="One variation per line, or use {a|b|c} expansion — e.g. {glowing|frozen|burning} version. Each is layered onto the source image's prompt."
+            value={variationCustomPrompt}
+            onChange={(e) => setVariationCustomPrompt(e.target.value)}
+          />
+          <PanelSubtitle>
+            {variationCount} variation{variationCount === 1 ? "" : "s"} (max 8)
+          </PanelSubtitle>
+        </ExpandedSection>
+      )}
+    </PanelContainer>
+  );
+};

--- a/src/components/pages/studio/constants/variation-presets.ts
+++ b/src/components/pages/studio/constants/variation-presets.ts
@@ -1,0 +1,62 @@
+// Canned variation presets for the Flow inline variation tool.
+//
+// Each preset is a fixed pack of modifiers that get layered onto the SOURCE
+// image's own prompt to produce distinct-but-on-theme variations. The seed
+// stays stable across the set, so the difference comes from the prompt, not
+// seed jitter (plain seed variation produced near-identical, generic results).
+//
+// Per Spot: a CANNED list — no custom prompt editor.
+
+export interface VariationPreset {
+  id: string;
+  label: string;
+  modifiers: string[];
+}
+
+export const VARIATION_PRESETS: VariationPreset[] = [
+  {
+    id: "scene",
+    label: "Scene",
+    modifiers: [
+      "different lighting and time of day",
+      "different color palette and mood",
+      "different camera angle and composition",
+      "different weather and atmosphere",
+    ],
+  },
+  {
+    id: "style",
+    label: "Art styles",
+    modifiers: [
+      "impressionist oil painting style",
+      "vibrant watercolor illustration",
+      "cinematic film still, shallow depth of field",
+      "bold graphic poster art",
+    ],
+  },
+  {
+    id: "mood",
+    label: "Mood",
+    modifiers: [
+      "serene and peaceful",
+      "dramatic and intense",
+      "dreamy and ethereal",
+      "dark and moody, low key",
+    ],
+  },
+];
+
+export const DEFAULT_VARIATION_PRESET_ID = "scene";
+
+export function getVariationPreset(id: string | undefined): VariationPreset {
+  return (
+    VARIATION_PRESETS.find((p) => p.id === id) ??
+    VARIATION_PRESETS.find((p) => p.id === DEFAULT_VARIATION_PRESET_ID) ??
+    VARIATION_PRESETS[0]
+  );
+}
+
+// Back-compat: the default pack's modifiers.
+export const VARIATION_MODIFIERS: string[] = getVariationPreset(
+  DEFAULT_VARIATION_PRESET_ID,
+).modifiers;

--- a/src/components/pages/studio/hooks/useBatchSubmit.ts
+++ b/src/components/pages/studio/hooks/useBatchSubmit.ts
@@ -8,6 +8,7 @@ import {
   getAllowedDurationsForActions,
 } from "../constants/duration-options";
 import { buildVideoAlgoParams } from "../utils/build-video-algo-params";
+import { expandPrompt } from "../utils/expand-prompt";
 
 // Serialized to avoid concurrent auth refresh races (see fix/session-refresh-race on backend)
 const BATCH_SIZE = 1;
@@ -30,7 +31,17 @@ export const useBatchSubmit = () => {
     const selectedImages = images.filter(
       (img) => img.selected && img.status === "processed",
     );
-    const enabledActions = actions.filter((a) => a.enabled && a.prompt.trim());
+    const enabledActions = actions
+      .filter((a) => a.enabled && a.prompt.trim())
+      .flatMap((action) => {
+        const expanded = expandPrompt(action.prompt);
+        if (expanded.length <= 1) return [action];
+        return expanded.map((prompt, i) => ({
+          ...action,
+          id: `${action.id}__exp${i}`,
+          prompt,
+        }));
+      });
 
     const existingJobKeys = new Set(
       jobs

--- a/src/components/pages/studio/hooks/useBatchSubmit.ts
+++ b/src/components/pages/studio/hooks/useBatchSubmit.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import Bugsnag from "@bugsnag/js";
 import { useStudioStore } from "@/stores/studio.store";
 import { useCreateDreamFromPrompt } from "@/api/dream/mutation/useCreateDreamFromPrompt";
 import { axiosClient } from "@/client/axios.client";
@@ -155,7 +156,11 @@ export const useBatchSubmit = () => {
 
         for (const result of results) {
           if (result.status === "rejected") {
-            console.error("Failed to create dream for combo:", result.reason);
+            Bugsnag.notify(
+              result.reason instanceof Error
+                ? result.reason
+                : new Error(String(result.reason)),
+            );
           }
         }
       }

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -1,11 +1,13 @@
 import { useCallback, useRef, useState } from "react";
 import Bugsnag from "@bugsnag/js";
+import { v4 as uuidv4 } from "uuid";
 import { useFlowStore } from "@/stores/flow.store";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { buildVideoAlgoParams } from "@/components/pages/studio/utils/build-video-algo-params";
 import { resolveEffectiveSettings } from "@/components/pages/studio/utils/resolve-flow-settings";
-import type { FlowTransition } from "@/types/flow.types";
+import { expandPrompt } from "@/components/pages/studio/utils/expand-prompt";
+import type { FlowTransition, VariationCandidate } from "@/types/flow.types";
 
 // Cap concurrent dream creations so "Generate All" doesn't fan out 50+ requests at once.
 const GENERATE_CONCURRENCY = 4;
@@ -18,10 +20,64 @@ export function useFlowGeneration() {
   const setTransitionDream = useFlowStore((s) => s.setTransitionDream);
   const updateTransitionStatus = useFlowStore((s) => s.updateTransitionStatus);
 
+  /** Create a single dream for a transition with the given prompt text. */
+  const createTransitionDream = useCallback(
+    async (
+      transition: FlowTransition,
+      promptText: string,
+      settings: ReturnType<typeof resolveEffectiveSettings>,
+    ) => {
+      const store = useFlowStore.getState();
+      const fromKf = store.keyframes.find(
+        (kf) => kf.id === transition.fromKeyframeId,
+      );
+      if (!fromKf) {
+        throw new Error(`Keyframe not found: ${transition.fromKeyframeId}`);
+      }
+      const toKf = store.keyframes.find(
+        (kf) => kf.id === transition.toKeyframeId,
+      );
+      const imageRef = fromKf.dreamUuid || fromKf.imageUrl;
+      const endImageRef = toKf ? toKf.dreamUuid || toKf.imageUrl : undefined;
+
+      const algoParams = buildVideoAlgoParams({
+        model: "ltx-i2v",
+        action: { ...settings.action, prompt: promptText },
+        imageUuid: imageRef,
+        endImageUuid: endImageRef,
+        imageSize: undefined,
+        duration: settings.duration,
+        numInferenceSteps: settings.numInferenceSteps,
+        guidance: settings.guidance,
+        negativePrompt: settings.negativePrompt,
+      });
+      const name = `${fromKf.name || "frame"} → ${toKf?.name || "frame"}`;
+      const headers = getRequestHeaders({ contentType: ContentType.json });
+      const { data: createData } = await axiosClient.post(
+        "/v1/dream",
+        { name, prompt: JSON.stringify(algoParams) },
+        { headers },
+      );
+      const dreamUuid = createData?.data?.dream?.uuid;
+      if (!dreamUuid) throw new Error("No dream UUID returned from API");
+
+      if (fromKf.keyframeUuid || toKf?.keyframeUuid) {
+        await axiosClient.put(
+          `/v1/dream/${dreamUuid}`,
+          {
+            startKeyframe: fromKf.keyframeUuid,
+            endKeyframe: toKf?.keyframeUuid,
+          },
+          { headers },
+        );
+      }
+      return dreamUuid;
+    },
+    [],
+  );
+
   const generateTransition = useCallback(
     async (index: number, transition: FlowTransition) => {
-      // Read latest store state directly — keeps the callback identity stable
-      // and avoids re-creating it on every settings keystroke.
       const store = useFlowStore.getState();
       const settings = resolveEffectiveSettings(transition, {
         globalPresetId: store.globalPresetId,
@@ -34,61 +90,54 @@ export function useFlowGeneration() {
         globalLora: store.globalLora,
       });
 
-      const fromKf = store.keyframes.find(
-        (kf) => kf.id === transition.fromKeyframeId,
-      );
-      if (!fromKf) {
-        Bugsnag.notify(
-          new Error(`Keyframe not found: ${transition.fromKeyframeId}`),
+      // Check for prompt expansion — if the prompt has {A|B|C} syntax,
+      // generate multiple variations instead of a single transition.
+      const expanded = expandPrompt(settings.action.prompt);
+
+      if (expanded.length > 1) {
+        // Multi-variant: create variation candidates and generate each in parallel
+        const candidates: VariationCandidate[] = expanded.map((promptText) => ({
+          id: uuidv4(),
+          method: "expansion" as const,
+          prompt: promptText,
+          status: "queue" as const,
+        }));
+        useFlowStore.getState().addTransitionVariations(index, candidates);
+
+        await Promise.all(
+          candidates.map(async (candidate) => {
+            try {
+              const dreamUuid = await createTransitionDream(
+                transition,
+                candidate.prompt!,
+                settings,
+              );
+              useFlowStore
+                .getState()
+                .updateTransitionVariation(index, candidate.id, {
+                  dreamUuid,
+                  status: "queue",
+                });
+            } catch (err) {
+              Bugsnag.notify(err as Error);
+              useFlowStore
+                .getState()
+                .updateTransitionVariation(index, candidate.id, {
+                  status: "failed",
+                });
+            }
+          }),
         );
-        updateTransitionStatus(index, "failed");
         return;
       }
 
-      const imageRef = fromKf.dreamUuid || fromKf.imageUrl;
-
-      const toKf = store.keyframes.find(
-        (kf) => kf.id === transition.toKeyframeId,
-      );
-      // LTX is the only working model — always generate i2v with an end frame.
-      const endImageRef = toKf ? toKf.dreamUuid || toKf.imageUrl : undefined;
-
-      const algoParams = buildVideoAlgoParams({
-        model: "ltx-i2v",
-        action: settings.action,
-        imageUuid: imageRef,
-        endImageUuid: endImageRef,
-        imageSize: undefined,
-        duration: settings.duration,
-        numInferenceSteps: settings.numInferenceSteps,
-        guidance: settings.guidance,
-        negativePrompt: settings.negativePrompt,
-      });
-      const name = `${fromKf.name || "frame"} → ${toKf?.name || "frame"}`;
-
+      // Single prompt — standard generation (existing behavior)
       try {
-        const headers = getRequestHeaders({ contentType: ContentType.json });
-        const { data: createData } = await axiosClient.post(
-          "/v1/dream",
-          { name, prompt: JSON.stringify(algoParams) },
-          { headers },
+        const dreamUuid = await createTransitionDream(
+          transition,
+          settings.action.prompt,
+          settings,
         );
-        const dreamUuid = createData?.data?.dream?.uuid;
-        if (!dreamUuid) {
-          throw new Error("No dream UUID returned from API");
-        }
-
-        if (fromKf.keyframeUuid || toKf?.keyframeUuid) {
-          await axiosClient.put(
-            `/v1/dream/${dreamUuid}`,
-            {
-              startKeyframe: fromKf.keyframeUuid,
-              endKeyframe: toKf?.keyframeUuid,
-            },
-            { headers },
-          );
-        }
-
         setTransitionDream(index, dreamUuid);
         updateTransitionStatus(index, "queue");
       } catch (error) {
@@ -96,7 +145,7 @@ export function useFlowGeneration() {
         updateTransitionStatus(index, "failed");
       }
     },
-    [setTransitionDream, updateTransitionStatus],
+    [createTransitionDream, setTransitionDream, updateTransitionStatus],
   );
 
   const startGenerating = useCallback(() => {

--- a/src/components/pages/studio/hooks/useFlowJobProgress.ts
+++ b/src/components/pages/studio/hooks/useFlowJobProgress.ts
@@ -110,7 +110,7 @@ export function useFlowJobProgress() {
 
   // Handle job:progress events
   const handleProgress = useCallback(
-    (data: {
+    async (data: {
       dreamUuid?: string;
       dream_uuid?: string;
       status?: string;
@@ -127,21 +127,48 @@ export function useFlowJobProgress() {
 
       // Variation candidate progress
       if (entry.variationType && entry.variationId) {
+        const patch: {
+          status: typeof mappedStatus;
+          progress?: number;
+          imageUrl?: string;
+        } = {
+          status: mappedStatus,
+          progress: data.progress,
+        };
+
+        // When a variation dream completes via Socket.IO, fetch the dream to
+        // resolve imageUrl (Socket.IO events don't carry the URL).
+        if (mappedStatus === "processed") {
+          try {
+            const headers = getRequestHeaders({
+              contentType: ContentType.json,
+            });
+            const { data: dreamData } = await axiosClient.get(
+              `/v1/dream/${uuid}`,
+              { headers },
+            );
+            const dream = dreamData?.data?.dream;
+            if (dream) {
+              patch.imageUrl =
+                dream.video || dream.original_video || dream.thumbnail || "";
+            }
+          } catch {
+            // Non-fatal — imageUrl will be resolved by the next poll cycle.
+          }
+        }
+
         if (entry.variationType === "keyframe" && entry.variationKeyframeId) {
           useFlowStore
             .getState()
             .updateKeyframeVariation(
               entry.variationKeyframeId,
               entry.variationId,
-              { status: mappedStatus, progress: data.progress },
+              patch,
             );
         } else if (entry.variationType === "transition") {
           useFlowStore
             .getState()
-            .updateTransitionVariation(entry.index, entry.variationId, {
-              status: mappedStatus,
-              progress: data.progress,
-            });
+            .updateTransitionVariation(entry.index, entry.variationId, patch);
         }
         return;
       }
@@ -242,8 +269,10 @@ export function useFlowJobProgress() {
               status: mappedStatus,
             };
             if (mappedStatus === "processed") {
-              // Extract image URL from the dream's thumbnail or video field
-              patch.imageUrl = dream.thumbnail || dream.video || dream.image;
+              // Match the field priority from useUploadImageDream:
+              // video (R2 URL) > original_video > thumbnail
+              patch.imageUrl =
+                dream.video || dream.original_video || dream.thumbnail || "";
             }
             if (
               entry.variationType === "keyframe" &&

--- a/src/components/pages/studio/hooks/useFlowJobProgress.ts
+++ b/src/components/pages/studio/hooks/useFlowJobProgress.ts
@@ -35,16 +35,28 @@ function mapStatus(
   }
 }
 
+type PendingEntry = {
+  uuid: string;
+  index: number;
+  isUprez: boolean;
+  // Variation tracking — when set, the entry is a variation candidate
+  variationType?: "keyframe" | "transition";
+  variationKeyframeId?: string;
+  variationId?: string;
+};
+
 export function useFlowJobProgress() {
   const { socket } = useSocket();
 
   const transitions = useFlowStore((s) => s.transitions);
+  const keyframes = useFlowStore((s) => s.keyframes);
   const updateTransitionStatus = useFlowStore((s) => s.updateTransitionStatus);
 
-  // Collect pending entries, UUIDs, and lookup map in one pass
+  // Collect pending entries from transitions AND variation candidates
   const { pendingEntries, pendingUuids, uuidMap } = useMemo(() => {
-    const entries: Array<{ uuid: string; index: number; isUprez: boolean }> =
-      [];
+    const entries: PendingEntry[] = [];
+
+    // Transition dreams (existing)
     transitions.forEach((t, i) => {
       if (t.dreamUuid && (t.status === "queue" || t.status === "processing")) {
         entries.push({ uuid: t.dreamUuid, index: i, isUprez: false });
@@ -55,13 +67,46 @@ export function useFlowJobProgress() {
       ) {
         entries.push({ uuid: t.uprezDreamUuid, index: i, isUprez: true });
       }
+      // Transition variation candidates
+      t.variations?.forEach((v) => {
+        if (
+          v.dreamUuid &&
+          (v.status === "queue" || v.status === "processing")
+        ) {
+          entries.push({
+            uuid: v.dreamUuid,
+            index: i,
+            isUprez: false,
+            variationType: "transition",
+            variationId: v.id,
+          });
+        }
+      });
     });
+
+    // Keyframe variation candidates
+    keyframes.forEach((kf) => {
+      kf.variations?.forEach((v) => {
+        if (
+          v.dreamUuid &&
+          (v.status === "queue" || v.status === "processing")
+        ) {
+          entries.push({
+            uuid: v.dreamUuid,
+            index: -1,
+            isUprez: false,
+            variationType: "keyframe",
+            variationKeyframeId: kf.id,
+            variationId: v.id,
+          });
+        }
+      });
+    });
+
     const uuids = entries.map((e) => e.uuid);
-    const map = new Map(
-      entries.map((e) => [e.uuid, { index: e.index, isUprez: e.isUprez }]),
-    );
+    const map = new Map(entries.map((e) => [e.uuid, e]));
     return { pendingEntries: entries, pendingUuids: uuids, uuidMap: map };
-  }, [transitions]);
+  }, [transitions, keyframes]);
 
   // Handle job:progress events
   const handleProgress = useCallback(
@@ -80,6 +125,28 @@ export function useFlowJobProgress() {
       const mappedStatus = mapStatus(data.status ?? "");
       if (!mappedStatus) return;
 
+      // Variation candidate progress
+      if (entry.variationType && entry.variationId) {
+        if (entry.variationType === "keyframe" && entry.variationKeyframeId) {
+          useFlowStore
+            .getState()
+            .updateKeyframeVariation(
+              entry.variationKeyframeId,
+              entry.variationId,
+              { status: mappedStatus, progress: data.progress },
+            );
+        } else if (entry.variationType === "transition") {
+          useFlowStore
+            .getState()
+            .updateTransitionVariation(entry.index, entry.variationId, {
+              status: mappedStatus,
+              progress: data.progress,
+            });
+        }
+        return;
+      }
+
+      // Standard transition progress (existing)
       if (entry.isUprez) {
         useFlowStore
           .getState()
@@ -165,6 +232,43 @@ export function useFlowJobProgress() {
           const mappedStatus = mapStatus(dream.status);
           if (!mappedStatus) continue;
 
+          // Variation candidate — update with status + imageUrl when processed
+          if (entry.variationType && entry.variationId) {
+            const patch: {
+              status: typeof mappedStatus;
+              progress?: number;
+              imageUrl?: string;
+            } = {
+              status: mappedStatus,
+            };
+            if (mappedStatus === "processed") {
+              // Extract image URL from the dream's thumbnail or video field
+              patch.imageUrl = dream.thumbnail || dream.video || dream.image;
+            }
+            if (
+              entry.variationType === "keyframe" &&
+              entry.variationKeyframeId
+            ) {
+              useFlowStore
+                .getState()
+                .updateKeyframeVariation(
+                  entry.variationKeyframeId,
+                  entry.variationId,
+                  patch,
+                );
+            } else if (entry.variationType === "transition") {
+              useFlowStore
+                .getState()
+                .updateTransitionVariation(
+                  entry.index,
+                  entry.variationId,
+                  patch,
+                );
+            }
+            continue;
+          }
+
+          // Standard transition progress (existing)
           if (entry.isUprez) {
             useFlowStore
               .getState()

--- a/src/components/pages/studio/hooks/useFlowJobProgress.ts
+++ b/src/components/pages/studio/hooks/useFlowJobProgress.ts
@@ -116,74 +116,78 @@ export function useFlowJobProgress() {
       status?: string;
       progress?: number;
     }) => {
-      const uuid = data.dreamUuid || data.dream_uuid;
-      if (!uuid) return;
+      try {
+        const uuid = data.dreamUuid || data.dream_uuid;
+        if (!uuid) return;
 
-      const entry = uuidMap.get(uuid);
-      if (!entry) return;
+        const entry = uuidMap.get(uuid);
+        if (!entry) return;
 
-      const mappedStatus = mapStatus(data.status ?? "");
-      if (!mappedStatus) return;
+        const mappedStatus = mapStatus(data.status ?? "");
+        if (!mappedStatus) return;
 
-      // Variation candidate progress
-      if (entry.variationType && entry.variationId) {
-        const patch: {
-          status: typeof mappedStatus;
-          progress?: number;
-          imageUrl?: string;
-        } = {
-          status: mappedStatus,
-          progress: data.progress,
-        };
+        // Variation candidate progress
+        if (entry.variationType && entry.variationId) {
+          const patch: {
+            status: typeof mappedStatus;
+            progress?: number;
+            imageUrl?: string;
+          } = {
+            status: mappedStatus,
+            progress: data.progress,
+          };
 
-        // When a variation dream completes via Socket.IO, fetch the dream to
-        // resolve imageUrl (Socket.IO events don't carry the URL).
-        if (mappedStatus === "processed") {
-          try {
-            const headers = getRequestHeaders({
-              contentType: ContentType.json,
-            });
-            const { data: dreamData } = await axiosClient.get(
-              `/v1/dream/${uuid}`,
-              { headers },
-            );
-            const dream = dreamData?.data?.dream;
-            if (dream) {
-              patch.imageUrl =
-                dream.video || dream.original_video || dream.thumbnail || "";
+          // When a variation dream completes via Socket.IO, fetch the dream to
+          // resolve imageUrl (Socket.IO events don't carry the URL).
+          if (mappedStatus === "processed") {
+            try {
+              const headers = getRequestHeaders({
+                contentType: ContentType.json,
+              });
+              const { data: dreamData } = await axiosClient.get(
+                `/v1/dream/${uuid}`,
+                { headers },
+              );
+              const dream = dreamData?.data?.dream;
+              if (dream) {
+                patch.imageUrl =
+                  dream.video || dream.original_video || dream.thumbnail || "";
+              }
+            } catch {
+              // Non-fatal — imageUrl will be resolved by the next poll cycle.
             }
-          } catch {
-            // Non-fatal — imageUrl will be resolved by the next poll cycle.
           }
+
+          if (entry.variationType === "keyframe" && entry.variationKeyframeId) {
+            useFlowStore
+              .getState()
+              .updateKeyframeVariation(
+                entry.variationKeyframeId,
+                entry.variationId,
+                patch,
+              );
+          } else if (entry.variationType === "transition") {
+            useFlowStore
+              .getState()
+              .updateTransitionVariation(entry.index, entry.variationId, patch);
+          }
+          return;
         }
 
-        if (entry.variationType === "keyframe" && entry.variationKeyframeId) {
+        // Standard transition progress (existing)
+        if (entry.isUprez) {
           useFlowStore
             .getState()
-            .updateKeyframeVariation(
-              entry.variationKeyframeId,
-              entry.variationId,
-              patch,
+            .updateTransitionUprezStatus(
+              entry.index,
+              mappedStatus,
+              data.progress,
             );
-        } else if (entry.variationType === "transition") {
-          useFlowStore
-            .getState()
-            .updateTransitionVariation(entry.index, entry.variationId, patch);
+        } else {
+          updateTransitionStatus(entry.index, mappedStatus, data.progress);
         }
-        return;
-      }
-
-      // Standard transition progress (existing)
-      if (entry.isUprez) {
-        useFlowStore
-          .getState()
-          .updateTransitionUprezStatus(
-            entry.index,
-            mappedStatus,
-            data.progress,
-          );
-      } else {
-        updateTransitionStatus(entry.index, mappedStatus, data.progress);
+      } catch (err) {
+        Bugsnag.notify(err as Error);
       }
     },
     [uuidMap, updateTransitionStatus],

--- a/src/components/pages/studio/hooks/useSessionAutoSave.ts
+++ b/src/components/pages/studio/hooks/useSessionAutoSave.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useFlowStore } from "@/stores/flow.store";
+import { useStudioStore } from "@/stores/studio.store";
+import { useSessionStore } from "@/stores/session.store";
+
+export function useSessionAutoSave() {
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const debouncedSave = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        useSessionStore.getState().saveCurrentSession();
+      }, 2000);
+    };
+
+    const unsubFlow = useFlowStore.subscribe(debouncedSave);
+    const unsubStudio = useStudioStore.subscribe(debouncedSave);
+
+    return () => {
+      unsubFlow();
+      unsubStudio();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+}

--- a/src/components/pages/studio/studio.page.styled.tsx
+++ b/src/components/pages/studio/studio.page.styled.tsx
@@ -54,8 +54,14 @@ export const StudioTitle = styled.h1`
   font-family: ${FLOW.fontFamily};
 `;
 
-export const HeaderSpacer = styled.div`
+export const HeaderSide = styled.div<{ $align: "left" | "right" }>`
   flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+  justify-content: ${(props) =>
+    props.$align === "right" ? "flex-end" : "flex-start"};
 `;
 
 export const NewSessionButton = styled.button`

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -18,7 +18,7 @@ import {
   StudioHeader,
   StudioTitle,
   BackButton,
-  HeaderSpacer,
+  HeaderSide,
   NewSessionButton,
   StudioBody,
   ModeToggle,
@@ -135,28 +135,34 @@ export const StudioPage: React.FC = () => {
   return (
     <StudioContainer $dragOver={isDragOver} {...dropHandlers}>
       <StudioHeader>
-        <BackButton onClick={handleBack} aria-label="Go back">
-          <ArrowLeft size={18} />
-        </BackButton>
+        <HeaderSide $align="left">
+          <BackButton onClick={handleBack} aria-label="Go back">
+            <ArrowLeft size={18} />
+          </BackButton>
+          <StudioTitle>Studio</StudioTitle>
+        </HeaderSide>
         <SessionSwitcher />
-        <StudioTitle>Studio</StudioTitle>
-        <ModeToggle>
-          <ModeButton $active={mode === "flow"} onClick={() => setMode("flow")}>
-            Flow
-          </ModeButton>
-          <ModeButton
-            $active={mode === "batch"}
-            onClick={() => setMode("batch")}
-          >
-            Batch (Advanced)
-          </ModeButton>
-        </ModeToggle>
-        <HeaderSpacer />
-        {mode === "batch" && hasContent && (
-          <NewSessionButton onClick={handleNewSession}>
-            New Session
-          </NewSessionButton>
-        )}
+        <HeaderSide $align="right">
+          <ModeToggle>
+            <ModeButton
+              $active={mode === "flow"}
+              onClick={() => setMode("flow")}
+            >
+              Flow
+            </ModeButton>
+            <ModeButton
+              $active={mode === "batch"}
+              onClick={() => setMode("batch")}
+            >
+              Batch
+            </ModeButton>
+          </ModeToggle>
+          {mode === "batch" && hasContent && (
+            <NewSessionButton onClick={handleNewSession}>
+              New Session
+            </NewSessionButton>
+          )}
+        </HeaderSide>
       </StudioHeader>
 
       <StudioBody $constrain={mode === "batch"}>

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -10,6 +10,8 @@ import { ROUTES } from "@/constants/routes.constants";
 import { StudioTabs } from "./components/studio-tabs";
 import { useStudioJobProgress } from "./hooks/useStudioJobProgress";
 import { useFileDropUpload } from "./hooks/useFileDropUpload";
+import { SessionSwitcher } from "./components/session-switcher";
+import { useSessionAutoSave } from "./hooks/useSessionAutoSave";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import {
   StudioContainer,
@@ -52,6 +54,7 @@ export const StudioPage: React.FC = () => {
     (s) => s.images.length > 0 || s.actions.length > 0 || s.jobs.length > 0,
   );
   useStudioJobProgress();
+  useSessionAutoSave();
 
   const addImage = useStudioStore((s) => s.addImage);
   const updateImage = useStudioStore((s) => s.updateImage);
@@ -133,8 +136,9 @@ export const StudioPage: React.FC = () => {
     <StudioContainer $dragOver={isDragOver} {...dropHandlers}>
       <StudioHeader>
         <BackButton onClick={handleBack} aria-label="Go back">
-          <ArrowLeft size={16} />
+          <ArrowLeft size={18} />
         </BackButton>
+        <SessionSwitcher />
         <StudioTitle>Studio</StudioTitle>
         <ModeToggle>
           <ModeButton $active={mode === "flow"} onClick={() => setMode("flow")}>

--- a/src/components/pages/studio/studio.page.tsx
+++ b/src/components/pages/studio/studio.page.tsx
@@ -19,7 +19,6 @@ import {
   StudioTitle,
   BackButton,
   HeaderSide,
-  NewSessionButton,
   StudioBody,
   ModeToggle,
   ModeButton,
@@ -49,10 +48,6 @@ export const StudioPage: React.FC = () => {
   const setMode = useStudioModeStore((s) => s.setMode);
 
   const activeTab = useStudioStore((s) => s.activeTab);
-  const resetSession = useStudioStore((s) => s.resetSession);
-  const hasContent = useStudioStore(
-    (s) => s.images.length > 0 || s.actions.length > 0 || s.jobs.length > 0,
-  );
   useStudioJobProgress();
   useSessionAutoSave();
 
@@ -122,16 +117,6 @@ export const StudioPage: React.FC = () => {
     onFiles: handleStudioDrop,
   });
 
-  const handleNewSession = () => {
-    if (
-      !window.confirm(
-        "Start a new session? This will clear all current images, actions, and results.",
-      )
-    )
-      return;
-    resetSession();
-  };
-
   return (
     <StudioContainer $dragOver={isDragOver} {...dropHandlers}>
       <StudioHeader>
@@ -157,11 +142,6 @@ export const StudioPage: React.FC = () => {
               Batch
             </ModeButton>
           </ModeToggle>
-          {mode === "batch" && hasContent && (
-            <NewSessionButton onClick={handleNewSession}>
-              New Session
-            </NewSessionButton>
-          )}
         </HeaderSide>
       </StudioHeader>
 

--- a/src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
+++ b/src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
@@ -1,6 +1,11 @@
 // src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
 import { describe, it, expect } from "vitest";
-import { expandPrompt, countExpansions } from "../expand-prompt";
+import {
+  expandPrompt,
+  countExpansions,
+  countRawExpansions,
+  MAX_EXPANSIONS,
+} from "../expand-prompt";
 
 describe("expandPrompt", () => {
   it("returns single-element array for plain text", () => {
@@ -55,6 +60,32 @@ describe("expandPrompt", () => {
   it("caps at 16 expansions", () => {
     const result = expandPrompt("{a|b|c} {x|y|z} {1|2|3}");
     expect(result).toHaveLength(16);
+  });
+
+  it("caps DURING expansion without building the full cross-product", () => {
+    // 30 binary groups = 2^30 combinations. The old implementation built the
+    // entire array before slicing, which froze/OOM'd the tab. If the cap is
+    // applied during expansion this returns instantly; otherwise this test
+    // hangs or runs out of memory.
+    const huge = "{a|b} ".repeat(30).trim();
+    const result = expandPrompt(huge);
+    expect(result).toHaveLength(MAX_EXPANSIONS);
+  });
+});
+
+describe("countRawExpansions", () => {
+  it("returns 1 for plain text", () => {
+    expect(countRawExpansions("no expansions here")).toBe(1);
+  });
+
+  it("returns the UNcapped cross-product count", () => {
+    expect(countRawExpansions("{a|b|c} {x|y|z} {1|2|3}")).toBe(27);
+  });
+
+  it("returns large counts without building the product", () => {
+    // 2^30 — a multiply, never an array.
+    const huge = "{a|b} ".repeat(30).trim();
+    expect(countRawExpansions(huge)).toBe(2 ** 30);
   });
 });
 

--- a/src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
+++ b/src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
@@ -1,0 +1,77 @@
+// src/components/pages/studio/utils/__tests__/expand-prompt.test.ts
+import { describe, it, expect } from "vitest";
+import { expandPrompt, countExpansions } from "../expand-prompt";
+
+describe("expandPrompt", () => {
+  it("returns single-element array for plain text", () => {
+    expect(expandPrompt("hello world")).toEqual(["hello world"]);
+  });
+
+  it("expands a single {A|B|C} group", () => {
+    expect(expandPrompt("{fire|water|earth} elemental")).toEqual([
+      "fire elemental",
+      "water elemental",
+      "earth elemental",
+    ]);
+  });
+
+  it("computes cross-product of two groups", () => {
+    const result = expandPrompt("{fire|water} {dragon|phoenix}");
+    expect(result).toEqual([
+      "fire dragon",
+      "fire phoenix",
+      "water dragon",
+      "water phoenix",
+    ]);
+  });
+
+  it("handles mixed static and dynamic parts", () => {
+    expect(expandPrompt("a {B|C} d")).toEqual(["a B d", "a C d"]);
+  });
+
+  it("handles escaped braces", () => {
+    expect(expandPrompt("\\{not expanded\\}")).toEqual(["{not expanded}"]);
+  });
+
+  it("handles single option in braces (no pipe)", () => {
+    expect(expandPrompt("{solo}")).toEqual(["solo"]);
+  });
+
+  it("handles empty string", () => {
+    expect(expandPrompt("")).toEqual([""]);
+  });
+
+  it("trims whitespace in options", () => {
+    expect(expandPrompt("{ fire | water }")).toEqual(["fire", "water"]);
+  });
+
+  it("handles three groups cross-product", () => {
+    const result = expandPrompt("{a|b} {x|y} {1|2}");
+    expect(result).toHaveLength(8);
+    expect(result).toContain("a x 1");
+    expect(result).toContain("b y 2");
+  });
+
+  it("caps at 16 expansions", () => {
+    const result = expandPrompt("{a|b|c} {x|y|z} {1|2|3}");
+    expect(result).toHaveLength(16);
+  });
+});
+
+describe("countExpansions", () => {
+  it("returns 1 for plain text", () => {
+    expect(countExpansions("no expansions here")).toBe(1);
+  });
+
+  it("returns option count for single group", () => {
+    expect(countExpansions("{a|b|c}")).toBe(3);
+  });
+
+  it("returns cross-product count for multiple groups", () => {
+    expect(countExpansions("{a|b} {x|y|z}")).toBe(6);
+  });
+
+  it("caps count at 16", () => {
+    expect(countExpansions("{a|b|c} {x|y|z} {1|2|3}")).toBe(16);
+  });
+});

--- a/src/components/pages/studio/utils/__tests__/variation-status.test.ts
+++ b/src/components/pages/studio/utils/__tests__/variation-status.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import type { FlowTransition, VariationCandidate } from "@/types/flow.types";
+import {
+  isVideoUrl,
+  aggregateVariationStatus,
+  aggregateVariationProgress,
+  effectiveTransitionStatus,
+  shouldOpenVariationLightbox,
+  transitionHasUsableResult,
+} from "../variation-status";
+
+const v = (
+  status: VariationCandidate["status"],
+  extra: Partial<VariationCandidate> = {},
+): VariationCandidate => ({
+  id: Math.random().toString(36).slice(2),
+  method: "expansion",
+  status,
+  ...extra,
+});
+
+const tr = (t: Partial<FlowTransition>): FlowTransition => ({
+  fromKeyframeId: "a",
+  toKeyframeId: "b",
+  status: "idle",
+  ...t,
+});
+
+describe("isVideoUrl", () => {
+  it("detects video extensions, including with query strings", () => {
+    expect(isVideoUrl("https://x/y/clip_processed.mp4")).toBe(true);
+    expect(isVideoUrl("https://x/y/clip.mp4?sig=abc123")).toBe(true);
+    expect(isVideoUrl("https://x/y/clip.webm")).toBe(true);
+  });
+  it("returns false for images and empty input", () => {
+    expect(isVideoUrl("https://x/y/thumb.jpg")).toBe(false);
+    expect(isVideoUrl("https://x/y/thumb.png?sig=z")).toBe(false);
+    expect(isVideoUrl(undefined)).toBe(false);
+    expect(isVideoUrl("")).toBe(false);
+  });
+});
+
+describe("aggregateVariationStatus", () => {
+  it("is 'none' when there are no variations", () => {
+    expect(aggregateVariationStatus(undefined)).toBe("none");
+    expect(aggregateVariationStatus([])).toBe("none");
+  });
+  it("is 'processing' if any variation is processing", () => {
+    expect(aggregateVariationStatus([v("processed"), v("processing")])).toBe(
+      "processing",
+    );
+  });
+  it("is 'queue' if any is queued and none processing", () => {
+    expect(aggregateVariationStatus([v("processed"), v("queue")])).toBe(
+      "queue",
+    );
+  });
+  it("is 'ready' when at least one processed and none pending", () => {
+    expect(aggregateVariationStatus([v("processed"), v("failed")])).toBe(
+      "ready",
+    );
+    expect(aggregateVariationStatus([v("processed"), v("processed")])).toBe(
+      "ready",
+    );
+  });
+  it("is 'failed' when all failed", () => {
+    expect(aggregateVariationStatus([v("failed"), v("failed")])).toBe("failed");
+  });
+});
+
+describe("aggregateVariationProgress", () => {
+  it("averages with processed counting as 100", () => {
+    expect(
+      aggregateVariationProgress([
+        v("processed"),
+        v("processing", { progress: 50 }),
+      ]),
+    ).toBe(75);
+  });
+  it("treats missing progress as 0", () => {
+    expect(aggregateVariationProgress([v("queue"), v("processing")])).toBe(0);
+  });
+});
+
+describe("effectiveTransitionStatus", () => {
+  it("uses the transition's own status for the single-variant path", () => {
+    expect(effectiveTransitionStatus(tr({ status: "processing" }))).toBe(
+      "processing",
+    );
+    expect(effectiveTransitionStatus(tr({ status: "processed" }))).toBe(
+      "processed",
+    );
+  });
+  it("derives from variations when transition is idle but variations exist", () => {
+    expect(
+      effectiveTransitionStatus(
+        tr({ status: "idle", variations: [v("processing"), v("queue")] }),
+      ),
+    ).toBe("processing");
+    // all variations done, none selected yet -> reviewable
+    expect(
+      effectiveTransitionStatus(
+        tr({ status: "idle", variations: [v("processed"), v("processed")] }),
+      ),
+    ).toBe("review");
+  });
+  it("stays idle when there are no variations", () => {
+    expect(effectiveTransitionStatus(tr({ status: "idle" }))).toBe("idle");
+  });
+});
+
+describe("shouldOpenVariationLightbox", () => {
+  it("opens for a processed single result", () => {
+    expect(shouldOpenVariationLightbox(tr({ status: "processed" }))).toBe(true);
+  });
+  it("opens whenever variations exist, regardless of transition status", () => {
+    expect(
+      shouldOpenVariationLightbox(
+        tr({ status: "idle", variations: [v("processed"), v("processed")] }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldOpenVariationLightbox(
+        tr({ status: "idle", variations: [v("processing")] }),
+      ),
+    ).toBe(true);
+  });
+  it("does not open for a bare idle transition (opens settings instead)", () => {
+    expect(shouldOpenVariationLightbox(tr({ status: "idle" }))).toBe(false);
+  });
+});
+
+describe("transitionHasUsableResult", () => {
+  it("true for a processed transition", () => {
+    expect(transitionHasUsableResult(tr({ status: "processed" }))).toBe(true);
+  });
+  it("true when variations are ready to review", () => {
+    expect(
+      transitionHasUsableResult(
+        tr({ status: "idle", variations: [v("processed")] }),
+      ),
+    ).toBe(true);
+  });
+  it("false while variations still generating", () => {
+    expect(
+      transitionHasUsableResult(
+        tr({ status: "idle", variations: [v("processing")] }),
+      ),
+    ).toBe(false);
+  });
+  it("false for a bare idle transition", () => {
+    expect(transitionHasUsableResult(tr({ status: "idle" }))).toBe(false);
+  });
+});

--- a/src/components/pages/studio/utils/expand-prompt.ts
+++ b/src/components/pages/studio/utils/expand-prompt.ts
@@ -50,7 +50,13 @@ function parse(template: string): ParsedSegment[] {
   return segments;
 }
 
-function crossProduct(segments: ParsedSegment[]): string[] {
+export const MAX_EXPANSIONS = 16;
+
+// Builds the cross-product but never grows beyond `limit` entries. Capping
+// here (rather than slicing a fully-materialized product) is essential: a
+// prompt with many groups expands exponentially, so building the full product
+// first would freeze or OOM the tab before the cap is ever applied.
+function crossProduct(segments: ParsedSegment[], limit: number): string[] {
   let results = [""];
 
   for (const seg of segments) {
@@ -58,28 +64,28 @@ function crossProduct(segments: ParsedSegment[]): string[] {
       results = results.map((r) => r + seg.value);
     } else {
       const next: string[] = [];
-      for (const r of results) {
+      outer: for (const r of results) {
         for (const opt of seg.options) {
           next.push(r + opt);
+          if (next.length >= limit) break outer;
         }
       }
       results = next;
     }
   }
 
-  return results;
+  return results.slice(0, limit);
 }
-
-const MAX_EXPANSIONS = 16;
 
 export function expandPrompt(template: string): string[] {
   if (!template) return [template];
   const segments = parse(template);
-  const results = crossProduct(segments);
-  return results.slice(0, MAX_EXPANSIONS);
+  return crossProduct(segments, MAX_EXPANSIONS);
 }
 
-export function countExpansions(template: string): number {
+// Uncapped count of how many combinations the template would expand to. Pure
+// multiplication — never materializes the product, so it's safe for any input.
+export function countRawExpansions(template: string): number {
   if (!template) return 1;
   const segments = parse(template);
   let count = 1;
@@ -88,5 +94,9 @@ export function countExpansions(template: string): number {
       count *= seg.options.length;
     }
   }
-  return Math.min(count, MAX_EXPANSIONS);
+  return count;
+}
+
+export function countExpansions(template: string): number {
+  return Math.min(countRawExpansions(template), MAX_EXPANSIONS);
 }

--- a/src/components/pages/studio/utils/expand-prompt.ts
+++ b/src/components/pages/studio/utils/expand-prompt.ts
@@ -1,0 +1,92 @@
+// src/components/pages/studio/utils/expand-prompt.ts
+
+interface ParsedSegment {
+  type: "literal" | "group";
+  value: string;
+  options: string[];
+}
+
+function parse(template: string): ParsedSegment[] {
+  const segments: ParsedSegment[] = [];
+  let current = "";
+  let i = 0;
+
+  while (i < template.length) {
+    if (
+      template[i] === "\\" &&
+      (template[i + 1] === "{" || template[i + 1] === "}")
+    ) {
+      current += template[i + 1];
+      i += 2;
+      continue;
+    }
+
+    if (template[i] === "{") {
+      if (current) {
+        segments.push({ type: "literal", value: current, options: [] });
+        current = "";
+      }
+      const closeIdx = template.indexOf("}", i);
+      if (closeIdx === -1) {
+        current += template[i];
+        i++;
+        continue;
+      }
+      const inner = template.slice(i + 1, closeIdx);
+      const options = inner.split("|").map((s) => s.trim());
+      segments.push({ type: "group", value: "", options });
+      i = closeIdx + 1;
+      continue;
+    }
+
+    current += template[i];
+    i++;
+  }
+
+  if (current) {
+    segments.push({ type: "literal", value: current, options: [] });
+  }
+
+  return segments;
+}
+
+function crossProduct(segments: ParsedSegment[]): string[] {
+  let results = [""];
+
+  for (const seg of segments) {
+    if (seg.type === "literal") {
+      results = results.map((r) => r + seg.value);
+    } else {
+      const next: string[] = [];
+      for (const r of results) {
+        for (const opt of seg.options) {
+          next.push(r + opt);
+        }
+      }
+      results = next;
+    }
+  }
+
+  return results;
+}
+
+const MAX_EXPANSIONS = 16;
+
+export function expandPrompt(template: string): string[] {
+  if (!template) return [template];
+  const segments = parse(template);
+  const results = crossProduct(segments);
+  return results.slice(0, MAX_EXPANSIONS);
+}
+
+export function countExpansions(template: string): number {
+  if (!template) return 1;
+  const segments = parse(template);
+  let count = 1;
+  for (const seg of segments) {
+    if (seg.type === "group") {
+      count *= seg.options.length;
+    }
+  }
+  return Math.min(count, MAX_EXPANSIONS);
+}

--- a/src/components/pages/studio/utils/variation-status.ts
+++ b/src/components/pages/studio/utils/variation-status.ts
@@ -1,0 +1,78 @@
+// Pure helpers for deriving a transition's display/interaction state from its
+// variation candidates. Multi-variant generation writes results into
+// `transition.variations[]` without rolling the transition's own `status` up to
+// "processed" (that only happens when the user picks one). These helpers let the
+// gap, click handler, and action bar reflect the variations' aggregate state so
+// completed variations are visible and reachable instead of stranded.
+import type { FlowTransition, VariationCandidate } from "@/types/flow.types";
+
+export function isVideoUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return /\.(mp4|webm|mov|m4v)(\?|$)/i.test(url);
+}
+
+export type VariationAggregate =
+  | "none"
+  | "queue"
+  | "processing"
+  | "ready"
+  | "failed";
+
+export function aggregateVariationStatus(
+  variations?: VariationCandidate[],
+): VariationAggregate {
+  if (!variations || variations.length === 0) return "none";
+  if (variations.some((v) => v.status === "processing")) return "processing";
+  if (variations.some((v) => v.status === "queue")) return "queue";
+  // No queued/processing left — terminal. Ready if at least one succeeded.
+  if (variations.some((v) => v.status === "processed")) return "ready";
+  return "failed";
+}
+
+export function aggregateVariationProgress(
+  variations?: VariationCandidate[],
+): number {
+  if (!variations || variations.length === 0) return 0;
+  const total = variations.reduce(
+    (sum, v) => sum + (v.status === "processed" ? 100 : v.progress ?? 0),
+    0,
+  );
+  return Math.round(total / variations.length);
+}
+
+// "review" = all variations finished and at least one succeeded, but the user
+// hasn't selected one yet. The other values mirror TransitionStatus.
+export type EffectiveTransitionStatus =
+  | "idle"
+  | "queue"
+  | "processing"
+  | "processed"
+  | "failed"
+  | "review";
+
+export function effectiveTransitionStatus(
+  t: FlowTransition,
+): EffectiveTransitionStatus {
+  // Single-variant path drives the transition's own status directly.
+  if (t.status !== "idle") return t.status;
+  // Idle transition that owns variations — derive from them.
+  const agg = aggregateVariationStatus(t.variations);
+  switch (agg) {
+    case "none":
+      return "idle";
+    case "ready":
+      return "review";
+    default:
+      return agg; // "queue" | "processing" | "failed"
+  }
+}
+
+export function shouldOpenVariationLightbox(t: FlowTransition): boolean {
+  if (t.status === "processed") return true;
+  return !!(t.variations && t.variations.length > 0);
+}
+
+export function transitionHasUsableResult(t: FlowTransition): boolean {
+  if (t.status === "processed") return true;
+  return aggregateVariationStatus(t.variations) === "ready";
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,40 +23,72 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );
 
+const BUGSNAG_API_KEY = import.meta.env.VITE_BUGSNAG_API_KEY;
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID;
+
+// Matches the props the Bugsnag React error boundary passes to its fallback,
+// so both the real boundary and the passthrough share one type.
+type BoundaryFallbackProps = {
+  error: Error;
+  info: React.ErrorInfo;
+  clearError: () => void;
+};
+type AppErrorBoundary = React.ComponentType<{
+  children?: React.ReactNode;
+  FallbackComponent?: React.ComponentType<BoundaryFallbackProps>;
+}>;
+
+// Passthrough used when Bugsnag can't start (missing key on local/preview).
+const PassthroughBoundary: AppErrorBoundary = ({ children }) => <>{children}</>;
+
 /**
- * Initialize Bugsnag
+ * Initialize Bugsnag.
+ *
+ * Guarded: with no API key (local/preview builds) Bugsnag.start() throws, and
+ * Bugsnag.getPlugin("react")! would then throw again — either one white-screens
+ * the entire app. When the key is absent we skip init and fall back to a
+ * passthrough error boundary so the app still boots.
  */
-Bugsnag.start({
-  apiKey: import.meta.env.VITE_BUGSNAG_API_KEY,
-  plugins: [new BugsnagPluginReact()],
-  enabledReleaseStages: ["production", "development"],
-  releaseStage: getReleaseStage(),
-  appVersion: import.meta.env.VITE_COMMIT_REF,
-  onError: function (event) {
-    if (event.originalError && event.originalError.stack) {
-      const stack = event.originalError.stack?.toLowerCase();
-      // Check for various types of browser extensions
-      if (
-        stack?.includes("chrome-extension://") ||
-        stack?.includes("moz-extension://") ||
-        stack?.includes("safari-extension://") ||
-        stack?.includes("safari-web-extension://") ||
-        stack?.includes("ms-browser-extension://") ||
-        stack?.includes("edge-extension://")
-      ) {
-        // Don't send event if comes from an extension
-        return false;
+export let ErrorBoundary: AppErrorBoundary = PassthroughBoundary;
+
+if (BUGSNAG_API_KEY) {
+  Bugsnag.start({
+    apiKey: BUGSNAG_API_KEY,
+    plugins: [new BugsnagPluginReact()],
+    enabledReleaseStages: ["production", "development"],
+    releaseStage: getReleaseStage(),
+    appVersion: import.meta.env.VITE_COMMIT_REF,
+    onError: function (event) {
+      if (event.originalError && event.originalError.stack) {
+        const stack = event.originalError.stack?.toLowerCase();
+        // Check for various types of browser extensions
+        if (
+          stack?.includes("chrome-extension://") ||
+          stack?.includes("moz-extension://") ||
+          stack?.includes("safari-extension://") ||
+          stack?.includes("safari-web-extension://") ||
+          stack?.includes("ms-browser-extension://") ||
+          stack?.includes("edge-extension://")
+        ) {
+          // Don't send event if comes from an extension
+          return false;
+        }
       }
-    }
 
-    return true;
-  },
-});
+      return true;
+    },
+  });
 
-BugsnagPerformance.start({ apiKey: import.meta.env.VITE_BUGSNAG_API_KEY });
+  BugsnagPerformance.start({ apiKey: BUGSNAG_API_KEY });
 
-export const ErrorBoundary =
-  Bugsnag.getPlugin("react")!.createErrorBoundary(React);
+  const reactPlugin = Bugsnag.getPlugin("react");
+  if (reactPlugin) {
+    ErrorBoundary = reactPlugin.createErrorBoundary(React);
+  }
+} else {
+  // eslint-disable-next-line no-console
+  console.warn("VITE_BUGSNAG_API_KEY not set — Bugsnag disabled.");
+}
 
 /**
  * Initialize GA4
@@ -64,13 +96,20 @@ export const ErrorBoundary =
  * using react-ga4 since is the latest package for Google Analytics
  *  recommended keep up to date with new Google releases and changes for GA
  * https://www.npmjs.com/package/react-ga4
+ *
+ * Guarded for the same reason as Bugsnag: initialize() throws on a missing id.
  */
-ReactGA.initialize(import.meta.env.VITE_GA_MEASUREMENT_ID, {
-  gaOptions: {
-    debug: IS_DEV,
-    titleCase: false,
-  },
-});
+if (GA_MEASUREMENT_ID) {
+  ReactGA.initialize(GA_MEASUREMENT_ID, {
+    gaOptions: {
+      debug: IS_DEV,
+      titleCase: false,
+    },
+  });
+} else {
+  // eslint-disable-next-line no-console
+  console.warn("VITE_GA_MEASUREMENT_ID not set — Google Analytics disabled.");
+}
 
 root.render(
   <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -431,6 +431,24 @@ describe("Phase 1: transitions", () => {
       expect(transitions[1].status).toBe("failed");
     });
 
+    it("keeps in-flight transitions that have a dreamUuid (recoverable) so polling can recover them", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe(makeKf("a"));
+      store.addKeyframe(makeKf("b"));
+      store.recomputeTransitions();
+
+      // A transition with a real backend job, still cooking.
+      store.setTransitionDream(0, "dream-123");
+      store.updateTransitionStatus(0, "processing", 50);
+
+      store.reconcileStaleTransitions();
+
+      const { transitions } = useFlowStore.getState();
+      // Recoverable: left in-flight, not failed.
+      expect(transitions[0].status).toBe("processing");
+      expect(transitions[0].dreamUuid).toBe("dream-123");
+    });
+
     it("does not reset processed or idle transitions", () => {
       const store = useFlowStore.getState();
       store.addKeyframe(makeKf("a"));

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -4,6 +4,7 @@ import type {
   FlowKeyframe,
   FlowTransition,
   TransitionStatus,
+  VariationCandidate,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
 
@@ -29,7 +30,7 @@ function buildKeyframesWithLoop(
   ];
 }
 
-type FlowStoreState = {
+export type FlowStoreState = {
   // Phase 0
   keyframes: FlowKeyframe[];
   loop: boolean;
@@ -90,6 +91,35 @@ type FlowStoreState = {
   ) => void;
   recomputeTransitions: () => void;
   reconcileStaleTransitions: () => void;
+
+  // Variation actions — keyframes
+  addKeyframeVariations: (
+    keyframeId: string,
+    candidates: VariationCandidate[],
+  ) => void;
+  selectKeyframeVariation: (keyframeId: string, variationId: string) => void;
+  clearKeyframeVariations: (keyframeId: string) => void;
+  updateKeyframeVariation: (
+    keyframeId: string,
+    variationId: string,
+    patch: Partial<VariationCandidate>,
+  ) => void;
+
+  // Variation actions — transitions
+  addTransitionVariations: (
+    transitionIndex: number,
+    candidates: VariationCandidate[],
+  ) => void;
+  selectTransitionVariation: (
+    transitionIndex: number,
+    variationId: string,
+  ) => void;
+  clearTransitionVariations: (transitionIndex: number) => void;
+  updateTransitionVariation: (
+    transitionIndex: number,
+    variationId: string,
+    patch: Partial<VariationCandidate>,
+  ) => void;
 };
 
 const PHASE_1_DEFAULTS = {
@@ -334,10 +364,117 @@ export const useFlowStore = create<FlowStoreState>()(
             };
           }),
         })),
+
+      // Variation actions — keyframes
+      addKeyframeVariations: (keyframeId, candidates) =>
+        set((s) => ({
+          keyframes: s.keyframes.map((kf) =>
+            kf.id === keyframeId
+              ? { ...kf, variations: [...(kf.variations || []), ...candidates] }
+              : kf,
+          ),
+        })),
+
+      selectKeyframeVariation: (keyframeId, variationId) =>
+        set((s) => {
+          const kf = s.keyframes.find((k) => k.id === keyframeId);
+          const variation = kf?.variations?.find((v) => v.id === variationId);
+          if (!kf || !variation || variation.status !== "processed") return s;
+          return {
+            keyframes: s.keyframes.map((k) =>
+              k.id === keyframeId
+                ? {
+                    ...k,
+                    activeVariationId: variationId,
+                    imageUrl: variation.imageUrl || k.imageUrl,
+                    dreamUuid: variation.dreamUuid || k.dreamUuid,
+                  }
+                : k,
+            ),
+          };
+        }),
+
+      clearKeyframeVariations: (keyframeId) =>
+        set((s) => ({
+          keyframes: s.keyframes.map((kf) =>
+            kf.id === keyframeId
+              ? { ...kf, variations: undefined, activeVariationId: undefined }
+              : kf,
+          ),
+        })),
+
+      updateKeyframeVariation: (keyframeId, variationId, patch) =>
+        set((s) => ({
+          keyframes: s.keyframes.map((kf) =>
+            kf.id === keyframeId
+              ? {
+                  ...kf,
+                  variations: kf.variations?.map((v) =>
+                    v.id === variationId ? { ...v, ...patch } : v,
+                  ),
+                }
+              : kf,
+          ),
+        })),
+
+      // Variation actions — transitions
+      addTransitionVariations: (index, candidates) =>
+        set((s) => ({
+          transitions: s.transitions.map((t, i) =>
+            i === index
+              ? { ...t, variations: [...(t.variations || []), ...candidates] }
+              : t,
+          ),
+        })),
+
+      selectTransitionVariation: (index, variationId) =>
+        set((s) => {
+          const transition = s.transitions[index];
+          const variation = transition?.variations?.find(
+            (v) => v.id === variationId,
+          );
+          if (!transition || !variation || variation.status !== "processed")
+            return s;
+          return {
+            transitions: s.transitions.map((t, i) =>
+              i === index
+                ? {
+                    ...t,
+                    activeVariationId: variationId,
+                    dreamUuid: variation.dreamUuid || t.dreamUuid,
+                    status: "processed" as const,
+                  }
+                : t,
+            ),
+          };
+        }),
+
+      clearTransitionVariations: (index) =>
+        set((s) => ({
+          transitions: s.transitions.map((t, i) =>
+            i === index
+              ? { ...t, variations: undefined, activeVariationId: undefined }
+              : t,
+          ),
+        })),
+
+      updateTransitionVariation: (index, variationId, patch) =>
+        set((s) => ({
+          transitions: s.transitions.map((t, i) =>
+            i === index
+              ? {
+                  ...t,
+                  variations: t.variations?.map((v) =>
+                    v.id === variationId ? { ...v, ...patch } : v,
+                  ),
+                }
+              : t,
+          ),
+        })),
     }),
     {
       name: "flow-session",
-      version: 3,
+      version: 4,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version < 2) {
@@ -353,6 +490,10 @@ export const useFlowStore = create<FlowStoreState>()(
             globalNegativePrompt: "",
             globalModel: "ltx-i2v",
           };
+        }
+        if (version < 4) {
+          // VariationCandidate fields added to keyframes and transitions; no data migration needed.
+          return state;
         }
         return state;
       },
@@ -382,9 +523,18 @@ export const useFlowStore = create<FlowStoreState>()(
             imageUrl: kf.imageUrl,
             name: kf.name,
             isLoopKeyframe: kf.isLoopKeyframe,
+            variations: kf.variations?.filter(
+              (v) => v.status !== "queue" && v.status !== "processing",
+            ),
+            activeVariationId: kf.activeVariationId,
           })),
         loop: state.loop,
-        transitions: state.transitions,
+        transitions: state.transitions.map((t) => ({
+          ...t,
+          variations: t.variations?.filter(
+            (v) => v.status !== "queue" && v.status !== "processing",
+          ),
+        })),
         globalPresetId: state.globalPresetId,
         globalPrompt: state.globalPrompt,
         globalNegativePrompt: state.globalNegativePrompt,

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -344,26 +344,49 @@ export const useFlowStore = create<FlowStoreState>()(
         })),
 
       reconcileStaleTransitions: () =>
-        set((s) => ({
-          transitions: s.transitions.map((t) => {
-            const dreamStale =
-              t.status === "processing" || t.status === "queue";
-            const uprezStale =
-              t.uprezStatus === "processing" || t.uprezStatus === "queue";
-            if (!dreamStale && !uprezStale) return t;
-            return {
-              ...t,
-              ...(dreamStale && {
-                status: "failed" as const,
-                progress: undefined,
-              }),
-              ...(uprezStale && {
-                uprezStatus: "failed" as const,
-                uprezProgress: undefined,
-              }),
-            };
-          }),
-        })),
+        set((s) => {
+          // Only fail in-flight work that has NO backend job to recover (no
+          // dreamUuid). Items WITH a dreamUuid are left in queue/processing so
+          // the polling hook (useFlowJobProgress) re-attaches and recovers their
+          // real status after a reload / session switch — work cooking in
+          // another session must survive switching back and forth.
+          const reconcileVariations = (vars?: VariationCandidate[]) =>
+            vars?.map((v) =>
+              (v.status === "queue" || v.status === "processing") &&
+              !v.dreamUuid
+                ? { ...v, status: "failed" as const, progress: undefined }
+                : v,
+            );
+          return {
+            transitions: s.transitions.map((t) => {
+              const dreamInFlight =
+                t.status === "processing" || t.status === "queue";
+              const uprezInFlight =
+                t.uprezStatus === "processing" || t.uprezStatus === "queue";
+              return {
+                ...t,
+                ...(dreamInFlight &&
+                  !t.dreamUuid && {
+                    status: "failed" as const,
+                    progress: undefined,
+                  }),
+                ...(uprezInFlight &&
+                  !t.uprezDreamUuid && {
+                    uprezStatus: "failed" as const,
+                    uprezProgress: undefined,
+                  }),
+                ...(t.variations && {
+                  variations: reconcileVariations(t.variations),
+                }),
+              };
+            }),
+            keyframes: s.keyframes.map((kf) =>
+              kf.variations
+                ? { ...kf, variations: reconcileVariations(kf.variations) }
+                : kf,
+            ),
+          };
+        }),
 
       // Variation actions — keyframes
       addKeyframeVariations: (keyframeId, candidates) =>

--- a/src/stores/session.store.test.ts
+++ b/src/stores/session.store.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 
-// Mock localStorage
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-  return {
+// Polyfill localStorage for Node environment (must run before store imports)
+beforeAll(() => {
+  const store: Record<string, string> = {};
+  globalThis.localStorage = {
     getItem: (key: string) => store[key] ?? null,
     setItem: (key: string, value: string) => {
       store[key] = value;
@@ -12,18 +12,24 @@ const localStorageMock = (() => {
       delete store[key];
     },
     clear: () => {
-      store = {};
+      Object.keys(store).forEach((k) => delete store[k]);
     },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
   };
-})();
-Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+});
 
-import { useSessionStore } from "./session.store";
+// Dynamic imports after localStorage is set up (persist middleware needs it)
+const { useSessionStore } = await import("./session.store");
+const { useFlowStore } = await import("./flow.store");
 
 describe("session store", () => {
   beforeEach(() => {
     localStorage.clear();
     useSessionStore.setState({ sessions: [], activeSessionId: null });
+    useFlowStore.getState().resetFlow();
   });
 
   it("creates a new session", () => {
@@ -43,6 +49,29 @@ describe("session store", () => {
     expect(useSessionStore.getState().activeSessionId).toBe(sessions[0].id);
   });
 
+  it("resets UI state on session switch", () => {
+    // Create two sessions
+    useSessionStore.getState().createSession("Session A");
+    useSessionStore.getState().createSession("Session B");
+
+    // Simulate stale UI state in the flow store (as if user selected transition 3)
+    useFlowStore.setState({
+      selectedTransitionIndex: 3,
+      settingsExpanded: true,
+      previewLightboxOpen: true,
+    });
+
+    // Switch back to Session A
+    const { sessions } = useSessionStore.getState();
+    useSessionStore.getState().switchSession(sessions[0].id);
+
+    // UI state should be reset to defaults, not carried over from previous session
+    const flowState = useFlowStore.getState();
+    expect(flowState.selectedTransitionIndex).toBeNull();
+    expect(flowState.settingsExpanded).toBe(false);
+    expect(flowState.previewLightboxOpen).toBe(false);
+  });
+
   it("renames a session", () => {
     useSessionStore.getState().createSession("Old Name");
     const { sessions } = useSessionStore.getState();
@@ -59,6 +88,22 @@ describe("session store", () => {
     expect(useSessionStore.getState().sessions[0].name).toBe("Keep");
   });
 
+  it("deletes active session and switches to remaining", () => {
+    useSessionStore.getState().createSession("First");
+    useSessionStore.getState().createSession("Second");
+    const { sessions } = useSessionStore.getState();
+    // Active session is "Second" (most recently created)
+    expect(useSessionStore.getState().activeSessionId).toBe(sessions[1].id);
+
+    // Delete the active session
+    useSessionStore.getState().deleteSession(sessions[1].id);
+
+    // Should switch to the remaining session
+    const updated = useSessionStore.getState();
+    expect(updated.sessions).toHaveLength(1);
+    expect(updated.activeSessionId).toBe(sessions[0].id);
+  });
+
   it("duplicates a session", () => {
     useSessionStore.getState().createSession("Original");
     const { sessions } = useSessionStore.getState();
@@ -68,10 +113,34 @@ describe("session store", () => {
     expect(updated[1].name).toBe("Original (copy)");
   });
 
-  it("caps at MAX_SESSIONS", () => {
+  it("caps at MAX_SESSIONS by dropping oldest", () => {
     for (let i = 0; i < 22; i++) {
       useSessionStore.getState().createSession(`Session ${i}`);
     }
-    expect(useSessionStore.getState().sessions.length).toBeLessThanOrEqual(20);
+    const { sessions } = useSessionStore.getState();
+    expect(sessions.length).toBeLessThanOrEqual(20);
+    // The newest session should still be present
+    expect(sessions[sessions.length - 1].name).toBe("Session 21");
+  });
+
+  it("saves and restores flow state across sessions", () => {
+    // Create session A and set some flow state
+    useSessionStore.getState().createSession("Session A");
+    useFlowStore.setState({ globalPrompt: "hello from A" });
+    useSessionStore.getState().saveCurrentSession();
+
+    // Create session B with different state
+    useSessionStore.getState().createSession("Session B");
+    useFlowStore.setState({ globalPrompt: "hello from B" });
+    useSessionStore.getState().saveCurrentSession();
+
+    // Switch back to A — flow state should restore
+    const { sessions } = useSessionStore.getState();
+    useSessionStore.getState().switchSession(sessions[0].id);
+    expect(useFlowStore.getState().globalPrompt).toBe("hello from A");
+
+    // Switch back to B
+    useSessionStore.getState().switchSession(sessions[1].id);
+    expect(useFlowStore.getState().globalPrompt).toBe("hello from B");
   });
 });

--- a/src/stores/session.store.test.ts
+++ b/src/stores/session.store.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+
+import { useSessionStore } from "./session.store";
+
+describe("session store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSessionStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it("creates a new session", () => {
+    useSessionStore.getState().createSession("My Flow");
+    const { sessions, activeSessionId } = useSessionStore.getState();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].name).toBe("My Flow");
+    expect(activeSessionId).toBe(sessions[0].id);
+  });
+
+  it("switches between sessions", () => {
+    useSessionStore.getState().createSession("Session A");
+    useSessionStore.getState().createSession("Session B");
+    const { sessions } = useSessionStore.getState();
+    expect(sessions).toHaveLength(2);
+    useSessionStore.getState().switchSession(sessions[0].id);
+    expect(useSessionStore.getState().activeSessionId).toBe(sessions[0].id);
+  });
+
+  it("renames a session", () => {
+    useSessionStore.getState().createSession("Old Name");
+    const { sessions } = useSessionStore.getState();
+    useSessionStore.getState().renameSession(sessions[0].id, "New Name");
+    expect(useSessionStore.getState().sessions[0].name).toBe("New Name");
+  });
+
+  it("deletes a session", () => {
+    useSessionStore.getState().createSession("To Delete");
+    useSessionStore.getState().createSession("Keep");
+    const { sessions } = useSessionStore.getState();
+    useSessionStore.getState().deleteSession(sessions[0].id);
+    expect(useSessionStore.getState().sessions).toHaveLength(1);
+    expect(useSessionStore.getState().sessions[0].name).toBe("Keep");
+  });
+
+  it("duplicates a session", () => {
+    useSessionStore.getState().createSession("Original");
+    const { sessions } = useSessionStore.getState();
+    useSessionStore.getState().duplicateSession(sessions[0].id);
+    const updated = useSessionStore.getState().sessions;
+    expect(updated).toHaveLength(2);
+    expect(updated[1].name).toBe("Original (copy)");
+  });
+
+  it("caps at MAX_SESSIONS", () => {
+    for (let i = 0; i < 22; i++) {
+      useSessionStore.getState().createSession(`Session ${i}`);
+    }
+    expect(useSessionStore.getState().sessions.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { v4 as uuidv4 } from "uuid";
 import { useFlowStore } from "./flow.store";
 import { useStudioStore } from "./studio.store";
 import { useStudioModeStore } from "./studio-mode.store";
@@ -109,11 +110,14 @@ const initialState = loadInitialState();
 // ---------------------------------------------------------------------------
 
 function defaultSessionName(): string {
-  return new Date().toLocaleString();
-}
-
-function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const now = new Date();
+  return `Session — ${now.toLocaleString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
 }
 
 function extractThumbnail(
@@ -172,17 +176,49 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
     const idx = sessions.findIndex((s) => s.id === activeSessionId);
     if (idx === -1) return;
 
-    // Capture raw state — serialize to strip functions, revive Sets so the
-    // stored snapshot is plain JSON (no live Set instances).
+    // Capture only serializable data fields — explicitly exclude function
+    // properties so the snapshot is pure data. This is safer than serializing
+    // the full store and relying on Zustand's shallow merge to preserve actions.
     const flowRaw = useFlowStore.getState();
     const batchRaw = useStudioStore.getState();
     const mode = useStudioModeStore.getState().mode;
 
     const flowState = JSON.parse(
-      JSON.stringify(flowRaw, stateReplacer),
+      JSON.stringify(
+        {
+          keyframes: flowRaw.keyframes,
+          loop: flowRaw.loop,
+          transitions: flowRaw.transitions,
+          globalPresetId: flowRaw.globalPresetId,
+          globalPrompt: flowRaw.globalPrompt,
+          globalNegativePrompt: flowRaw.globalNegativePrompt,
+          globalDuration: flowRaw.globalDuration,
+          globalModel: flowRaw.globalModel,
+          globalNumInferenceSteps: flowRaw.globalNumInferenceSteps,
+          globalGuidance: flowRaw.globalGuidance,
+          globalLora: flowRaw.globalLora,
+          selectedTransitionIndex: flowRaw.selectedTransitionIndex,
+          settingsExpanded: flowRaw.settingsExpanded,
+        },
+        stateReplacer,
+      ),
     ) as Record<string, unknown>;
     const batchState = JSON.parse(
-      JSON.stringify(batchRaw, stateReplacer),
+      JSON.stringify(
+        {
+          activeTab: batchRaw.activeTab,
+          imagePrompt: batchRaw.imagePrompt,
+          imageGenParams: batchRaw.imageGenParams,
+          images: batchRaw.images,
+          actions: batchRaw.actions,
+          videoGenParams: batchRaw.videoGenParams,
+          outputPlaylistId: batchRaw.outputPlaylistId,
+          uprezPlaylistId: batchRaw.uprezPlaylistId,
+          excludedCombos: batchRaw.excludedCombos,
+          jobs: batchRaw.jobs,
+        },
+        stateReplacer,
+      ),
     ) as Record<string, unknown>;
 
     const thumbnail = extractThumbnail(flowState, batchState, mode);
@@ -207,13 +243,12 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
    */
   createSession: (name?: string) => {
     const { sessions, saveCurrentSession } = get();
-    if (sessions.length >= MAX_SESSIONS) return;
 
     saveCurrentSession();
 
     const mode = useStudioModeStore.getState().mode;
     const session: StudioSession = {
-      id: generateId(),
+      id: uuidv4(),
       name: name ?? defaultSessionName(),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -222,7 +257,11 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
       batchState: {},
     };
 
-    const next = [...sessions, session];
+    // Enforce cap — drop oldest sessions when over the limit
+    let next = [...sessions, session];
+    if (next.length > MAX_SESSIONS) {
+      next = next.slice(next.length - MAX_SESSIONS);
+    }
     set({ sessions: next, activeSessionId: session.id });
     persistSessions(next);
     persistActiveId(session.id);
@@ -332,7 +371,7 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
 
     const copy: StudioSession = {
       ...source,
-      id: generateId(),
+      id: uuidv4(),
       name: `${source.name} (copy)`,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand";
 import { v4 as uuidv4 } from "uuid";
 import { useFlowStore } from "./flow.store";
-import { useStudioStore } from "./studio.store";
+import { useStudioStore, DEFAULT_VARIATION_SEED } from "./studio.store";
 import { useStudioModeStore } from "./studio-mode.store";
+import { DEFAULT_VARIATION_PRESET_ID } from "@/components/pages/studio/constants/variation-presets";
 import type { StudioSession } from "@/types/session.types";
 import {
   MAX_SESSIONS,
@@ -210,6 +211,9 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
           activeTab: batchRaw.activeTab,
           imagePrompt: batchRaw.imagePrompt,
           imageGenParams: batchRaw.imageGenParams,
+          variationPresetId: batchRaw.variationPresetId,
+          variationCustomPrompt: batchRaw.variationCustomPrompt,
+          variationSeed: batchRaw.variationSeed,
           images: batchRaw.images,
           actions: batchRaw.actions,
           videoGenParams: batchRaw.videoGenParams,
@@ -300,8 +304,9 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
         settingsExpanded: false,
         previewLightboxOpen: false,
       });
-      // Order matters: reconcile first (mark stale in-flight as failed),
-      // then recompute (rebuild transition list from keyframes).
+      // Order matters: reconcile first (fail only UNRECOVERABLE in-flight work
+      // — items with no dreamUuid; recoverable ones keep their queue/processing
+      // status so polling re-attaches), then recompute the transition list.
       useFlowStore.getState().reconcileStaleTransitions();
       useFlowStore.getState().recomputeTransitions();
     } else {
@@ -314,9 +319,15 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
         string,
         unknown
       >;
-      useStudioStore.setState(
-        batchRevived as Parameters<typeof useStudioStore.setState>[0],
-      );
+      // Default the variation settings first so sessions saved before these
+      // fields existed don't leak the previous session's values; the session's
+      // own saved values (if any) override.
+      useStudioStore.setState({
+        variationPresetId: DEFAULT_VARIATION_PRESET_ID,
+        variationCustomPrompt: "",
+        variationSeed: DEFAULT_VARIATION_SEED,
+        ...batchRevived,
+      } as Parameters<typeof useStudioStore.setState>[0]);
     } else {
       useStudioStore.getState().resetSession();
     }

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -197,8 +197,9 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
           globalNumInferenceSteps: flowRaw.globalNumInferenceSteps,
           globalGuidance: flowRaw.globalGuidance,
           globalLora: flowRaw.globalLora,
-          selectedTransitionIndex: flowRaw.selectedTransitionIndex,
-          settingsExpanded: flowRaw.settingsExpanded,
+          // NOTE: selectedTransitionIndex and settingsExpanded are intentionally
+          // excluded — they are UI state that goes stale when transitions change.
+          // See AGENTS.md anti-rationalization: "Persist data, not UI state."
         },
         stateReplacer,
       ),

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -1,0 +1,345 @@
+import { create } from "zustand";
+import { useFlowStore } from "./flow.store";
+import { useStudioStore } from "./studio.store";
+import { useStudioModeStore } from "./studio-mode.store";
+import type { StudioSession } from "@/types/session.types";
+import {
+  MAX_SESSIONS,
+  SESSIONS_STORAGE_KEY,
+  ACTIVE_SESSION_KEY,
+} from "@/types/session.types";
+
+// ---------------------------------------------------------------------------
+// Set serialization helpers
+// ---------------------------------------------------------------------------
+
+interface SerializedSet {
+  __type: "Set";
+  values: unknown[];
+}
+
+function isSerializedSet(value: unknown): value is SerializedSet {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as SerializedSet).__type === "Set" &&
+    Array.isArray((value as SerializedSet).values)
+  );
+}
+
+/**
+ * JSON replacer: strips functions, serializes Sets with a marker object.
+ */
+function stateReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "function") return undefined;
+  if (value instanceof Set) {
+    return { __type: "Set", values: [...value] };
+  }
+  return value;
+}
+
+/**
+ * Walk a parsed JSON object and revive any `{ __type: "Set", values: [...] }`
+ * back into real Set instances.
+ */
+function reviveSets(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(reviveSets);
+  if (isSerializedSet(obj)) return new Set(obj.values);
+  if (obj !== null && typeof obj === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      result[k] = reviveSets(v);
+    }
+    return result;
+  }
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+function persistSessions(sessions: StudioSession[]): void {
+  try {
+    localStorage.setItem(SESSIONS_STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    /* quota exceeded — ignore */
+  }
+}
+
+function persistActiveId(id: string | null): void {
+  try {
+    if (id === null) {
+      localStorage.removeItem(ACTIVE_SESSION_KEY);
+    } else {
+      localStorage.setItem(ACTIVE_SESSION_KEY, id);
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous init — must run at module load, not in a useEffect
+// ---------------------------------------------------------------------------
+
+function loadInitialState(): {
+  sessions: StudioSession[];
+  activeSessionId: string | null;
+} {
+  try {
+    const raw = localStorage.getItem(SESSIONS_STORAGE_KEY);
+    const activeId = localStorage.getItem(ACTIVE_SESSION_KEY);
+    if (raw) {
+      return {
+        sessions: JSON.parse(raw) as StudioSession[],
+        activeSessionId: activeId,
+      };
+    }
+  } catch {
+    /* corrupted */
+  }
+  return { sessions: [], activeSessionId: null };
+}
+
+const initialState = loadInitialState();
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function defaultSessionName(): string {
+  return new Date().toLocaleString();
+}
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function extractThumbnail(
+  flowState: Record<string, unknown>,
+  batchState: Record<string, unknown>,
+  mode: "flow" | "batch",
+): string | undefined {
+  if (mode === "flow") {
+    const keyframes = flowState.keyframes;
+    if (Array.isArray(keyframes) && keyframes.length > 0) {
+      const first = keyframes[0] as { imageUrl?: string };
+      return first.imageUrl ?? undefined;
+    }
+  } else {
+    const images = batchState.images;
+    if (Array.isArray(images) && images.length > 0) {
+      const first = images[0] as { url?: string; imageUrl?: string };
+      return first.url ?? first.imageUrl ?? undefined;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Store type
+// ---------------------------------------------------------------------------
+
+export type SessionStoreState = {
+  sessions: StudioSession[];
+  activeSessionId: string | null;
+
+  createSession: (name?: string) => void;
+  switchSession: (id: string) => void;
+  renameSession: (id: string, name: string) => void;
+  deleteSession: (id: string) => void;
+  duplicateSession: (id: string) => void;
+  saveCurrentSession: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Store implementation
+// ---------------------------------------------------------------------------
+
+export const useSessionStore = create<SessionStoreState>()((set, get) => ({
+  sessions: initialState.sessions,
+  activeSessionId: initialState.activeSessionId,
+
+  /**
+   * Capture flow + batch state into the currently-active session record and
+   * persist to localStorage.
+   */
+  saveCurrentSession: () => {
+    const { sessions, activeSessionId } = get();
+    if (!activeSessionId) return;
+
+    const idx = sessions.findIndex((s) => s.id === activeSessionId);
+    if (idx === -1) return;
+
+    // Capture raw state — serialize to strip functions, revive Sets so the
+    // stored snapshot is plain JSON (no live Set instances).
+    const flowRaw = useFlowStore.getState();
+    const batchRaw = useStudioStore.getState();
+    const mode = useStudioModeStore.getState().mode;
+
+    const flowState = JSON.parse(
+      JSON.stringify(flowRaw, stateReplacer),
+    ) as Record<string, unknown>;
+    const batchState = JSON.parse(
+      JSON.stringify(batchRaw, stateReplacer),
+    ) as Record<string, unknown>;
+
+    const thumbnail = extractThumbnail(flowState, batchState, mode);
+
+    const updated: StudioSession = {
+      ...sessions[idx],
+      updatedAt: new Date().toISOString(),
+      mode,
+      flowState,
+      batchState,
+      thumbnail,
+    };
+
+    const next = sessions.map((s, i) => (i === idx ? updated : s));
+    set({ sessions: next });
+    persistSessions(next);
+  },
+
+  /**
+   * Create a new named session and make it active. Saves the current session
+   * first, then resets the stores to a blank slate.
+   */
+  createSession: (name?: string) => {
+    const { sessions, saveCurrentSession } = get();
+    if (sessions.length >= MAX_SESSIONS) return;
+
+    saveCurrentSession();
+
+    const mode = useStudioModeStore.getState().mode;
+    const session: StudioSession = {
+      id: generateId(),
+      name: name ?? defaultSessionName(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      mode,
+      flowState: {},
+      batchState: {},
+    };
+
+    const next = [...sessions, session];
+    set({ sessions: next, activeSessionId: session.id });
+    persistSessions(next);
+    persistActiveId(session.id);
+
+    // Reset both stores for a blank new session
+    useFlowStore.getState().resetFlow();
+    useStudioStore.getState().resetSession();
+  },
+
+  /**
+   * Save the current session then load the target session's state into both
+   * stores.
+   */
+  switchSession: (id: string) => {
+    const { sessions, saveCurrentSession } = get();
+
+    saveCurrentSession();
+
+    const session = sessions.find((s) => s.id === id);
+    if (!session) return;
+
+    // Restore flow state
+    if (Object.keys(session.flowState).length > 0) {
+      const flowRevived = reviveSets(session.flowState) as Record<
+        string,
+        unknown
+      >;
+      useFlowStore.setState(
+        flowRevived as Parameters<typeof useFlowStore.setState>[0],
+      );
+      // Order matters: reconcile first (mark stale in-flight as failed),
+      // then recompute (rebuild transition list from keyframes).
+      useFlowStore.getState().reconcileStaleTransitions();
+      useFlowStore.getState().recomputeTransitions();
+    } else {
+      useFlowStore.getState().resetFlow();
+    }
+
+    // Restore batch state — revive Sets (excludedCombos)
+    if (Object.keys(session.batchState).length > 0) {
+      const batchRevived = reviveSets(session.batchState) as Record<
+        string,
+        unknown
+      >;
+      useStudioStore.setState(
+        batchRevived as Parameters<typeof useStudioStore.setState>[0],
+      );
+    } else {
+      useStudioStore.getState().resetSession();
+    }
+
+    // Restore mode
+    useStudioModeStore.getState().setMode(session.mode);
+
+    set({ activeSessionId: id });
+    persistActiveId(id);
+  },
+
+  /**
+   * Rename a session by id.
+   */
+  renameSession: (id: string, name: string) => {
+    const { sessions } = get();
+    const next = sessions.map((s) =>
+      s.id === id ? { ...s, name, updatedAt: new Date().toISOString() } : s,
+    );
+    set({ sessions: next });
+    persistSessions(next);
+  },
+
+  /**
+   * Delete a session. If it was the active session, switch to another one
+   * (or null if none remain).
+   */
+  deleteSession: (id: string) => {
+    const { sessions, activeSessionId, switchSession } = get();
+    const remaining = sessions.filter((s) => s.id !== id);
+
+    // Update sessions list first, before any switchSession call, so that
+    // saveCurrentSession (called inside switchSession) does not re-save the
+    // deleted session's state into the new active slot.
+    set({ sessions: remaining });
+    persistSessions(remaining);
+
+    if (activeSessionId === id) {
+      if (remaining.length > 0) {
+        switchSession(remaining[remaining.length - 1].id);
+      } else {
+        set({ activeSessionId: null });
+        persistActiveId(null);
+        // Reset stores to blank state
+        useFlowStore.getState().resetFlow();
+        useStudioStore.getState().resetSession();
+      }
+    }
+  },
+
+  /**
+   * Duplicate a session, appending " (copy)" to the name.
+   */
+  duplicateSession: (id: string) => {
+    const { sessions } = get();
+    if (sessions.length >= MAX_SESSIONS) return;
+
+    const source = sessions.find((s) => s.id === id);
+    if (!source) return;
+
+    const copy: StudioSession = {
+      ...source,
+      id: generateId(),
+      name: `${source.name} (copy)`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const next = [...sessions, copy];
+    set({ sessions: next });
+    persistSessions(next);
+  },
+}));

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -293,6 +293,13 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
       useFlowStore.setState(
         flowRevived as Parameters<typeof useFlowStore.setState>[0],
       );
+      // Reset UI state to defaults — these are intentionally not captured in
+      // sessions because persisted indices go stale when transitions change.
+      useFlowStore.setState({
+        selectedTransitionIndex: null,
+        settingsExpanded: false,
+        previewLightboxOpen: false,
+      });
       // Order matters: reconcile first (mark stale in-flight as failed),
       // then recompute (rebuild transition list from keyframes).
       useFlowStore.getState().reconcileStaleTransitions();

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -8,6 +8,11 @@ import type {
   ImageGenParams,
   VideoGenParams,
 } from "@/types/studio.types";
+import { DEFAULT_VARIATION_PRESET_ID } from "@/components/pages/studio/constants/variation-presets";
+
+// Default variation seed: the same across all sessions until the user changes
+// it (then the new value is persisted for that session only).
+export const DEFAULT_VARIATION_SEED = 42;
 
 export type StudioState = {
   activeTab: StudioTab;
@@ -17,6 +22,12 @@ export type StudioState = {
   setImagePrompt: (prompt: string) => void;
   imageGenParams: ImageGenParams;
   setImageGenParams: (params: Partial<ImageGenParams>) => void;
+  variationPresetId: string;
+  setVariationPresetId: (id: string) => void;
+  variationCustomPrompt: string;
+  setVariationCustomPrompt: (prompt: string) => void;
+  variationSeed: number;
+  setVariationSeed: (seed: number) => void;
   images: StudioImage[];
   addImage: (image: StudioImage) => void;
   updateImage: (uuid: string, updates: Partial<StudioImage>) => void;
@@ -86,6 +97,13 @@ export const useStudioStore = create<StudioState>()(
       imageGenParams: DEFAULT_IMAGE_GEN_PARAMS,
       setImageGenParams: (params: Partial<ImageGenParams>) =>
         set((s) => ({ imageGenParams: { ...s.imageGenParams, ...params } })),
+      variationPresetId: DEFAULT_VARIATION_PRESET_ID,
+      setVariationPresetId: (id: string) => set({ variationPresetId: id }),
+      variationCustomPrompt: "",
+      setVariationCustomPrompt: (prompt: string) =>
+        set({ variationCustomPrompt: prompt }),
+      variationSeed: DEFAULT_VARIATION_SEED,
+      setVariationSeed: (seed: number) => set({ variationSeed: seed }),
       images: [] as StudioImage[],
       addImage: (image: StudioImage) =>
         set((s) => ({ images: [...s.images, image] })),
@@ -205,6 +223,9 @@ export const useStudioStore = create<StudioState>()(
           activeTab: "images" as StudioTab,
           imagePrompt: "",
           imageGenParams: DEFAULT_IMAGE_GEN_PARAMS,
+          variationPresetId: DEFAULT_VARIATION_PRESET_ID,
+          variationCustomPrompt: "",
+          variationSeed: DEFAULT_VARIATION_SEED,
           images: [],
           actions: [],
           videoGenParams: DEFAULT_VIDEO_GEN_PARAMS,
@@ -223,6 +244,9 @@ export const useStudioStore = create<StudioState>()(
         activeTab: state.activeTab,
         imagePrompt: state.imagePrompt,
         imageGenParams: state.imageGenParams,
+        variationPresetId: state.variationPresetId,
+        variationCustomPrompt: state.variationCustomPrompt,
+        variationSeed: state.variationSeed,
         images: state.images.map((img) => ({
           ...img,
           previewFrame: undefined,

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -9,7 +9,7 @@ import type {
   VideoGenParams,
 } from "@/types/studio.types";
 
-type StudioState = {
+export type StudioState = {
   activeTab: StudioTab;
   setActiveTab: (tab: StudioTab) => void;
 

--- a/src/types/__tests__/flow.types.test.ts
+++ b/src/types/__tests__/flow.types.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import type { FlowTransition, TransitionStatus } from "@/types/flow.types";
+import type {
+  FlowTransition,
+  TransitionStatus,
+  VariationCandidate,
+  FlowKeyframe,
+} from "@/types/flow.types";
 
 describe("FlowTransition type", () => {
   it("accepts a valid idle transition", () => {
@@ -39,5 +44,61 @@ describe("FlowTransition type", () => {
       "failed",
     ];
     expect(statuses).toHaveLength(5);
+  });
+});
+
+describe("VariationCandidate type", () => {
+  it("accepts a seed variation", () => {
+    const v: VariationCandidate = {
+      id: "v1",
+      method: "seed",
+      seed: 42,
+      dreamUuid: "dream-123",
+      imageUrl: "https://example.com/img.jpg",
+      status: "processed",
+    };
+    expect(v.method).toBe("seed");
+  });
+
+  it("accepts an expansion variation", () => {
+    const v: VariationCandidate = {
+      id: "v2",
+      method: "expansion",
+      prompt: "fire elemental",
+      status: "queue",
+    };
+    expect(v.prompt).toBe("fire elemental");
+  });
+
+  it("accepts i2i variation", () => {
+    const v: VariationCandidate = {
+      id: "v3",
+      method: "i2i",
+      status: "processing",
+      progress: 45,
+    };
+    expect(v.method).toBe("i2i");
+  });
+
+  it("FlowKeyframe accepts variations array", () => {
+    const kf: FlowKeyframe = {
+      id: "kf-1",
+      dreamUuid: "dream-settled",
+      imageUrl: "https://example.com/img.jpg",
+      name: "test",
+      variations: [
+        {
+          id: "v1",
+          method: "seed",
+          seed: 1,
+          status: "processed",
+          imageUrl: "url1",
+        },
+        { id: "v2", method: "seed", seed: 2, status: "queue" },
+      ],
+      activeVariationId: "v1",
+    };
+    expect(kf.variations).toHaveLength(2);
+    expect(kf.activeVariationId).toBe("v1");
   });
 });

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -18,6 +18,10 @@ export interface FlowKeyframe {
   // Local-only upload state — never persisted to backend.
   uploadStatus?: "uploading" | "failed";
   uploadProgress?: number; // 0-100
+
+  // Variation candidates for this keyframe
+  variations?: VariationCandidate[];
+  activeVariationId?: string;
 }
 
 export type TransitionStatus =
@@ -50,4 +54,19 @@ export interface FlowTransition {
   uprezDreamUuid?: string;
   uprezStatus?: "queue" | "processing" | "processed" | "failed";
   uprezProgress?: number;
+
+  // Variation candidates for this transition
+  variations?: VariationCandidate[];
+  activeVariationId?: string;
+}
+
+export interface VariationCandidate {
+  id: string;
+  method: "seed" | "expansion" | "i2i";
+  prompt?: string;
+  seed?: number;
+  dreamUuid?: string;
+  imageUrl?: string;
+  status: TransitionStatus;
+  progress?: number;
 }

--- a/src/types/session.types.ts
+++ b/src/types/session.types.ts
@@ -1,0 +1,16 @@
+import type { StudioMode } from "@/types/flow.types";
+
+export interface StudioSession {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  mode: StudioMode;
+  flowState: Record<string, unknown>;
+  batchState: Record<string, unknown>;
+  thumbnail?: string;
+}
+
+export const MAX_SESSIONS = 20;
+export const SESSIONS_STORAGE_KEY = "studio-sessions";
+export const ACTIVE_SESSION_KEY = "studio-active-session-id";


### PR DESCRIPTION
## Summary

- **Sessions** — named studio sessions with save/load/switch via localStorage. Auto-saves on every store change (debounced 2s). Session switcher dropdown in studio header. Works for both Flow and Batch modes.
- **Inline Variation Grid** — 2x2/3x3/4x4 grid below keyframes showing seed re-roll variations. Click to swap winner into the flow. Progress tracked via Socket.IO + polling fallback.
- **Prompt Expansion** — `{A|B|C}` syntax in prompts expands to multiple variants. Works in flow mode (generates transition variations) and batch mode (expands actions in the combinatorial grid). Badge shows "N variants" next to prompt fields.

### Origin

- Jay Gidwitz (May 7): "The most important part is MidJourney-style variations — otherwise the loops become very obvious"
- Jef (Feb 13): "The most important thing is organization"
- Spec: `metarepo/docs/superpowers/specs/2026-06-08-variations-sessions-expansion-design.md`

### Key decisions

- Sessions use localStorage (Phase 2 will migrate to backend for cross-device sync)
- Prompt expansion capped at 16 variants to prevent runaway generation
- `excludedCombos` Set serialized via `{ __type: "Set", values: [...] }` markers
- UI state (selectedTransitionIndex, settingsExpanded) intentionally excluded from session persistence — indices go stale when transitions change
- Variation grid uses FLOW theme (target design system for entire studio)

### Deferred

- Transition-gap inline variations (gap component too compact — better via selected transition panel)
- i2i variations (Phase 1 — requires API key config for Flux/OpenAI)
- Server-side session persistence (Phase 2)

## Test plan

- [x] 115 tests passing (14 prompt parser, 28 flow store, 9 session store, 7 flow types, + existing)
- [x] `tsc --noEmit` clean
- [x] 4 rounds of code review with all findings addressed
- [ ] Manual: open studio → session switcher visible in header → create new session → switch back → state restored
- [ ] Manual: add 2+ keyframes → click Shuffle icon → 4 variations generate in grid → click to swap
- [ ] Manual: type `{zoom in|orbit|drift}` in prompt → see "3 variants" badge → generate → 3 transition variations
- [ ] Manual: batch mode → action with `{fire|water} dragon` → generate tab shows 2 expanded actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)