### PR TITLE
Phase 1: API Key Config & i2i Variations — Frontend

### DIFF
--- a/src/api/user-api-endpoints/useCreateUserApiEndpoint.ts
+++ b/src/api/user-api-endpoints/useCreateUserApiEndpoint.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { axiosClient } from "@/client/axios.client";
+import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
+import type { ApiResponse } from "@/types/api.types";
+import type {
+  UserApiEndpoint,
+  CreateUserApiEndpointParams,
+} from "@/types/user-api-endpoint.types";
+import { USER_API_ENDPOINTS_QUERY_KEY } from "./useUserApiEndpoints";
+
+const createEndpoint = async (params: CreateUserApiEndpointParams) => {
+  const { data } = await axiosClient.post<
+    ApiResponse<{ endpoint: UserApiEndpoint }>
+  >("/v1/user/api-endpoints", params, {
+    headers: getRequestHeaders({ contentType: ContentType.json }),
+  });
+  return data;
+};
+
+export const useCreateUserApiEndpoint = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ApiResponse<{ endpoint: UserApiEndpoint }>,
+    Error,
+    CreateUserApiEndpointParams
+  >(createEndpoint, {
+    mutationKey: ["createUserApiEndpoint"],
+    onSuccess: () => {
+      queryClient.invalidateQueries([USER_API_ENDPOINTS_QUERY_KEY]);
+    },
+  });
+};

--- a/src/api/user-api-endpoints/useDeleteUserApiEndpoint.ts
+++ b/src/api/user-api-endpoints/useDeleteUserApiEndpoint.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { axiosClient } from "@/client/axios.client";
+import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
+import type { ApiResponse } from "@/types/api.types";
+import { USER_API_ENDPOINTS_QUERY_KEY } from "./useUserApiEndpoints";
+
+const deleteEndpoint = async (uuid: string) => {
+  const { data } = await axiosClient.delete<ApiResponse<null>>(
+    `/v1/user/api-endpoints/${uuid}`,
+    { headers: getRequestHeaders({ contentType: ContentType.json }) },
+  );
+  return data;
+};
+
+export const useDeleteUserApiEndpoint = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ApiResponse<null>, Error, string>(deleteEndpoint, {
+    mutationKey: ["deleteUserApiEndpoint"],
+    onSuccess: () => {
+      queryClient.invalidateQueries([USER_API_ENDPOINTS_QUERY_KEY]);
+    },
+  });
+};

--- a/src/api/user-api-endpoints/useTestUserApiEndpoint.ts
+++ b/src/api/user-api-endpoints/useTestUserApiEndpoint.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { axiosClient } from "@/client/axios.client";
+import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
+import type { ApiResponse } from "@/types/api.types";
+
+const testEndpoint = async (uuid: string) => {
+  const { data } = await axiosClient.post<ApiResponse<null>>(
+    `/v1/user/api-endpoints/${uuid}/test`,
+    {},
+    { headers: getRequestHeaders({ contentType: ContentType.json }) },
+  );
+  return data;
+};
+
+export const useTestUserApiEndpoint = () => {
+  return useMutation<ApiResponse<null>, Error, string>(testEndpoint, {
+    mutationKey: ["testUserApiEndpoint"],
+  });
+};

--- a/src/api/user-api-endpoints/useUpdateUserApiEndpoint.ts
+++ b/src/api/user-api-endpoints/useUpdateUserApiEndpoint.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { axiosClient } from "@/client/axios.client";
+import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
+import type { ApiResponse } from "@/types/api.types";
+import type {
+  UserApiEndpoint,
+  UpdateUserApiEndpointParams,
+} from "@/types/user-api-endpoint.types";
+import { USER_API_ENDPOINTS_QUERY_KEY } from "./useUserApiEndpoints";
+
+const updateEndpoint = async ({ uuid, ...params }: UpdateUserApiEndpointParams) => {
+  const { data } = await axiosClient.put<
+    ApiResponse<{ endpoint: UserApiEndpoint }>
+  >(`/v1/user/api-endpoints/${uuid}`, params, {
+    headers: getRequestHeaders({ contentType: ContentType.json }),
+  });
+  return data;
+};
+
+export const useUpdateUserApiEndpoint = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ApiResponse<{ endpoint: UserApiEndpoint }>,
+    Error,
+    UpdateUserApiEndpointParams
+  >(updateEndpoint, {
+    mutationKey: ["updateUserApiEndpoint"],
+    onSuccess: () => {
+      queryClient.invalidateQueries([USER_API_ENDPOINTS_QUERY_KEY]);
+    },
+  });
+};

--- a/src/api/user-api-endpoints/useUpdateUserApiEndpoint.ts
+++ b/src/api/user-api-endpoints/useUpdateUserApiEndpoint.ts
@@ -8,7 +8,10 @@ import type {
 } from "@/types/user-api-endpoint.types";
 import { USER_API_ENDPOINTS_QUERY_KEY } from "./useUserApiEndpoints";
 
-const updateEndpoint = async ({ uuid, ...params }: UpdateUserApiEndpointParams) => {
+const updateEndpoint = async ({
+  uuid,
+  ...params
+}: UpdateUserApiEndpointParams) => {
   const { data } = await axiosClient.put<
     ApiResponse<{ endpoint: UserApiEndpoint }>
   >(`/v1/user/api-endpoints/${uuid}`, params, {

--- a/src/api/user-api-endpoints/useUserApiEndpoints.ts
+++ b/src/api/user-api-endpoints/useUserApiEndpoints.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { axiosClient } from "@/client/axios.client";
+import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
+import type { ApiResponse } from "@/types/api.types";
+import type { UserApiEndpoint } from "@/types/user-api-endpoint.types";
+import useAuth from "@/hooks/useAuth";
+
+export const USER_API_ENDPOINTS_QUERY_KEY = "userApiEndpoints";
+
+const getEndpoints = () => {
+  return async () =>
+    axiosClient
+      .get("/v1/user/api-endpoints", {
+        headers: getRequestHeaders({ contentType: ContentType.json }),
+      })
+      .then((res) => res.data);
+};
+
+export const useUserApiEndpoints = () => {
+  const { user } = useAuth();
+  return useQuery<ApiResponse<{ endpoints: UserApiEndpoint[] }>, Error>(
+    [USER_API_ENDPOINTS_QUERY_KEY],
+    getEndpoints(),
+    { enabled: Boolean(user) },
+  );
+};

--- a/src/components/pages/profile/add-endpoint-modal.styled.tsx
+++ b/src/components/pages/profile/add-endpoint-modal.styled.tsx
@@ -1,0 +1,177 @@
+import styled from "styled-components";
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`;
+
+export const ModalContent = styled.div`
+  background: #0d0d0d;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  width: 480px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 1.5rem;
+`;
+
+export const ModalTitle = styled.h3`
+  font-size: 1rem;
+  color: ${(p) => p.theme.textPrimaryColor};
+  margin: 0 0 1.25rem;
+`;
+
+export const PresetCard = styled.div<{ $selected?: boolean }>`
+  border: 1px solid ${(p) => (p.$selected ? "#c9a227" : "#333")};
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  &:hover {
+    border-color: #555;
+  }
+`;
+
+export const PresetIcon = styled.div<{ $color: string }>`
+  width: 2.25rem;
+  height: 2.25rem;
+  background: ${(p) => p.$color};
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${(p) => p.theme.textPrimaryColor};
+  flex-shrink: 0;
+`;
+
+export const PresetInfo = styled.div`
+  flex: 1;
+`;
+
+export const PresetName = styled.div`
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: ${(p) => p.theme.textPrimaryColor};
+`;
+
+export const PresetDesc = styled.div`
+  font-size: 0.7rem;
+  color: ${(p) => p.theme.textSecondaryColor || "#888"};
+  margin-top: 0.125rem;
+`;
+
+export const PresetCaps = styled.div`
+  font-size: 0.7rem;
+  color: #4ade80;
+`;
+
+export const FormGroup = styled.div`
+  margin-bottom: 1rem;
+`;
+
+export const FormLabel = styled.label`
+  display: block;
+  font-size: 0.7rem;
+  color: ${(p) => p.theme.textSecondaryColor || "#888"};
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.375rem;
+`;
+
+export const FormInput = styled.input`
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: ${(p) => p.theme.textPrimaryColor};
+  padding: 0.625rem 0.75rem;
+  font-size: 0.8rem;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #c9a227;
+  }
+
+  &::placeholder {
+    color: #555;
+  }
+`;
+
+export const FormHint = styled.div`
+  font-size: 0.7rem;
+  color: #666;
+  margin-top: 0.375rem;
+
+  a {
+    color: #c9a227;
+    text-decoration: none;
+  }
+`;
+
+export const FormError = styled.div`
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-top: 0.375rem;
+`;
+
+export const ButtonRow = styled.div`
+  display: flex;
+  gap: 0.625rem;
+  justify-content: flex-end;
+  margin-top: 1.25rem;
+`;
+
+export const ModalButton = styled.button<{
+  $accent?: boolean;
+  $outline?: boolean;
+}>`
+  background: ${(p) =>
+    p.$accent ? "#c9a227" : p.$outline ? "transparent" : "#1a1a1a"};
+  color: ${(p) => (p.$accent ? "#0d0d0d" : p.$outline ? "#aaa" : "#aaa")};
+  border: 1px solid ${(p) => (p.$accent ? "#c9a227" : "#333")};
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-weight: ${(p) => (p.$accent ? 500 : 400)};
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+export const CustomFields = styled.div`
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #2a2a2a;
+`;
+
+export const FormSelect = styled.select`
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: ${(p) => p.theme.textPrimaryColor};
+  padding: 0.625rem 0.75rem;
+  font-size: 0.8rem;
+  box-sizing: border-box;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: #c9a227;
+  }
+`;

--- a/src/components/pages/profile/add-endpoint-modal.tsx
+++ b/src/components/pages/profile/add-endpoint-modal.tsx
@@ -103,16 +103,6 @@ export function AddEndpointModal({
     setStep("form");
   }, []);
 
-  const handleSelectCustom = useCallback(() => {
-    setSelectedPreset(null);
-    setIsCustom(true);
-    setName("");
-    setEndpointUrl("");
-    setModelId("");
-    setProviderType("openai");
-    setStep("form");
-  }, []);
-
   const handleSave = useCallback(async () => {
     setError("");
 
@@ -228,15 +218,6 @@ export function AddEndpointModal({
                 </PresetCaps>
               </PresetCard>
             ))}
-
-            <PresetCard onClick={handleSelectCustom} style={{ opacity: 0.7 }}>
-              <PresetIcon $color="#2a2a2a">⚙</PresetIcon>
-              <PresetInfo>
-                <PresetName>Custom OpenAI-Compatible</PresetName>
-                <PresetDesc>Any endpoint that speaks OpenAI format</PresetDesc>
-              </PresetInfo>
-              <PresetCaps style={{ color: "#888" }}>manual</PresetCaps>
-            </PresetCard>
           </>
         ) : (
           <>

--- a/src/components/pages/profile/add-endpoint-modal.tsx
+++ b/src/components/pages/profile/add-endpoint-modal.tsx
@@ -233,9 +233,7 @@ export function AddEndpointModal({
               <PresetIcon $color="#2a2a2a">⚙</PresetIcon>
               <PresetInfo>
                 <PresetName>Custom OpenAI-Compatible</PresetName>
-                <PresetDesc>
-                  Any endpoint that speaks OpenAI format
-                </PresetDesc>
+                <PresetDesc>Any endpoint that speaks OpenAI format</PresetDesc>
               </PresetInfo>
               <PresetCaps style={{ color: "#888" }}>manual</PresetCaps>
             </PresetCard>
@@ -291,9 +289,7 @@ export function AddEndpointModal({
                   <FormSelect
                     value={providerType}
                     onChange={(e) =>
-                      setProviderType(
-                        e.target.value as EndpointProviderType,
-                      )
+                      setProviderType(e.target.value as EndpointProviderType)
                     }
                   >
                     <option value="openai">OpenAI-Compatible</option>

--- a/src/components/pages/profile/add-endpoint-modal.tsx
+++ b/src/components/pages/profile/add-endpoint-modal.tsx
@@ -1,0 +1,345 @@
+import { useState, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useCreateUserApiEndpoint } from "@/api/user-api-endpoints/useCreateUserApiEndpoint";
+import { useUpdateUserApiEndpoint } from "@/api/user-api-endpoints/useUpdateUserApiEndpoint";
+import { ENDPOINT_PRESETS } from "@/constants/endpoint-presets";
+import { toast } from "react-toastify";
+import type { EndpointPreset } from "@/constants/endpoint-presets";
+import type {
+  UserApiEndpoint,
+  EndpointProviderType,
+} from "@/types/user-api-endpoint.types";
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalTitle,
+  PresetCard,
+  PresetIcon,
+  PresetInfo,
+  PresetName,
+  PresetDesc,
+  PresetCaps,
+  FormGroup,
+  FormLabel,
+  FormInput,
+  FormSelect,
+  FormHint,
+  FormError,
+  ButtonRow,
+  ModalButton,
+  CustomFields,
+} from "./add-endpoint-modal.styled";
+
+const PROVIDER_COLORS: Record<string, string> = {
+  fal: "#1a1a2e",
+  openai: "#1a2e1a",
+};
+
+interface AddEndpointModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  editingEndpoint: UserApiEndpoint | null;
+}
+
+export function AddEndpointModal({
+  isOpen,
+  onClose,
+  editingEndpoint,
+}: AddEndpointModalProps) {
+  const createMutation = useCreateUserApiEndpoint();
+  const updateMutation = useUpdateUserApiEndpoint();
+
+  const [step, setStep] = useState<"preset" | "form">(
+    editingEndpoint ? "form" : "preset",
+  );
+  const [selectedPreset, setSelectedPreset] = useState<EndpointPreset | null>(
+    null,
+  );
+  const [isCustom, setIsCustom] = useState(false);
+
+  const [name, setName] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [endpointUrl, setEndpointUrl] = useState("");
+  const [modelId, setModelId] = useState("");
+  const [providerType, setProviderType] =
+    useState<EndpointProviderType>("openai");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      if (editingEndpoint) {
+        setStep("form");
+        setName(editingEndpoint.name);
+        setApiKey("");
+        setEndpointUrl(editingEndpoint.endpointUrl);
+        setModelId(editingEndpoint.modelId);
+        setProviderType(editingEndpoint.providerType);
+        const preset = ENDPOINT_PRESETS.find(
+          (p) => p.id === editingEndpoint.presetId,
+        );
+        setSelectedPreset(preset ?? null);
+        setIsCustom(!preset);
+      } else {
+        setStep("preset");
+        setSelectedPreset(null);
+        setIsCustom(false);
+        setName("");
+        setApiKey("");
+        setEndpointUrl("");
+        setModelId("");
+        setProviderType("openai");
+      }
+      setError("");
+    }
+  }, [isOpen, editingEndpoint]);
+
+  const handleSelectPreset = useCallback((preset: EndpointPreset) => {
+    setSelectedPreset(preset);
+    setIsCustom(false);
+    setName(preset.name);
+    setEndpointUrl(preset.endpointUrl);
+    setModelId(preset.modelId);
+    setProviderType(preset.providerType);
+    setStep("form");
+  }, []);
+
+  const handleSelectCustom = useCallback(() => {
+    setSelectedPreset(null);
+    setIsCustom(true);
+    setName("");
+    setEndpointUrl("");
+    setModelId("");
+    setProviderType("openai");
+    setStep("form");
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setError("");
+
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (!editingEndpoint && !apiKey.trim()) {
+      setError("API key is required");
+      return;
+    }
+    if (isCustom && !endpointUrl.trim()) {
+      setError("Endpoint URL is required");
+      return;
+    }
+    if (isCustom && !modelId.trim()) {
+      setError("Model ID is required");
+      return;
+    }
+
+    if (editingEndpoint) {
+      updateMutation.mutate(
+        {
+          uuid: editingEndpoint.uuid,
+          name: name.trim(),
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+          ...(isCustom
+            ? { endpointUrl: endpointUrl.trim(), modelId: modelId.trim() }
+            : {}),
+        },
+        {
+          onSuccess: () => {
+            toast.success("Endpoint updated");
+            onClose();
+          },
+          onError: (err) => {
+            setError(err.message || "Failed to update endpoint");
+          },
+        },
+      );
+    } else {
+      const preset = selectedPreset;
+      createMutation.mutate(
+        {
+          name: name.trim(),
+          providerType: isCustom ? providerType : preset!.providerType,
+          presetId: preset?.id ?? "custom",
+          endpointUrl: isCustom ? endpointUrl.trim() : preset!.endpointUrl,
+          apiKey: apiKey.trim(),
+          modelId: isCustom ? modelId.trim() : preset!.modelId,
+          capabilities: preset?.capabilities ?? {
+            textToImage: true,
+            imageToImage: true,
+            sizes: ["1024x1024"],
+          },
+        },
+        {
+          onSuccess: () => {
+            toast.success("Endpoint added");
+            onClose();
+          },
+          onError: (err) => {
+            setError(err.message || "Failed to create endpoint");
+          },
+        },
+      );
+    }
+  }, [
+    name,
+    apiKey,
+    endpointUrl,
+    modelId,
+    providerType,
+    isCustom,
+    selectedPreset,
+    editingEndpoint,
+    createMutation,
+    updateMutation,
+    onClose,
+  ]);
+
+  if (!isOpen) return null;
+
+  const isSaving = createMutation.isLoading || updateMutation.isLoading;
+
+  return createPortal(
+    <ModalOverlay onClick={onClose}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        {step === "preset" ? (
+          <>
+            <ModalTitle>Add Endpoint — Choose Service</ModalTitle>
+            {ENDPOINT_PRESETS.map((preset) => (
+              <PresetCard
+                key={preset.id}
+                onClick={() => handleSelectPreset(preset)}
+              >
+                <PresetIcon
+                  $color={PROVIDER_COLORS[preset.providerType] ?? "#2a2a2a"}
+                >
+                  {preset.providerType === "fal" ? "F" : "O"}
+                </PresetIcon>
+                <PresetInfo>
+                  <PresetName>{preset.name}</PresetName>
+                  <PresetDesc>{preset.description}</PresetDesc>
+                </PresetInfo>
+                <PresetCaps>
+                  {[
+                    preset.capabilities.textToImage && "t2i",
+                    preset.capabilities.imageToImage && "i2i",
+                  ]
+                    .filter(Boolean)
+                    .join(", ")}
+                </PresetCaps>
+              </PresetCard>
+            ))}
+
+            <PresetCard onClick={handleSelectCustom} style={{ opacity: 0.7 }}>
+              <PresetIcon $color="#2a2a2a">⚙</PresetIcon>
+              <PresetInfo>
+                <PresetName>Custom OpenAI-Compatible</PresetName>
+                <PresetDesc>
+                  Any endpoint that speaks OpenAI format
+                </PresetDesc>
+              </PresetInfo>
+              <PresetCaps style={{ color: "#888" }}>manual</PresetCaps>
+            </PresetCard>
+          </>
+        ) : (
+          <>
+            <ModalTitle>
+              {editingEndpoint ? "Edit Endpoint" : "Add Endpoint"}
+            </ModalTitle>
+
+            <FormGroup>
+              <FormLabel>Display Name</FormLabel>
+              <FormInput
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Flux Schnell"
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <FormLabel>API Key</FormLabel>
+              <FormInput
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={
+                  editingEndpoint
+                    ? `Current: ••••••••${editingEndpoint.apiKeyLastFour}`
+                    : "Paste your API key"
+                }
+              />
+              <FormHint>
+                Your key is encrypted at rest and never shared.
+                {selectedPreset && (
+                  <>
+                    {" "}
+                    <a
+                      href={selectedPreset.keyUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Get a key →
+                    </a>
+                  </>
+                )}
+              </FormHint>
+            </FormGroup>
+
+            {isCustom && (
+              <CustomFields>
+                <FormGroup>
+                  <FormLabel>Provider Type</FormLabel>
+                  <FormSelect
+                    value={providerType}
+                    onChange={(e) =>
+                      setProviderType(
+                        e.target.value as EndpointProviderType,
+                      )
+                    }
+                  >
+                    <option value="openai">OpenAI-Compatible</option>
+                    <option value="fal">FAL</option>
+                  </FormSelect>
+                </FormGroup>
+
+                <FormGroup>
+                  <FormLabel>Endpoint URL</FormLabel>
+                  <FormInput
+                    value={endpointUrl}
+                    onChange={(e) => setEndpointUrl(e.target.value)}
+                    placeholder="https://api.example.com/v1"
+                  />
+                </FormGroup>
+
+                <FormGroup>
+                  <FormLabel>Model ID</FormLabel>
+                  <FormInput
+                    value={modelId}
+                    onChange={(e) => setModelId(e.target.value)}
+                    placeholder="model-name"
+                  />
+                </FormGroup>
+              </CustomFields>
+            )}
+
+            {error && <FormError>{error}</FormError>}
+
+            <ButtonRow>
+              {!editingEndpoint && (
+                <ModalButton onClick={() => setStep("preset")}>
+                  Back
+                </ModalButton>
+              )}
+              <ModalButton $outline onClick={onClose}>
+                Cancel
+              </ModalButton>
+              <ModalButton $accent onClick={handleSave} disabled={isSaving}>
+                {isSaving ? "Saving..." : "Save"}
+              </ModalButton>
+            </ButtonRow>
+          </>
+        )}
+      </ModalContent>
+    </ModalOverlay>,
+    document.body,
+  );
+}

--- a/src/components/pages/profile/api-endpoints-section.styled.tsx
+++ b/src/components/pages/profile/api-endpoints-section.styled.tsx
@@ -106,7 +106,8 @@ export const ActionBtn = styled.button<{ $danger?: boolean }>`
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid #333;
   border-radius: 6px;
-  color: ${(p) => (p.$danger ? "#ef4444" : p.theme.textSecondaryColor || "#aaa")};
+  color: ${(p) =>
+    p.$danger ? "#ef4444" : p.theme.textSecondaryColor || "#aaa"};
   padding: 0.375rem 0.625rem;
   font-size: 0.75rem;
   cursor: pointer;

--- a/src/components/pages/profile/api-endpoints-section.styled.tsx
+++ b/src/components/pages/profile/api-endpoints-section.styled.tsx
@@ -1,0 +1,122 @@
+import styled from "styled-components";
+
+export const SectionContainer = styled.div`
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+`;
+
+export const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+export const SectionTitle = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${(p) => p.theme.textPrimaryColor};
+  margin: 0;
+`;
+
+export const SectionSubtitle = styled.p`
+  font-size: 0.75rem;
+  color: ${(p) => p.theme.textSecondaryColor || "#888"};
+  margin: 0.25rem 0 0;
+`;
+
+export const AddButton = styled.button`
+  background: ${(p) => p.theme.textAccentColor || "#c9a227"};
+  color: #0d0d0d;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+export const EmptyState = styled.div`
+  border: 1px dashed #333;
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  color: ${(p) => p.theme.textSecondaryColor || "#666"};
+  font-size: 0.85rem;
+`;
+
+export const EndpointCard = styled.div`
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const EndpointInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+export const ProviderIcon = styled.div<{ $color: string }>`
+  width: 2rem;
+  height: 2rem;
+  background: ${(p) => p.$color};
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: ${(p) => p.theme.textPrimaryColor};
+`;
+
+export const EndpointName = styled.div`
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: ${(p) => p.theme.textPrimaryColor};
+`;
+
+export const EndpointMeta = styled.div`
+  font-size: 0.7rem;
+  color: ${(p) => p.theme.textSecondaryColor || "#888"};
+  margin-top: 0.125rem;
+`;
+
+export const StatusDot = styled.span<{ $color: string }>`
+  color: ${(p) => p.$color};
+`;
+
+export const EndpointActions = styled.div`
+  display: flex;
+  gap: 0.5rem;
+`;
+
+export const ActionBtn = styled.button<{ $danger?: boolean }>`
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: ${(p) => (p.$danger ? "#ef4444" : p.theme.textSecondaryColor || "#aaa")};
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/src/components/pages/profile/api-endpoints-section.tsx
+++ b/src/components/pages/profile/api-endpoints-section.tsx
@@ -1,0 +1,138 @@
+import { useState, useCallback } from "react";
+import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
+import { useDeleteUserApiEndpoint } from "@/api/user-api-endpoints/useDeleteUserApiEndpoint";
+import { useTestUserApiEndpoint } from "@/api/user-api-endpoints/useTestUserApiEndpoint";
+import { AddEndpointModal } from "./add-endpoint-modal";
+import { toast } from "react-toastify";
+import type { UserApiEndpoint } from "@/types/user-api-endpoint.types";
+import {
+  SectionContainer,
+  SectionHeader,
+  SectionTitle,
+  SectionSubtitle,
+  AddButton,
+  EmptyState,
+  EndpointCard,
+  EndpointInfo,
+  ProviderIcon,
+  EndpointName,
+  EndpointMeta,
+  StatusDot,
+  EndpointActions,
+  ActionBtn,
+} from "./api-endpoints-section.styled";
+
+const PROVIDER_COLORS: Record<string, string> = {
+  fal: "#1a1a2e",
+  openai: "#1a2e1a",
+};
+
+export function ApiEndpointsSection() {
+  const { data } = useUserApiEndpoints();
+  const deleteMutation = useDeleteUserApiEndpoint();
+  const testMutation = useTestUserApiEndpoint();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingEndpoint, setEditingEndpoint] =
+    useState<UserApiEndpoint | null>(null);
+
+  const endpoints = data?.data?.endpoints ?? [];
+
+  const handleDelete = useCallback(
+    (uuid: string) => {
+      if (!confirm("Delete this endpoint?")) return;
+      deleteMutation.mutate(uuid, {
+        onSuccess: () => toast.success("Endpoint deleted"),
+        onError: () => toast.error("Failed to delete endpoint"),
+      });
+    },
+    [deleteMutation],
+  );
+
+  const handleTest = useCallback(
+    (uuid: string) => {
+      testMutation.mutate(uuid, {
+        onSuccess: () => toast.success("Connection successful"),
+        onError: (err) =>
+          toast.error(err.message || "Connection failed"),
+      });
+    },
+    [testMutation],
+  );
+
+  const handleEdit = useCallback((endpoint: UserApiEndpoint) => {
+    setEditingEndpoint(endpoint);
+    setModalOpen(true);
+  }, []);
+
+  const handleCloseModal = useCallback(() => {
+    setModalOpen(false);
+    setEditingEndpoint(null);
+  }, []);
+
+  return (
+    <SectionContainer>
+      <SectionHeader>
+        <div>
+          <SectionTitle>Your API Endpoints</SectionTitle>
+          <SectionSubtitle>
+            Bring your own AI models to the studio
+          </SectionSubtitle>
+        </div>
+        <AddButton onClick={() => setModalOpen(true)}>
+          + Add Endpoint
+        </AddButton>
+      </SectionHeader>
+
+      {endpoints.length === 0 ? (
+        <EmptyState>
+          No endpoints configured.
+          <br />
+          Add an endpoint to use Flux, OpenAI, or other models in the studio.
+        </EmptyState>
+      ) : (
+        endpoints.map((ep) => (
+          <EndpointCard key={ep.uuid}>
+            <EndpointInfo>
+              <ProviderIcon
+                $color={PROVIDER_COLORS[ep.providerType] ?? "#2a2a2a"}
+              >
+                {ep.providerType === "fal" ? "F" : "O"}
+              </ProviderIcon>
+              <div>
+                <EndpointName>{ep.name}</EndpointName>
+                <EndpointMeta>
+                  <StatusDot $color="#4ade80">●</StatusDot> Key: ...{ep.apiKeyLastFour}
+                  &nbsp;·&nbsp;
+                  {[
+                    ep.capabilities.textToImage && "t2i",
+                    ep.capabilities.imageToImage && "i2i",
+                  ]
+                    .filter(Boolean)
+                    .join(", ")}
+                </EndpointMeta>
+              </div>
+            </EndpointInfo>
+            <EndpointActions>
+              <ActionBtn
+                onClick={() => handleTest(ep.uuid)}
+                disabled={testMutation.isLoading}
+              >
+                Test
+              </ActionBtn>
+              <ActionBtn onClick={() => handleEdit(ep)}>Edit</ActionBtn>
+              <ActionBtn $danger onClick={() => handleDelete(ep.uuid)}>
+                Delete
+              </ActionBtn>
+            </EndpointActions>
+          </EndpointCard>
+        ))
+      )}
+
+      <AddEndpointModal
+        isOpen={modalOpen}
+        onClose={handleCloseModal}
+        editingEndpoint={editingEndpoint}
+      />
+    </SectionContainer>
+  );
+}

--- a/src/components/pages/profile/api-endpoints-section.tsx
+++ b/src/components/pages/profile/api-endpoints-section.tsx
@@ -3,6 +3,8 @@ import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoint
 import { useDeleteUserApiEndpoint } from "@/api/user-api-endpoints/useDeleteUserApiEndpoint";
 import { useTestUserApiEndpoint } from "@/api/user-api-endpoints/useTestUserApiEndpoint";
 import { AddEndpointModal } from "./add-endpoint-modal";
+import { ConfirmModal } from "@/components/modals/confirm.modal";
+import { Text } from "@/components/shared";
 import { toast } from "react-toastify";
 import type { UserApiEndpoint } from "@/types/user-api-endpoint.types";
 import {
@@ -34,19 +36,31 @@ export function ApiEndpointsSection() {
   const [modalOpen, setModalOpen] = useState(false);
   const [editingEndpoint, setEditingEndpoint] =
     useState<UserApiEndpoint | null>(null);
+  const [deletingUuid, setDeletingUuid] = useState<string | null>(null);
 
   const endpoints = data?.data?.endpoints ?? [];
 
-  const handleDelete = useCallback(
-    (uuid: string) => {
-      if (!confirm("Delete this endpoint?")) return;
-      deleteMutation.mutate(uuid, {
-        onSuccess: () => toast.success("Endpoint deleted"),
-        onError: () => toast.error("Failed to delete endpoint"),
-      });
-    },
-    [deleteMutation],
-  );
+  const handleDelete = useCallback((uuid: string) => {
+    setDeletingUuid(uuid);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setDeletingUuid(null);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!deletingUuid) return;
+    deleteMutation.mutate(deletingUuid, {
+      onSuccess: () => {
+        toast.success("Endpoint deleted");
+        setDeletingUuid(null);
+      },
+      onError: () => {
+        toast.error("Failed to delete endpoint");
+        setDeletingUuid(null);
+      },
+    });
+  }, [deleteMutation, deletingUuid]);
 
   const handleTest = useCallback(
     (uuid: string) => {
@@ -132,6 +146,17 @@ export function ApiEndpointsSection() {
         isOpen={modalOpen}
         onClose={handleCloseModal}
         editingEndpoint={editingEndpoint}
+      />
+
+      <ConfirmModal
+        isOpen={deletingUuid !== null}
+        onCancel={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+        confirmButtonType="danger"
+        confirmText="Delete"
+        isConfirming={deleteMutation.isLoading}
+        title="Delete endpoint"
+        text={<Text>Delete this endpoint? This cannot be undone.</Text>}
       />
     </SectionContainer>
   );

--- a/src/components/pages/profile/api-endpoints-section.tsx
+++ b/src/components/pages/profile/api-endpoints-section.tsx
@@ -66,8 +66,7 @@ export function ApiEndpointsSection() {
     (uuid: string) => {
       testMutation.mutate(uuid, {
         onSuccess: () => toast.success("Connection successful"),
-        onError: (err) =>
-          toast.error(err.message || "Connection failed"),
+        onError: (err) => toast.error(err.message || "Connection failed"),
       });
     },
     [testMutation],
@@ -92,9 +91,7 @@ export function ApiEndpointsSection() {
             Bring your own AI models to the studio
           </SectionSubtitle>
         </div>
-        <AddButton onClick={() => setModalOpen(true)}>
-          + Add Endpoint
-        </AddButton>
+        <AddButton onClick={() => setModalOpen(true)}>+ Add Endpoint</AddButton>
       </SectionHeader>
 
       {endpoints.length === 0 ? (
@@ -115,7 +112,8 @@ export function ApiEndpointsSection() {
               <div>
                 <EndpointName>{ep.name}</EndpointName>
                 <EndpointMeta>
-                  <StatusDot $color="#4ade80">●</StatusDot> Key: ...{ep.apiKeyLastFour}
+                  <StatusDot $color="#4ade80">●</StatusDot> Key: ...
+                  {ep.apiKeyLastFour}
                   &nbsp;·&nbsp;
                   {[
                     ep.capabilities.textToImage && "t2i",

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -289,6 +289,16 @@ export const FlowBuilder: React.FC = () => {
       const I2I_VARIATION_COUNT = 4;
       const baseName = keyframe.name || "frame";
 
+      // Distinct per-candidate prompts so the four i2i outputs actually differ
+      // from one another. Using the keyframe name (the old behaviour) gave the
+      // model no variation direction, so it just reproduced the source image.
+      const VARIATION_PROMPTS = [
+        "Reinterpret this scene as a vivid impressionist oil painting, keeping the same subject and composition.",
+        "Reimagine this scene as a moody, cinematic night shot with dramatic lighting, same subject and composition.",
+        "Render this scene as a bright, saturated watercolor illustration, same subject and composition.",
+        "Restyle this scene as a warm-toned vintage film photograph with grain, same subject and composition.",
+      ];
+
       // Create candidate keyframes as a GATED staging area: addI2iCandidates
       // flags them so transition derivation skips them — they will not spawn
       // generation jobs until the user accepts one. Patch each in place as its
@@ -312,7 +322,7 @@ export const FlowBuilder: React.FC = () => {
           const algoParams = {
             userEndpointUuid: endpointUuid,
             image: sourceImage,
-            prompt: keyframe.name ?? "",
+            prompt: VARIATION_PROMPTS[i % VARIATION_PROMPTS.length],
             n: 1,
           };
           try {

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -47,7 +47,6 @@ export const FlowBuilder: React.FC = () => {
   const addKeyframe = useFlowStore((s) => s.addKeyframe);
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
-  const setI2iEndpoint = useFlowStore((s) => s.setI2iEndpoint);
   const addI2iCandidates = useFlowStore((s) => s.addI2iCandidates);
   const acceptI2iCandidate = useFlowStore((s) => s.acceptI2iCandidate);
   const discardI2iCandidate = useFlowStore((s) => s.discardI2iCandidate);
@@ -153,28 +152,25 @@ export const FlowBuilder: React.FC = () => {
 
   const handleI2iVariation = useCallback(
     async (keyframe: FlowKeyframe) => {
-      // Resolve which i2i endpoint to use. Prefer the one already selected this
-      // session; otherwise auto-select (single -> that one, multiple -> first).
-      const endpoints = i2iEndpoints;
-      if (endpoints.length === 0) return;
+      // Route by the Variation Settings "Model" dropdown: a BYO i2i endpoint
+      // (i2iEndpointUuid set) runs image-to-image off the source frame; with no
+      // endpoint selected we fall back to the built-in text-to-image model.
+      const endpointUuid = useFlowStore.getState().i2iEndpointUuid;
+      const i2iEndpoint = endpointUuid
+        ? i2iEndpoints.find((ep) => ep.uuid === endpointUuid)
+        : undefined;
 
-      let endpointUuid = useFlowStore.getState().i2iEndpointUuid;
-      if (!endpointUuid || !endpoints.some((ep) => ep.uuid === endpointUuid)) {
-        // TODO: inline picker when multiple i2i endpoints are configured.
-        endpointUuid = endpoints[0].uuid;
-        setI2iEndpoint(endpointUuid);
-      }
-
-      // Source image — the worker adapter DOWNLOADS the `image` field as a
+      // Source image — the i2i worker adapter DOWNLOADS the `image` field as a
       // fetchable URL, so we must send the presigned imageUrl, NOT a Dream UUID
-      // (a UUID is not fetchable). Skip if there's no usable URL.
+      // (a UUID is not fetchable). Required only for the i2i route.
       const sourceImage = keyframe.imageUrl;
-      if (!sourceImage) return;
+      if (i2iEndpoint && !sourceImage) return;
 
       // Read Variation Settings at call time (NOT via React subscription) to
       // keep the callback identity stable across settings keystrokes.
       const {
         imagePrompt,
+        imageGenParams,
         variationPresetId,
         variationCustomPrompt,
         variationSeed,
@@ -250,13 +246,21 @@ export const FlowBuilder: React.FC = () => {
       const headers = getRequestHeaders({ contentType: ContentType.json });
       void Promise.allSettled(
         candidates.map(async ({ id }, i) => {
-          const algoParams = {
-            userEndpointUuid: endpointUuid,
-            image: sourceImage,
-            prompt: `${basePrompt}, ${modifiers[i % modifiers.length]}`,
-            seed: baseSeed,
-            n: 1,
-          };
+          const prompt = `${basePrompt}, ${modifiers[i % modifiers.length]}`;
+          const algoParams = i2iEndpoint
+            ? {
+                userEndpointUuid: i2iEndpoint.uuid,
+                image: sourceImage,
+                prompt,
+                seed: baseSeed,
+                n: 1,
+              }
+            : {
+                infinidream_algorithm: imageGenParams.model,
+                prompt,
+                size: imageGenParams.size,
+                seed: baseSeed,
+              };
           try {
             const { data } = await axiosClient.post(
               "/v1/dream",
@@ -287,7 +291,7 @@ export const FlowBuilder: React.FC = () => {
         }),
       );
     },
-    [i2iEndpoints, setI2iEndpoint, addI2iCandidates, updateKeyframe],
+    [i2iEndpoints, addI2iCandidates, updateKeyframe],
   );
 
   const handleAcceptI2iCandidate = useCallback(

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -3,12 +3,15 @@ import Bugsnag from "@bugsnag/js";
 import { v4 as uuidv4 } from "uuid";
 import styled from "styled-components";
 import { useFlowStore } from "@/stores/flow.store";
+import { useStudioStore } from "@/stores/studio.store";
 import { FLOW } from "@/constants/flow-theme.constants";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
 import type { FlowKeyframe } from "@/types/flow.types";
+import { getVariationPreset } from "../constants/variation-presets";
+import { expandPrompt } from "../utils/expand-prompt";
 import { KeyframeStrip } from "./keyframe-strip";
 import { TransitionSettingsPanel } from "./transition-settings-panel";
 import { VariationSettingsPanel } from "./variation-settings-panel";
@@ -149,7 +152,7 @@ export const FlowBuilder: React.FC = () => {
   );
 
   const handleI2iVariation = useCallback(
-    (keyframe: FlowKeyframe) => {
+    async (keyframe: FlowKeyframe) => {
       // Resolve which i2i endpoint to use. Prefer the one already selected this
       // session; otherwise auto-select (single -> that one, multiple -> first).
       const endpoints = i2iEndpoints;
@@ -168,50 +171,97 @@ export const FlowBuilder: React.FC = () => {
       const sourceImage = keyframe.imageUrl;
       if (!sourceImage) return;
 
-      const I2I_VARIATION_COUNT = 4;
+      // Read Variation Settings at call time (NOT via React subscription) to
+      // keep the callback identity stable across settings keystrokes.
+      const {
+        imagePrompt,
+        variationPresetId,
+        variationCustomPrompt,
+        variationSeed,
+      } = useStudioStore.getState();
+
+      // Custom prompts (Customize section) override the preset when present:
+      // split per line and apply {a|b|c} expansion to each line. Falls back to
+      // the selected preset's modifiers. Capped at 8 (matches the panel).
+      const customModifiers = variationCustomPrompt
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .flatMap((line) => expandPrompt(line));
+      const modifiers = (
+        customModifiers.length > 0
+          ? customModifiers
+          : getVariationPreset(variationPresetId).modifiers
+      ).slice(0, 8);
+
+      const VARIATION_COUNT = modifiers.length;
+      if (VARIATION_COUNT === 0) return;
+
       const baseName = keyframe.name || "frame";
 
-      // Distinct per-candidate prompts so the four i2i outputs actually differ
-      // from one another. Using the keyframe name (the old behaviour) gave the
-      // model no variation direction, so it just reproduced the source image.
-      const VARIATION_PROMPTS = [
-        "Reinterpret this scene as a vivid impressionist oil painting, keeping the same subject and composition.",
-        "Reimagine this scene as a moody, cinematic night shot with dramatic lighting, same subject and composition.",
-        "Render this scene as a bright, saturated watercolor illustration, same subject and composition.",
-        "Restyle this scene as a warm-toned vintage film photograph with grain, same subject and composition.",
-      ];
+      // The user's seed is the anchor (stable across a batch — variation comes
+      // from the prompt). Each +More batch is offset by the count of candidates
+      // already staged for this parent, so +More yields NEW images while
+      // staying reproducible.
+      const existingCount = useFlowStore
+        .getState()
+        .keyframes.filter((kf) => kf.i2iParentId === keyframe.id).length;
+      const baseSeed = variationSeed + existingCount;
 
       // Create candidate keyframes as a GATED staging area: addI2iCandidates
       // flags them so transition derivation skips them — they will not spawn
       // generation jobs until the user accepts one. Patch each in place as its
       // generation request settles.
-      const candidates = Array.from(
-        { length: I2I_VARIATION_COUNT },
-        (_, i) => ({
-          id: uuidv4(),
-          imageUrl: keyframe.imageUrl,
-          name: `${baseName} · variation ${i + 1}`,
-          uploadStatus: "uploading" as const,
-          uploadProgress: 0,
-        }),
-      );
+      const candidates = Array.from({ length: VARIATION_COUNT }, (_, i) => ({
+        id: uuidv4(),
+        imageUrl: keyframe.imageUrl,
+        name: `${baseName} · variation ${existingCount + i + 1}`,
+        uploadStatus: "uploading" as const,
+        uploadProgress: 0,
+      }));
       addI2iCandidates(keyframe.id, candidates);
 
+      // Use the SOURCE image's own prompt as the base so variations stay
+      // on-theme. The original prompt is stored as algoParams JSON on the dream;
+      // fall back to the studio prompt, then the keyframe name.
+      let originalPrompt = "";
+      if (keyframe.dreamUuid) {
+        try {
+          const { data } = await axiosClient.get(
+            `/v1/dream/${keyframe.dreamUuid}`,
+          );
+          const rawPrompt = data?.data?.dream?.prompt;
+          if (typeof rawPrompt === "string" && rawPrompt) {
+            try {
+              originalPrompt = JSON.parse(rawPrompt)?.prompt || "";
+            } catch {
+              originalPrompt = rawPrompt;
+            }
+          }
+        } catch (err) {
+          Bugsnag.notify(err as Error);
+        }
+      }
+      const basePrompt = originalPrompt || imagePrompt || baseName;
+
       // Fire all variation generations concurrently (no sequential await loop).
+      // Layer a variation modifier onto the source prompt so the set is
+      // meaningfully different, with a STABLE seed across the batch.
       const headers = getRequestHeaders({ contentType: ContentType.json });
       void Promise.allSettled(
         candidates.map(async ({ id }, i) => {
           const algoParams = {
             userEndpointUuid: endpointUuid,
             image: sourceImage,
-            prompt: VARIATION_PROMPTS[i % VARIATION_PROMPTS.length],
+            prompt: `${basePrompt}, ${modifiers[i % modifiers.length]}`,
+            seed: baseSeed,
             n: 1,
           };
           try {
             const { data } = await axiosClient.post(
               "/v1/dream",
               {
-                name: `${baseName} · variation ${i + 1}`,
+                name: `${baseName} · variation ${existingCount + i + 1}`,
                 prompt: JSON.stringify(algoParams),
                 description: "Studio i2i variation",
               },

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -242,7 +242,8 @@ export const FlowBuilder: React.FC = () => {
 
       // Fire all variation generations concurrently (no sequential await loop).
       // Layer a variation modifier onto the source prompt so the set is
-      // meaningfully different, with a STABLE seed across the batch.
+      // meaningfully different, with a STABLE seed across the batch (variation
+      // comes from the prompt, not seed jitter — keeps results reproducible).
       const headers = getRequestHeaders({ contentType: ContentType.json });
       void Promise.allSettled(
         candidates.map(async ({ id }, i) => {

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -275,17 +275,21 @@ export const FlowBuilder: React.FC = () => {
             if (!dreamUuid) {
               throw new Error("No dream UUID returned from API");
             }
-            // Settle the placeholder into a real, queued keyframe.
+            // Settle the placeholder into a real, queued candidate. i2iStatus
+            // marks it pending so job progress polls the dream and swaps in this
+            // candidate's distinct result once it finishes generating.
             updateKeyframe(id, {
               dreamUuid,
               uploadStatus: undefined,
               uploadProgress: undefined,
+              i2iStatus: "queue",
             });
           } catch (err) {
             Bugsnag.notify(err as Error);
             updateKeyframe(id, {
               uploadStatus: "failed",
               uploadProgress: undefined,
+              i2iStatus: "failed",
             });
           }
         }),

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -48,6 +48,9 @@ export const FlowBuilder: React.FC = () => {
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
   const setI2iEndpoint = useFlowStore((s) => s.setI2iEndpoint);
+  const addI2iCandidates = useFlowStore((s) => s.addI2iCandidates);
+  const acceptI2iCandidate = useFlowStore((s) => s.acceptI2iCandidate);
+  const discardI2iCandidate = useFlowStore((s) => s.discardI2iCandidate);
 
   // User i2i endpoints (BYO key) for image-to-image variations.
   const { data: endpointsData } = useUserApiEndpoints();
@@ -277,34 +280,35 @@ export const FlowBuilder: React.FC = () => {
         setI2iEndpoint(endpointUuid);
       }
 
-      // Source image — prefer the backend dream UUID, fall back to the URL.
-      const sourceImage = keyframe.dreamUuid ?? keyframe.imageUrl;
+      // Source image — the worker adapter DOWNLOADS the `image` field as a
+      // fetchable URL, so we must send the presigned imageUrl, NOT a Dream UUID
+      // (a UUID is not fetchable). Skip if there's no usable URL.
+      const sourceImage = keyframe.imageUrl;
       if (!sourceImage) return;
 
       const I2I_VARIATION_COUNT = 4;
       const baseName = keyframe.name || "frame";
 
-      // Create placeholder candidate keyframes up-front so the user sees them
-      // immediately, then patch each in place as its generation request settles.
+      // Create candidate keyframes as a GATED staging area: addI2iCandidates
+      // flags them so transition derivation skips them — they will not spawn
+      // generation jobs until the user accepts one. Patch each in place as its
+      // generation request settles.
       const candidates = Array.from(
         { length: I2I_VARIATION_COUNT },
-        (_, i) => {
-          const id = uuidv4();
-          addKeyframe({
-            id,
-            imageUrl: keyframe.imageUrl,
-            name: `${baseName} · variation ${i + 1}`,
-            uploadStatus: "uploading",
-            uploadProgress: 0,
-          });
-          return id;
-        },
+        (_, i) => ({
+          id: uuidv4(),
+          imageUrl: keyframe.imageUrl,
+          name: `${baseName} · variation ${i + 1}`,
+          uploadStatus: "uploading" as const,
+          uploadProgress: 0,
+        }),
       );
+      addI2iCandidates(keyframe.id, candidates);
 
       // Fire all variation generations concurrently (no sequential await loop).
       const headers = getRequestHeaders({ contentType: ContentType.json });
       void Promise.allSettled(
-        candidates.map(async (id, i) => {
+        candidates.map(async ({ id }, i) => {
           const algoParams = {
             userEndpointUuid: endpointUuid,
             image: sourceImage,
@@ -341,7 +345,21 @@ export const FlowBuilder: React.FC = () => {
         }),
       );
     },
-    [i2iEndpoints, setI2iEndpoint, addKeyframe, updateKeyframe],
+    [i2iEndpoints, setI2iEndpoint, addI2iCandidates, updateKeyframe],
+  );
+
+  const handleAcceptI2iCandidate = useCallback(
+    (keyframe: FlowKeyframe) => {
+      acceptI2iCandidate(keyframe.id);
+    },
+    [acceptI2iCandidate],
+  );
+
+  const handleDiscardI2iCandidate = useCallback(
+    (keyframe: FlowKeyframe) => {
+      discardI2iCandidate(keyframe.id);
+    },
+    [discardI2iCandidate],
   );
 
   const handleAddFromPlaylist = useCallback(() => {
@@ -367,6 +385,8 @@ export const FlowBuilder: React.FC = () => {
         onRequestVariations={handleKeyframeVariations}
         onOpenVariationLightbox={setVariationLightboxIndex}
         onRequestI2iVariation={handleI2iVariation}
+        onAcceptI2iCandidate={handleAcceptI2iCandidate}
+        onDiscardI2iCandidate={handleDiscardI2iCandidate}
       />
 
       <TransitionSettingsPanel

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -3,15 +3,12 @@ import Bugsnag from "@bugsnag/js";
 import { v4 as uuidv4 } from "uuid";
 import styled from "styled-components";
 import { useFlowStore } from "@/stores/flow.store";
-import { useStudioStore } from "@/stores/studio.store";
 import { FLOW } from "@/constants/flow-theme.constants";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
-import type { VariationCandidate, FlowKeyframe } from "@/types/flow.types";
-import { getVariationPreset } from "../constants/variation-presets";
-import { expandPrompt } from "../utils/expand-prompt";
+import type { FlowKeyframe } from "@/types/flow.types";
 import { KeyframeStrip } from "./keyframe-strip";
 import { TransitionSettingsPanel } from "./transition-settings-panel";
 import { VariationSettingsPanel } from "./variation-settings-panel";
@@ -140,121 +137,6 @@ export const FlowBuilder: React.FC = () => {
     },
     [addKeyframe, updateKeyframe, removeKeyframe, uploadDream],
   );
-
-  const handleKeyframeVariations = useCallback(async (keyframeId: string) => {
-    // Read image generation settings at call time (NOT via React subscription)
-    // to keep callback identity stable across settings keystrokes.
-    const {
-      imagePrompt,
-      imageGenParams,
-      variationPresetId,
-      variationCustomPrompt,
-      variationSeed,
-    } = useStudioStore.getState();
-    const keyframe = useFlowStore
-      .getState()
-      .keyframes.find((kf) => kf.id === keyframeId);
-    if (!keyframe) return;
-
-    // Custom prompt (Customize section) overrides the canned preset: split per
-    // line and apply {a|b|c} expansion to each line. Falls back to the preset.
-    // Custom prompts (Customize section) override the preset when present: split
-    // per line and apply {a|b|c} expansion to each line.
-    const customModifiers = variationCustomPrompt
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .flatMap((line) => expandPrompt(line));
-    const modifiers = (
-      customModifiers.length > 0
-        ? customModifiers
-        : getVariationPreset(variationPresetId).modifiers
-    ).slice(0, 8);
-
-    const VARIATION_COUNT = modifiers.length;
-    // The user's seed is the anchor (stable across a batch — variation comes
-    // from the prompt). Each +More batch is offset by the count of variations
-    // already present, so pressing +More yields NEW images rather than
-    // regenerating the same seed/prompt, while staying reproducible.
-    const existingCount = keyframe.variations?.length ?? 0;
-    const baseSeed = variationSeed + existingCount;
-
-    // Use the SOURCE image's own prompt as the base so variations stay on-theme.
-    // Without this the tool fell back to the keyframe name and produced generic
-    // qwen output. The original prompt is stored as algoParams JSON on the dream.
-    let originalPrompt = "";
-    if (keyframe.dreamUuid) {
-      try {
-        const { data } = await axiosClient.get(
-          `/v1/dream/${keyframe.dreamUuid}`,
-        );
-        const rawPrompt = data?.data?.dream?.prompt;
-        if (typeof rawPrompt === "string" && rawPrompt) {
-          try {
-            originalPrompt = JSON.parse(rawPrompt)?.prompt || "";
-          } catch {
-            originalPrompt = rawPrompt;
-          }
-        }
-      } catch (err) {
-        Bugsnag.notify(err as Error);
-      }
-    }
-    const basePrompt = originalPrompt || imagePrompt || keyframe.name;
-
-    // Layer a canned variation modifier onto the source prompt so the set is
-    // meaningfully different (not generic seed jitter), and keep the seed STABLE
-    // across the set so the difference comes from the prompt.
-    const candidates: VariationCandidate[] = Array.from(
-      { length: VARIATION_COUNT },
-      (_, i) => ({
-        id: uuidv4(),
-        method: "expansion" as const,
-        prompt: `${basePrompt}, ${modifiers[i % modifiers.length]}`,
-        seed: baseSeed,
-        status: "queue" as const,
-      }),
-    );
-
-    useFlowStore.getState().addKeyframeVariations(keyframeId, candidates);
-
-    // Fire all API calls in parallel — never sequential for-loop.
-    await Promise.all(
-      candidates.map(async (candidate, i) => {
-        const algoParams = {
-          infinidream_algorithm: imageGenParams.model,
-          prompt: candidate.prompt,
-          size: imageGenParams.size,
-          seed: candidate.seed,
-        };
-
-        try {
-          const { data } = await axiosClient.post("/v1/dream", {
-            name: `${keyframe.name} v${i + 1}`,
-            prompt: JSON.stringify(algoParams),
-            description: "Keyframe variation",
-          });
-          const dreamUuid = data?.data?.dream?.uuid;
-          if (!dreamUuid) {
-            throw new Error("No dream UUID returned from API");
-          }
-          useFlowStore
-            .getState()
-            .updateKeyframeVariation(keyframeId, candidate.id, {
-              dreamUuid,
-              status: "queue",
-            });
-        } catch (err) {
-          Bugsnag.notify(err as Error);
-          useFlowStore
-            .getState()
-            .updateKeyframeVariation(keyframeId, candidate.id, {
-              status: "failed",
-            });
-        }
-      }),
-    );
-  }, []);
 
   const handleFileSelected = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -392,7 +274,6 @@ export const FlowBuilder: React.FC = () => {
         onAddFromPlaylist={handleAddFromPlaylist}
         onAddFromLibrary={handleAddFromLibrary}
         onRetry={generateOne}
-        onRequestVariations={handleKeyframeVariations}
         onOpenVariationLightbox={setVariationLightboxIndex}
         onRequestI2iVariation={handleI2iVariation}
         onAcceptI2iCandidate={handleAcceptI2iCandidate}

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -5,9 +5,11 @@ import styled from "styled-components";
 import { useFlowStore } from "@/stores/flow.store";
 import { useStudioStore } from "@/stores/studio.store";
 import { FLOW } from "@/constants/flow-theme.constants";
-import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import { axiosClient } from "@/client/axios.client";
-import type { VariationCandidate } from "@/types/flow.types";
+import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
+import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
+import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
+import type { VariationCandidate, FlowKeyframe } from "@/types/flow.types";
 import { getVariationPreset } from "../constants/variation-presets";
 import { expandPrompt } from "../utils/expand-prompt";
 import { KeyframeStrip } from "./keyframe-strip";
@@ -45,6 +47,13 @@ export const FlowBuilder: React.FC = () => {
   const addKeyframe = useFlowStore((s) => s.addKeyframe);
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
+  const setI2iEndpoint = useFlowStore((s) => s.setI2iEndpoint);
+
+  // User i2i endpoints (BYO key) for image-to-image variations.
+  const { data: endpointsData } = useUserApiEndpoints();
+  const i2iEndpoints = (endpointsData?.data?.endpoints ?? []).filter(
+    (ep) => ep.capabilities.imageToImage,
+  );
 
   // State declarations must come before selectors that reference them (TDZ).
   const [showPlaylistModal, setShowPlaylistModal] = useState(false);
@@ -254,6 +263,87 @@ export const FlowBuilder: React.FC = () => {
     [uploadFiles],
   );
 
+  const handleI2iVariation = useCallback(
+    (keyframe: FlowKeyframe) => {
+      // Resolve which i2i endpoint to use. Prefer the one already selected this
+      // session; otherwise auto-select (single -> that one, multiple -> first).
+      const endpoints = i2iEndpoints;
+      if (endpoints.length === 0) return;
+
+      let endpointUuid = useFlowStore.getState().i2iEndpointUuid;
+      if (!endpointUuid || !endpoints.some((ep) => ep.uuid === endpointUuid)) {
+        // TODO: inline picker when multiple i2i endpoints are configured.
+        endpointUuid = endpoints[0].uuid;
+        setI2iEndpoint(endpointUuid);
+      }
+
+      // Source image — prefer the backend dream UUID, fall back to the URL.
+      const sourceImage = keyframe.dreamUuid ?? keyframe.imageUrl;
+      if (!sourceImage) return;
+
+      const I2I_VARIATION_COUNT = 4;
+      const baseName = keyframe.name || "frame";
+
+      // Create placeholder candidate keyframes up-front so the user sees them
+      // immediately, then patch each in place as its generation request settles.
+      const candidates = Array.from(
+        { length: I2I_VARIATION_COUNT },
+        (_, i) => {
+          const id = uuidv4();
+          addKeyframe({
+            id,
+            imageUrl: keyframe.imageUrl,
+            name: `${baseName} · variation ${i + 1}`,
+            uploadStatus: "uploading",
+            uploadProgress: 0,
+          });
+          return id;
+        },
+      );
+
+      // Fire all variation generations concurrently (no sequential await loop).
+      const headers = getRequestHeaders({ contentType: ContentType.json });
+      void Promise.allSettled(
+        candidates.map(async (id, i) => {
+          const algoParams = {
+            userEndpointUuid: endpointUuid,
+            image: sourceImage,
+            prompt: keyframe.name ?? "",
+            n: 1,
+          };
+          try {
+            const { data } = await axiosClient.post(
+              "/v1/dream",
+              {
+                name: `${baseName} · variation ${i + 1}`,
+                prompt: JSON.stringify(algoParams),
+                description: "Studio i2i variation",
+              },
+              { headers },
+            );
+            const dreamUuid = data?.data?.dream?.uuid;
+            if (!dreamUuid) {
+              throw new Error("No dream UUID returned from API");
+            }
+            // Settle the placeholder into a real, queued keyframe.
+            updateKeyframe(id, {
+              dreamUuid,
+              uploadStatus: undefined,
+              uploadProgress: undefined,
+            });
+          } catch (err) {
+            Bugsnag.notify(err as Error);
+            updateKeyframe(id, {
+              uploadStatus: "failed",
+              uploadProgress: undefined,
+            });
+          }
+        }),
+      );
+    },
+    [i2iEndpoints, setI2iEndpoint, addKeyframe, updateKeyframe],
+  );
+
   const handleAddFromPlaylist = useCallback(() => {
     setShowPlaylistModal(true);
   }, []);
@@ -276,6 +366,7 @@ export const FlowBuilder: React.FC = () => {
         onRetry={generateOne}
         onRequestVariations={handleKeyframeVariations}
         onOpenVariationLightbox={setVariationLightboxIndex}
+        onRequestI2iVariation={handleI2iVariation}
       />
 
       <TransitionSettingsPanel

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -40,6 +40,8 @@ import {
 } from "./images-tab.styled";
 import { PresignedImage } from "@/components/shared/presigned-image";
 import { AddFromPlaylistModal } from "./add-from-playlist-modal";
+import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
+import type { UserApiEndpoint } from "@/types/user-api-endpoint.types";
 
 const MODEL_LABELS: Record<ImageModel, string> = {
   "z-image-turbo": "Z Image Turbo",
@@ -70,6 +72,19 @@ export const ImagesTab: React.FC = () => {
   const [expandedImageUuid, setExpandedImageUuid] = useState<string | null>(
     null,
   );
+
+  // User-configured text-to-image API endpoints (BYO key).
+  const { data: endpointsData } = useUserApiEndpoints();
+  const userEndpoints = useMemo(
+    () =>
+      (endpointsData?.data?.endpoints ?? []).filter(
+        (ep) => ep.capabilities.textToImage,
+      ),
+    [endpointsData],
+  );
+  // When a user endpoint is chosen the built-in model picker falls through to it.
+  const [selectedEndpoint, setSelectedEndpoint] =
+    useState<UserApiEndpoint | null>(null);
 
   const sizeOptions = SIZE_OPTIONS[imageGenParams.model];
 
@@ -107,19 +122,35 @@ export const ImagesTab: React.FC = () => {
       })),
     );
 
+    // When a user endpoint is selected, route generation to it via
+    // userEndpointUuid and the endpoint's own size; otherwise use the
+    // built-in algorithm + size.
+    const endpoint = selectedEndpoint;
+    const effectiveSize = endpoint
+      ? endpoint.capabilities.sizes[0] ?? imageGenParams.size
+      : imageGenParams.size;
+    const namePrefix = endpoint
+      ? endpoint.name
+      : MODEL_LABELS[imageGenParams.model];
+
     const promises = jobs.map(({ prompt, seed }, idx) => {
-      const algoParams = {
-        infinidream_algorithm: imageGenParams.model,
-        prompt,
-        size: imageGenParams.size,
-        seed,
-      };
+      const algoParams = endpoint
+        ? {
+            userEndpointUuid: endpoint.uuid,
+            prompt,
+            size: effectiveSize,
+            seed,
+          }
+        : {
+            infinidream_algorithm: imageGenParams.model,
+            prompt,
+            size: effectiveSize,
+            seed,
+          };
 
       return axiosClient
         .post("/v1/dream", {
-          name: `${MODEL_LABELS[imageGenParams.model]} ${
-            currentImageCount + idx + 1
-          }`,
+          name: `${namePrefix} ${currentImageCount + idx + 1}`,
           prompt: JSON.stringify(algoParams),
           description: "Studio generated image",
         })
@@ -131,7 +162,7 @@ export const ImagesTab: React.FC = () => {
             url: dream.thumbnail || "",
             name: dream.name,
             seed,
-            size: imageGenParams.size,
+            size: effectiveSize,
             status: (dream.status as StudioImage["status"]) || "queue",
             selected: false,
           });
@@ -143,7 +174,7 @@ export const ImagesTab: React.FC = () => {
 
     await Promise.all(promises);
     setIsGenerating(false);
-  }, [imagePrompt, imageGenParams, addImage, setIsGenerating]);
+  }, [imagePrompt, imageGenParams, selectedEndpoint, addImage, setIsGenerating]);
 
   const handleUploadFiles = useCallback(
     async (files: File[]) => {
@@ -208,9 +239,16 @@ export const ImagesTab: React.FC = () => {
           <FormField>
             <FieldLabel>Model:</FieldLabel>
             <StyledSelect
-              value={imageGenParams.model}
+              value={selectedEndpoint ? selectedEndpoint.uuid : imageGenParams.model}
               onChange={(e) => {
-                const newModel = e.target.value as ImageModel;
+                const value = e.target.value;
+                const endpoint = userEndpoints.find((ep) => ep.uuid === value);
+                if (endpoint) {
+                  setSelectedEndpoint(endpoint);
+                  return;
+                }
+                setSelectedEndpoint(null);
+                const newModel = value as ImageModel;
                 setImageGenParams({
                   model: newModel,
                   size: clampSizeToModel(imageGenParams.size, newModel),
@@ -220,6 +258,11 @@ export const ImagesTab: React.FC = () => {
               {IMAGE_MODELS.map((m) => (
                 <option key={m} value={m}>
                   {MODEL_LABELS[m]}
+                </option>
+              ))}
+              {userEndpoints.map((ep) => (
+                <option key={ep.uuid} value={ep.uuid}>
+                  {ep.name} · your key
                 </option>
               ))}
             </StyledSelect>

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -193,7 +193,13 @@ export const ImagesTab: React.FC = () => {
 
     await Promise.all(promises);
     setIsGenerating(false);
-  }, [imagePrompt, imageGenParams, selectedEndpoint, addImage, setIsGenerating]);
+  }, [
+    imagePrompt,
+    imageGenParams,
+    selectedEndpoint,
+    addImage,
+    setIsGenerating,
+  ]);
 
   const handleUploadFiles = useCallback(
     async (files: File[]) => {
@@ -258,7 +264,9 @@ export const ImagesTab: React.FC = () => {
           <FormField>
             <FieldLabel>Model:</FieldLabel>
             <StyledSelect
-              value={selectedEndpoint ? selectedEndpoint.uuid : imageGenParams.model}
+              value={
+                selectedEndpoint ? selectedEndpoint.uuid : imageGenParams.model
+              }
               onChange={(e) => {
                 const value = e.target.value;
                 const endpoint = userEndpoints.find((ep) => ep.uuid === value);

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Bugsnag from "@bugsnag/js";
 import { v4 as uuidv4 } from "uuid";
 import { useStudioStore } from "@/stores/studio.store";
 import { axiosClient } from "@/client/axios.client";
@@ -86,6 +93,18 @@ export const ImagesTab: React.FC = () => {
   const [selectedEndpoint, setSelectedEndpoint] =
     useState<UserApiEndpoint | null>(null);
 
+  // Reconcile a stale endpoint selection: if the chosen endpoint was deleted
+  // (refetch dropped it from userEndpoints), clear it so the <select> falls
+  // back to the built-in model instead of showing a value with no option.
+  useEffect(() => {
+    if (
+      selectedEndpoint &&
+      !userEndpoints.some((ep) => ep.uuid === selectedEndpoint.uuid)
+    ) {
+      setSelectedEndpoint(null);
+    }
+  }, [userEndpoints, selectedEndpoint]);
+
   const sizeOptions = SIZE_OPTIONS[imageGenParams.model];
 
   const processedImages = useMemo(
@@ -168,7 +187,7 @@ export const ImagesTab: React.FC = () => {
           });
         })
         .catch((err) => {
-          console.error("Failed to create image:", err);
+          Bugsnag.notify(err as Error);
         });
     });
 
@@ -198,7 +217,7 @@ export const ImagesTab: React.FC = () => {
             name: result.name,
           });
         } catch (err) {
-          console.error("Failed to upload image:", err);
+          Bugsnag.notify(err as Error);
           updateImage(placeholderUuid, { status: "failed" });
         } finally {
           URL.revokeObjectURL(blobUrl);

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -314,7 +314,7 @@ export const DeleteButton = styled.button`
   height: 20px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textDim};
+  color: ${FLOW.text};
   font-size: 12px;
   display: flex;
   align-items: center;
@@ -339,7 +339,7 @@ export const VaryButton = styled.button`
   height: 22px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textDim};
+  color: ${FLOW.text};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -11,6 +11,7 @@ export const CardWrapper = styled.div<{
   $isDragging?: boolean;
   $uploading?: boolean;
   $failed?: boolean;
+  $candidate?: boolean;
 }>`
   flex-shrink: 0;
   width: 140px;
@@ -55,6 +56,13 @@ export const CardWrapper = styled.div<{
       cursor: default;
       border-color: ${FLOW.error};
       animation: ${errorBreathe} 1.8s ease-in-out infinite;
+    `}
+
+  ${(props) =>
+    props.$candidate &&
+    css`
+      border-style: dashed;
+      border-color: ${FLOW.accent};
     `}
 
   &:hover {
@@ -184,6 +192,66 @@ export const LoopBadge = styled.span`
   letter-spacing: 0.1em;
   color: ${FLOW.accent};
   opacity: 0.7;
+`;
+
+export const CandidateBadge = styled.span`
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: ${FLOW.accent};
+`;
+
+export const CandidateActions = styled.div`
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  display: flex;
+  gap: 4px;
+`;
+
+export const AcceptButton = styled.button`
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 10px;
+  background: ${FLOW.successDim};
+  color: ${FLOW.success};
+  font-family: ${FLOW.fontFamily};
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  transition: filter 0.2s;
+
+  &:hover {
+    filter: brightness(1.2);
+  }
+`;
+
+export const DiscardButton = styled.button`
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 10px;
+  background: ${FLOW.errorDim};
+  color: ${FLOW.error};
+  font-family: ${FLOW.fontFamily};
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  transition: filter 0.2s;
+
+  &:hover {
+    filter: brightness(1.2);
+  }
 `;
 
 export const DeleteButton = styled.button`

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -6,6 +6,10 @@ const errorBreathe = keyframes`
   50%      { box-shadow: 0 0 0 6px transparent; }
 `;
 
+const spin = keyframes`
+  to { transform: rotate(360deg); }
+`;
+
 export const CardWrapper = styled.div<{
   $loop?: boolean;
   $isDragging?: boolean;
@@ -132,6 +136,41 @@ export const UploadPercent = styled.span`
   letter-spacing: 0.06em;
   color: ${FLOW.accent};
   font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+`;
+
+// i2i candidate "generating" state — an indeterminate gold spinner over a
+// dimmed card, so a varying candidate reads as working rather than showing a
+// frozen copy of its source image while its own result is still rendering.
+export const GeneratingOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: rgba(12, 12, 14, 0.55);
+  backdrop-filter: blur(1px);
+  pointer-events: none;
+`;
+
+export const GeneratingSpinner = styled.div`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid rgba(212, 168, 83, 0.22);
+  border-top-color: ${FLOW.accent};
+  animation: ${spin} 0.8s linear infinite;
+`;
+
+export const GeneratingLabel = styled.span`
+  font-family: ${FLOW.fontFamily};
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: ${FLOW.accent};
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 `;
 

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -329,12 +329,12 @@ export const DeleteButton = styled.button`
   }
 `;
 
-// Per-keyframe "Vary" trigger — a circular shuffle icon button (bottom-right),
+// Per-keyframe "Vary" trigger — a circular shuffle icon button (top-left),
 // revealed on hover. Generates i2i/t2i variation candidates for this frame.
 export const VaryButton = styled.button`
   position: absolute;
-  bottom: 4px;
-  right: 4px;
+  top: 4px;
+  left: 4px;
   width: 22px;
   height: 22px;
   border-radius: 50%;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -195,19 +195,32 @@ export const LoopBadge = styled.span`
 `;
 
 export const CandidateBadge = styled.span`
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  z-index: 3;
   font-size: 9px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: ${FLOW.accent};
+  background: rgba(0, 0, 0, 0.6);
+  padding: 2px 6px;
+  border-radius: 4px;
+  backdrop-filter: blur(4px);
 `;
 
 export const CandidateActions = styled.div`
   position: absolute;
   bottom: 4px;
   right: 4px;
+  z-index: 3;
   display: flex;
   gap: 4px;
+  padding: 3px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
 `;
 
 export const AcceptButton = styled.button`

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -198,6 +198,14 @@ export const FailedOverlay = styled.div`
   }
 `;
 
+// Candidate variant — a candidate card also carries a bottom-right Discard
+// pill, so shift the failed message up out of its way (the shared overlay
+// centers vertically and crowds the button on these short cards).
+export const CandidateFailedOverlay = styled(FailedOverlay)`
+  justify-content: flex-start;
+  padding-top: 16px;
+`;
+
 export const CardPlaceholder = styled.div`
   width: 100%;
   height: 100%;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -290,32 +290,6 @@ export const DeleteButton = styled.button`
   }
 `;
 
-export const VariationsButton = styled.button`
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.textDim};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.2s;
-
-  ${CardWrapper}:hover & {
-    opacity: 1;
-  }
-
-  &:hover {
-    color: ${FLOW.accent};
-  }
-`;
-
 export const VaryButton = styled.button`
   position: absolute;
   bottom: 4px;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -329,30 +329,29 @@ export const DeleteButton = styled.button`
   }
 `;
 
+// Per-keyframe "Vary" trigger — a circular shuffle icon button (bottom-right),
+// revealed on hover. Generates i2i/t2i variation candidates for this frame.
 export const VaryButton = styled.button`
   position: absolute;
   bottom: 4px;
   right: 4px;
-  height: 20px;
-  padding: 0 8px;
-  border-radius: 10px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
-  color: ${FLOW.accent};
-  font-family: ${FLOW.fontFamily};
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  color: ${FLOW.textDim};
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition:
+    opacity 0.2s,
+    color 0.2s;
 
-  &:disabled {
-    color: ${FLOW.textMuted};
-    cursor: not-allowed;
+  &:hover {
+    color: ${FLOW.accent};
   }
 
   ${CardWrapper}:hover & {

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -234,3 +234,34 @@ export const VariationsButton = styled.button`
     color: ${FLOW.accent};
   }
 `;
+
+export const VaryButton = styled.button`
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  color: ${FLOW.accent};
+  font-family: ${FLOW.fontFamily};
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s;
+
+  &:disabled {
+    color: ${FLOW.textMuted};
+    cursor: not-allowed;
+  }
+
+  ${CardWrapper}:hover & {
+    opacity: 1;
+  }
+`;

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -110,7 +110,9 @@ export const KeyframeCard: React.FC<Props> = ({
     id: keyframe.id,
     // Dragging a card mid-upload would re-key React and abort the visual
     // continuity of the preview, so lock it until the upload settles.
-    disabled: isLoop || isBusy,
+    // i2i candidates live in a separate staging row and are not part of the
+    // timeline, so reordering them is meaningless — keep them non-draggable.
+    disabled: isLoop || isBusy || isCandidate,
   });
 
   const style = {
@@ -142,7 +144,9 @@ export const KeyframeCard: React.FC<Props> = ({
         $uploading={isUploading}
         $failed={isFailed}
         $candidate={isCandidate}
-        {...(isLoop || isBusy ? {} : { ...attributes, ...listeners })}
+        {...(isLoop || isBusy || isCandidate
+          ? {}
+          : { ...attributes, ...listeners })}
       >
         {imgSrc ? (
           <CardImage

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -24,6 +24,9 @@ import {
   UploadRingFill,
   UploadPercent,
   FailedOverlay,
+  GeneratingOverlay,
+  GeneratingSpinner,
+  GeneratingLabel,
 } from "./keyframe-card.styled";
 
 interface Props {
@@ -48,6 +51,12 @@ export const KeyframeCard: React.FC<Props> = ({
   const isUploading = keyframe.uploadStatus === "uploading";
   const isFailed = keyframe.uploadStatus === "failed";
   const isBusy = isUploading || isFailed;
+  // A candidate whose own dream is still rendering. Show a loader instead of the
+  // placeholder source image (which is identical across a batch and reads as
+  // frozen); job progress swaps in the distinct result once processed.
+  const isGenerating =
+    isCandidate &&
+    (keyframe.i2iStatus === "queue" || keyframe.i2iStatus === "processing");
 
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
 
@@ -168,6 +177,13 @@ export const KeyframeCard: React.FC<Props> = ({
         </FailedOverlay>
       )}
 
+      {isGenerating && (
+        <GeneratingOverlay role="status" aria-label="Generating variation">
+          <GeneratingSpinner />
+          <GeneratingLabel>Generating…</GeneratingLabel>
+        </GeneratingOverlay>
+      )}
+
       {/* Index / loop label sits bottom-left. Not shown for candidates —
           they get their own top-left badge so it can't collide with the
           bottom-right Accept/Discard actions on narrow cards. */}
@@ -189,6 +205,7 @@ export const KeyframeCard: React.FC<Props> = ({
 
       {isCandidate &&
         !isBusy &&
+        !isGenerating &&
         (onAcceptI2iCandidate || onDiscardI2iCandidate) && (
           <CandidateActions>
             {onAcceptI2iCandidate && (

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -184,17 +184,24 @@ export const KeyframeCard: React.FC<Props> = ({
           </FailedOverlay>
         )}
 
-        <CardLabel>
-          {isLoop ? (
-            <>
-              {keyframe.name} <LoopBadge>Loop</LoopBadge>
-            </>
-          ) : isCandidate ? (
-            <CandidateBadge>Variation</CandidateBadge>
-          ) : (
-            `${index + 1}`
-          )}
-        </CardLabel>
+        {/* Index / loop label sits bottom-left. Not shown for candidates —
+            they get their own top-left badge so it can't collide with the
+            bottom-right Accept/Discard actions on narrow cards. */}
+        {!isCandidate && (
+          <CardLabel>
+            {isLoop ? (
+              <>
+                {keyframe.name} <LoopBadge>Loop</LoopBadge>
+              </>
+            ) : (
+              `${index + 1}`
+            )}
+          </CardLabel>
+        )}
+
+        {/* Candidate badge: top-left, hidden while busy so the full-card
+            progress/failed overlay owns the card. */}
+        {isCandidate && !isBusy && <CandidateBadge>Variation</CandidateBadge>}
 
         {isCandidate &&
           !isBusy &&

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -24,6 +24,7 @@ import {
   UploadRingFill,
   UploadPercent,
   FailedOverlay,
+  CandidateFailedOverlay,
   GeneratingOverlay,
   GeneratingSpinner,
   GeneratingLabel,
@@ -57,6 +58,10 @@ export const KeyframeCard: React.FC<Props> = ({
   const isGenerating =
     isCandidate &&
     (keyframe.i2iStatus === "queue" || keyframe.i2iStatus === "processing");
+  // A candidate whose generation failed. Surface it as failed rather than
+  // silently falling back to the source image (which is identical across the
+  // batch and reads as "nothing happened / they all look the same").
+  const isGenFailed = isCandidate && keyframe.i2iStatus === "failed";
 
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
 
@@ -184,6 +189,13 @@ export const KeyframeCard: React.FC<Props> = ({
         </GeneratingOverlay>
       )}
 
+      {isGenFailed && (
+        <CandidateFailedOverlay role="alert">
+          <AlertTriangle size={16} strokeWidth={2.2} />
+          Variation failed
+        </CandidateFailedOverlay>
+      )}
+
       {/* Index / loop label sits bottom-left. Not shown for candidates —
           they get their own top-left badge so it can't collide with the
           bottom-right Accept/Discard actions on narrow cards. */}
@@ -201,14 +213,16 @@ export const KeyframeCard: React.FC<Props> = ({
 
       {/* Candidate badge: top-left, hidden while busy so the full-card
           progress/failed overlay owns the card. */}
-      {isCandidate && !isBusy && <CandidateBadge>Variation</CandidateBadge>}
+      {isCandidate && !isBusy && !isGenFailed && (
+        <CandidateBadge>Variation</CandidateBadge>
+      )}
 
       {isCandidate &&
         !isBusy &&
         !isGenerating &&
         (onAcceptI2iCandidate || onDiscardI2iCandidate) && (
           <CandidateActions>
-            {onAcceptI2iCandidate && (
+            {onAcceptI2iCandidate && !isGenFailed && (
               <AcceptButton
                 title="Accept this variation as a keyframe"
                 onClick={(e) => {

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -14,9 +14,13 @@ import {
   CardPlaceholder,
   CardLabel,
   LoopBadge,
+  CandidateBadge,
   DeleteButton,
   VariationsButton,
   VaryButton,
+  CandidateActions,
+  AcceptButton,
+  DiscardButton,
   UploadOverlay,
   UploadRing,
   UploadRingTrack,
@@ -31,6 +35,8 @@ interface Props {
   onDelete?: (id: string) => void;
   onRequestVariations?: (keyframeId: string) => void;
   onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
+  onAcceptI2iCandidate?: (keyframe: FlowKeyframe) => void;
+  onDiscardI2iCandidate?: (keyframe: FlowKeyframe) => void;
 }
 
 export const KeyframeCard: React.FC<Props> = ({
@@ -39,8 +45,11 @@ export const KeyframeCard: React.FC<Props> = ({
   onDelete,
   onRequestVariations,
   onRequestI2iVariation,
+  onAcceptI2iCandidate,
+  onDiscardI2iCandidate,
 }) => {
   const isLoop = keyframe.isLoopKeyframe ?? false;
+  const isCandidate = keyframe.i2iCandidate ?? false;
   const isUploading = keyframe.uploadStatus === "uploading";
   const isFailed = keyframe.uploadStatus === "failed";
   const isBusy = isUploading || isFailed;
@@ -132,6 +141,7 @@ export const KeyframeCard: React.FC<Props> = ({
         $isDragging={isDragging}
         $uploading={isUploading}
         $failed={isFailed}
+        $candidate={isCandidate}
         {...(isLoop || isBusy ? {} : { ...attributes, ...listeners })}
       >
         {imgSrc ? (
@@ -175,12 +185,43 @@ export const KeyframeCard: React.FC<Props> = ({
             <>
               {keyframe.name} <LoopBadge>Loop</LoopBadge>
             </>
+          ) : isCandidate ? (
+            <CandidateBadge>Variation</CandidateBadge>
           ) : (
             `${index + 1}`
           )}
         </CardLabel>
 
-        {!isLoop && !isBusy && onDelete && (
+        {isCandidate &&
+          !isBusy &&
+          (onAcceptI2iCandidate || onDiscardI2iCandidate) && (
+            <CandidateActions>
+              {onAcceptI2iCandidate && (
+                <AcceptButton
+                  title="Accept this variation as a keyframe"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAcceptI2iCandidate(keyframe);
+                  }}
+                >
+                  Accept
+                </AcceptButton>
+              )}
+              {onDiscardI2iCandidate && (
+                <DiscardButton
+                  title="Discard this variation"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDiscardI2iCandidate(keyframe);
+                  }}
+                >
+                  Discard
+                </DiscardButton>
+              )}
+            </CandidateActions>
+          )}
+
+        {!isLoop && !isCandidate && !isBusy && onDelete && (
           <DeleteButton
             onClick={(e) => {
               e.stopPropagation();
@@ -191,25 +232,29 @@ export const KeyframeCard: React.FC<Props> = ({
           </DeleteButton>
         )}
 
-        {!isLoop && !isBusy && isSettled && onRequestVariations && (
-          <VariationsButton
-            onClick={(e) => {
-              e.stopPropagation();
-              if (
-                !showVariations &&
-                (!keyframe.variations || keyframe.variations.length === 0)
-              ) {
-                onRequestVariations(keyframe.id);
-              }
-              setShowVariations((v) => !v);
-            }}
-            title="Generate variations"
-          >
-            <Shuffle size={11} />
-          </VariationsButton>
-        )}
+        {!isLoop &&
+          !isCandidate &&
+          !isBusy &&
+          isSettled &&
+          onRequestVariations && (
+            <VariationsButton
+              onClick={(e) => {
+                e.stopPropagation();
+                if (
+                  !showVariations &&
+                  (!keyframe.variations || keyframe.variations.length === 0)
+                ) {
+                  onRequestVariations(keyframe.id);
+                }
+                setShowVariations((v) => !v);
+              }}
+              title="Generate variations"
+            >
+              <Shuffle size={11} />
+            </VariationsButton>
+          )}
 
-        {!isLoop && !isBusy && onRequestI2iVariation && (
+        {!isLoop && !isCandidate && !isBusy && onRequestI2iVariation && (
           <VaryButton
             disabled={!hasI2iEndpoints}
             title={

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -7,6 +7,7 @@ import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
 import { VariationGrid } from "./variation-grid";
+import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
 import {
   CardWrapper,
   CardImage,
@@ -15,6 +16,7 @@ import {
   LoopBadge,
   DeleteButton,
   VariationsButton,
+  VaryButton,
   UploadOverlay,
   UploadRing,
   UploadRingTrack,
@@ -28,6 +30,7 @@ interface Props {
   index: number;
   onDelete?: (id: string) => void;
   onRequestVariations?: (keyframeId: string) => void;
+  onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
 }
 
 export const KeyframeCard: React.FC<Props> = ({
@@ -35,6 +38,7 @@ export const KeyframeCard: React.FC<Props> = ({
   index,
   onDelete,
   onRequestVariations,
+  onRequestI2iVariation,
 }) => {
   const isLoop = keyframe.isLoopKeyframe ?? false;
   const isUploading = keyframe.uploadStatus === "uploading";
@@ -47,6 +51,11 @@ export const KeyframeCard: React.FC<Props> = ({
     (s) => s.selectKeyframeVariation,
   );
 
+  // Whether the user has at least one image-to-image capable endpoint configured.
+  const { data: endpointsData } = useUserApiEndpoints();
+  const hasI2iEndpoints = (endpointsData?.data?.endpoints ?? []).some(
+    (ep) => ep.capabilities.imageToImage,
+  );
   const [imgSrc, setImgSrc] = useState(keyframe.imageUrl);
   const [showVariations, setShowVariations] = useState(false);
 
@@ -198,6 +207,24 @@ export const KeyframeCard: React.FC<Props> = ({
           >
             <Shuffle size={11} />
           </VariationsButton>
+        )}
+
+        {!isLoop && !isBusy && onRequestI2iVariation && (
+          <VaryButton
+            disabled={!hasI2iEndpoints}
+            title={
+              hasI2iEndpoints
+                ? "Generate image-to-image variations"
+                : "Configure an image-to-image endpoint in account settings to use this"
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!hasI2iEndpoints) return;
+              onRequestI2iVariation(keyframe);
+            }}
+          >
+            Vary (i2i)
+          </VaryButton>
         )}
       </CardWrapper>
 

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangle, Shuffle } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import type { FlowKeyframe } from "@/types/flow.types";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
-import { VariationGrid } from "./variation-grid";
-import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
 import {
   CardWrapper,
   CardImage,
@@ -16,7 +14,6 @@ import {
   LoopBadge,
   CandidateBadge,
   DeleteButton,
-  VariationsButton,
   VaryButton,
   CandidateActions,
   AcceptButton,
@@ -33,7 +30,6 @@ interface Props {
   keyframe: FlowKeyframe;
   index: number;
   onDelete?: (id: string) => void;
-  onRequestVariations?: (keyframeId: string) => void;
   onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
   onAcceptI2iCandidate?: (keyframe: FlowKeyframe) => void;
   onDiscardI2iCandidate?: (keyframe: FlowKeyframe) => void;
@@ -43,7 +39,6 @@ export const KeyframeCard: React.FC<Props> = ({
   keyframe,
   index,
   onDelete,
-  onRequestVariations,
   onRequestI2iVariation,
   onAcceptI2iCandidate,
   onDiscardI2iCandidate,
@@ -53,20 +48,10 @@ export const KeyframeCard: React.FC<Props> = ({
   const isUploading = keyframe.uploadStatus === "uploading";
   const isFailed = keyframe.uploadStatus === "failed";
   const isBusy = isUploading || isFailed;
-  const isSettled = !!(keyframe.dreamUuid || keyframe.keyframeUuid);
 
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
-  const selectKeyframeVariation = useFlowStore(
-    (s) => s.selectKeyframeVariation,
-  );
 
-  // Whether the user has at least one image-to-image capable endpoint configured.
-  const { data: endpointsData } = useUserApiEndpoints();
-  const hasI2iEndpoints = (endpointsData?.data?.endpoints ?? []).some(
-    (ep) => ep.capabilities.imageToImage,
-  );
   const [imgSrc, setImgSrc] = useState(keyframe.imageUrl);
-  const [showVariations, setShowVariations] = useState(false);
 
   useEffect(() => {
     setImgSrc(keyframe.imageUrl);
@@ -135,168 +120,124 @@ export const KeyframeCard: React.FC<Props> = ({
   };
 
   return (
-    <>
-      <CardWrapper
-        ref={setNodeRef}
-        style={style}
-        $loop={isLoop}
-        $isDragging={isDragging}
-        $uploading={isUploading}
-        $failed={isFailed}
-        $candidate={isCandidate}
-        {...(isLoop || isBusy || isCandidate
-          ? {}
-          : { ...attributes, ...listeners })}
-      >
-        {imgSrc ? (
-          <CardImage
-            src={imgSrc}
-            alt={keyframe.name}
-            $uploading={isUploading}
-            onClick={isClickable ? handleOpen : undefined}
-            style={isClickable ? { cursor: "pointer" } : undefined}
-            onError={keyframe.dreamUuid ? handleImgError : undefined}
-          />
-        ) : (
-          <CardPlaceholder>{keyframe.name}</CardPlaceholder>
-        )}
+    <CardWrapper
+      ref={setNodeRef}
+      style={style}
+      $loop={isLoop}
+      $isDragging={isDragging}
+      $uploading={isUploading}
+      $failed={isFailed}
+      $candidate={isCandidate}
+      {...(isLoop || isBusy || isCandidate
+        ? {}
+        : { ...attributes, ...listeners })}
+    >
+      {imgSrc ? (
+        <CardImage
+          src={imgSrc}
+          alt={keyframe.name}
+          $uploading={isUploading}
+          onClick={isClickable ? handleOpen : undefined}
+          style={isClickable ? { cursor: "pointer" } : undefined}
+          onError={keyframe.dreamUuid ? handleImgError : undefined}
+        />
+      ) : (
+        <CardPlaceholder>{keyframe.name}</CardPlaceholder>
+      )}
 
-        {isUploading && (
-          <UploadOverlay
-            role="progressbar"
-            aria-label={`Uploading ${keyframe.name}`}
-            aria-valuenow={percent}
-            aria-valuemin={0}
-            aria-valuemax={100}
-          >
-            <UploadRing viewBox="0 0 36 36">
-              <UploadRingTrack cx="18" cy="18" r="16" />
-              <UploadRingFill cx="18" cy="18" r="16" $percent={percent} />
-            </UploadRing>
-            <UploadPercent>{percent}%</UploadPercent>
-          </UploadOverlay>
-        )}
+      {isUploading && (
+        <UploadOverlay
+          role="progressbar"
+          aria-label={`Uploading ${keyframe.name}`}
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <UploadRing viewBox="0 0 36 36">
+            <UploadRingTrack cx="18" cy="18" r="16" />
+            <UploadRingFill cx="18" cy="18" r="16" $percent={percent} />
+          </UploadRing>
+          <UploadPercent>{percent}%</UploadPercent>
+        </UploadOverlay>
+      )}
 
-        {isFailed && (
-          <FailedOverlay role="alert">
-            <AlertTriangle size={16} strokeWidth={2.2} />
-            Upload failed
-          </FailedOverlay>
-        )}
+      {isFailed && (
+        <FailedOverlay role="alert">
+          <AlertTriangle size={16} strokeWidth={2.2} />
+          Upload failed
+        </FailedOverlay>
+      )}
 
-        {/* Index / loop label sits bottom-left. Not shown for candidates —
-            they get their own top-left badge so it can't collide with the
-            bottom-right Accept/Discard actions on narrow cards. */}
-        {!isCandidate && (
-          <CardLabel>
-            {isLoop ? (
-              <>
-                {keyframe.name} <LoopBadge>Loop</LoopBadge>
-              </>
-            ) : (
-              `${index + 1}`
+      {/* Index / loop label sits bottom-left. Not shown for candidates —
+          they get their own top-left badge so it can't collide with the
+          bottom-right Accept/Discard actions on narrow cards. */}
+      {!isCandidate && (
+        <CardLabel>
+          {isLoop ? (
+            <>
+              {keyframe.name} <LoopBadge>Loop</LoopBadge>
+            </>
+          ) : (
+            `${index + 1}`
+          )}
+        </CardLabel>
+      )}
+
+      {/* Candidate badge: top-left, hidden while busy so the full-card
+          progress/failed overlay owns the card. */}
+      {isCandidate && !isBusy && <CandidateBadge>Variation</CandidateBadge>}
+
+      {isCandidate &&
+        !isBusy &&
+        (onAcceptI2iCandidate || onDiscardI2iCandidate) && (
+          <CandidateActions>
+            {onAcceptI2iCandidate && (
+              <AcceptButton
+                title="Accept this variation as a keyframe"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAcceptI2iCandidate(keyframe);
+                }}
+              >
+                Accept
+              </AcceptButton>
             )}
-          </CardLabel>
+            {onDiscardI2iCandidate && (
+              <DiscardButton
+                title="Discard this variation"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDiscardI2iCandidate(keyframe);
+                }}
+              >
+                Discard
+              </DiscardButton>
+            )}
+          </CandidateActions>
         )}
 
-        {/* Candidate badge: top-left, hidden while busy so the full-card
-            progress/failed overlay owns the card. */}
-        {isCandidate && !isBusy && <CandidateBadge>Variation</CandidateBadge>}
+      {!isLoop && !isCandidate && !isBusy && onDelete && (
+        <DeleteButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(keyframe.id);
+          }}
+        >
+          &times;
+        </DeleteButton>
+      )}
 
-        {isCandidate &&
-          !isBusy &&
-          (onAcceptI2iCandidate || onDiscardI2iCandidate) && (
-            <CandidateActions>
-              {onAcceptI2iCandidate && (
-                <AcceptButton
-                  title="Accept this variation as a keyframe"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onAcceptI2iCandidate(keyframe);
-                  }}
-                >
-                  Accept
-                </AcceptButton>
-              )}
-              {onDiscardI2iCandidate && (
-                <DiscardButton
-                  title="Discard this variation"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDiscardI2iCandidate(keyframe);
-                  }}
-                >
-                  Discard
-                </DiscardButton>
-              )}
-            </CandidateActions>
-          )}
-
-        {!isLoop && !isCandidate && !isBusy && onDelete && (
-          <DeleteButton
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(keyframe.id);
-            }}
-          >
-            &times;
-          </DeleteButton>
-        )}
-
-        {!isLoop &&
-          !isCandidate &&
-          !isBusy &&
-          isSettled &&
-          onRequestVariations && (
-            <VariationsButton
-              onClick={(e) => {
-                e.stopPropagation();
-                if (
-                  !showVariations &&
-                  (!keyframe.variations || keyframe.variations.length === 0)
-                ) {
-                  onRequestVariations(keyframe.id);
-                }
-                setShowVariations((v) => !v);
-              }}
-              title="Generate variations"
-            >
-              <Shuffle size={11} />
-            </VariationsButton>
-          )}
-
-        {!isLoop && !isCandidate && !isBusy && onRequestI2iVariation && (
-          <VaryButton
-            disabled={!hasI2iEndpoints}
-            title={
-              hasI2iEndpoints
-                ? "Generate image-to-image variations"
-                : "Configure an image-to-image endpoint in account settings to use this"
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              if (!hasI2iEndpoints) return;
-              onRequestI2iVariation(keyframe);
-            }}
-          >
-            Vary (i2i)
-          </VaryButton>
-        )}
-      </CardWrapper>
-
-      {showVariations &&
-        keyframe.variations &&
-        keyframe.variations.length > 0 && (
-          <VariationGrid
-            variations={keyframe.variations}
-            activeVariationId={keyframe.activeVariationId}
-            onSelect={(variationId) =>
-              selectKeyframeVariation(keyframe.id, variationId)
-            }
-            onGenerateMore={() => onRequestVariations?.(keyframe.id)}
-            onClose={() => setShowVariations(false)}
-          />
-        )}
-    </>
+      {!isLoop && !isCandidate && !isBusy && onRequestI2iVariation && (
+        <VaryButton
+          title="Generate variations"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRequestI2iVariation(keyframe);
+          }}
+        >
+          Vary
+        </VaryButton>
+      )}
+    </CardWrapper>
   );
 };

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Shuffle } from "lucide-react";
 import type { FlowKeyframe } from "@/types/flow.types";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
@@ -252,7 +252,7 @@ export const KeyframeCard: React.FC<Props> = ({
             onRequestI2iVariation(keyframe);
           }}
         >
-          Vary
+          <Shuffle size={12} />
         </VaryButton>
       )}
     </CardWrapper>

--- a/src/components/pages/studio/components/keyframe-strip.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.styled.tsx
@@ -105,3 +105,27 @@ export const EmptyState = styled.div`
   color: ${FLOW.textDim};
   font-size: 14px;
 `;
+
+export const VariationsSection = styled.div`
+  margin-top: 20px;
+`;
+
+export const VariationsLabel = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: ${FLOW.textMuted};
+  font-family: ${FLOW.fontFamily};
+  margin-bottom: 12px;
+`;
+
+export const VariationsRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+`;

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
 import { shouldOpenVariationLightbox } from "../utils/variation-status";
+import type { FlowKeyframe } from "@/types/flow.types";
 import { KeyframeCard } from "./keyframe-card";
 import { TransitionGapEnhanced } from "./transition-gap";
 import {
@@ -40,6 +41,7 @@ interface Props {
   onRetry: (index: number) => void;
   onRequestVariations?: (keyframeId: string) => void;
   onOpenVariationLightbox?: (transitionIndex: number) => void;
+  onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
 }
 
 export const KeyframeStrip: React.FC<Props> = ({
@@ -49,6 +51,7 @@ export const KeyframeStrip: React.FC<Props> = ({
   onRetry,
   onRequestVariations,
   onOpenVariationLightbox,
+  onRequestI2iVariation,
 }) => {
   // Actions (stable refs)
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
@@ -150,6 +153,7 @@ export const KeyframeStrip: React.FC<Props> = ({
         index={i}
         onDelete={removeKeyframe}
         onRequestVariations={onRequestVariations}
+        onRequestI2iVariation={onRequestI2iVariation}
       />,
     );
   });

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -42,6 +42,8 @@ interface Props {
   onRequestVariations?: (keyframeId: string) => void;
   onOpenVariationLightbox?: (transitionIndex: number) => void;
   onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
+  onAcceptI2iCandidate?: (keyframe: FlowKeyframe) => void;
+  onDiscardI2iCandidate?: (keyframe: FlowKeyframe) => void;
 }
 
 export const KeyframeStrip: React.FC<Props> = ({
@@ -52,6 +54,8 @@ export const KeyframeStrip: React.FC<Props> = ({
   onRequestVariations,
   onOpenVariationLightbox,
   onRequestI2iVariation,
+  onAcceptI2iCandidate,
+  onDiscardI2iCandidate,
 }) => {
   // Actions (stable refs)
   const removeKeyframe = useFlowStore((s) => s.removeKeyframe);
@@ -154,6 +158,8 @@ export const KeyframeStrip: React.FC<Props> = ({
         onDelete={removeKeyframe}
         onRequestVariations={onRequestVariations}
         onRequestI2iVariation={onRequestI2iVariation}
+        onAcceptI2iCandidate={onAcceptI2iCandidate}
+        onDiscardI2iCandidate={onDiscardI2iCandidate}
       />,
     );
   });

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -32,6 +32,9 @@ import {
   LoopToggle,
   LoopCheckbox,
   EmptyState,
+  VariationsSection,
+  VariationsLabel,
+  VariationsRow,
 } from "./keyframe-strip.styled";
 
 interface Props {
@@ -69,12 +72,27 @@ export const KeyframeStrip: React.FC<Props> = ({
   const transitions = useFlowStore((s) => s.transitions);
   const globalDuration = useFlowStore((s) => s.globalDuration);
 
-  // Derive display keyframes from raw data to avoid new-array-every-render
+  // i2i candidates are a staging area: they are excluded from the store's
+  // `transitions` derivation (see timelineKeyframesWithLoop in flow.store). The
+  // strip's timeline must be built from the SAME non-candidate list so the
+  // transition-gap index mapping (transitionIndex = i - 1) lines up with the
+  // `transitions` array. Candidates render separately, without gaps.
+  const timelineKeyframes = useMemo(
+    () => rawKeyframes.filter((kf) => !kf.i2iCandidate),
+    [rawKeyframes],
+  );
+  const candidateKeyframes = useMemo(
+    () => rawKeyframes.filter((kf) => kf.i2iCandidate),
+    [rawKeyframes],
+  );
+
+  // Derive display keyframes (timeline + synthetic loop frame) from the
+  // candidate-free list to avoid new-array-every-render.
   const displayKeyframes = useMemo(() => {
-    if (!loop || rawKeyframes.length < 2) return rawKeyframes;
-    const first = rawKeyframes[0];
+    if (!loop || timelineKeyframes.length < 2) return timelineKeyframes;
+    const first = timelineKeyframes[0];
     return [
-      ...rawKeyframes,
+      ...timelineKeyframes,
       {
         id: LOOP_KEYFRAME_ID,
         keyframeUuid: first.keyframeUuid,
@@ -84,7 +102,7 @@ export const KeyframeStrip: React.FC<Props> = ({
         isLoopKeyframe: true,
       },
     ];
-  }, [rawKeyframes, loop]);
+  }, [timelineKeyframes, loop]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -98,21 +116,28 @@ export const KeyframeStrip: React.FC<Props> = ({
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
-      const oldIndex = rawKeyframes.findIndex((kf) => kf.id === active.id);
-      const newIndex = rawKeyframes.findIndex((kf) => kf.id === over.id);
+      // Only timeline (non-candidate) keyframes are sortable.
+      const oldIndex = timelineKeyframes.findIndex((kf) => kf.id === active.id);
+      const newIndex = timelineKeyframes.findIndex((kf) => kf.id === over.id);
       if (oldIndex === -1 || newIndex === -1) return;
 
-      const newOrder = [...rawKeyframes];
+      const newOrder = [...timelineKeyframes];
       const [moved] = newOrder.splice(oldIndex, 1);
       newOrder.splice(newIndex, 0, moved);
-      reorderKeyframes(newOrder.map((kf) => kf.id));
+      // Preserve candidates (untouched by drag) so reorderKeyframes does not
+      // drop them — it rebuilds keyframes from the id list it receives.
+      reorderKeyframes([
+        ...newOrder.map((kf) => kf.id),
+        ...candidateKeyframes.map((kf) => kf.id),
+      ]);
     },
-    [rawKeyframes, reorderKeyframes],
+    [timelineKeyframes, candidateKeyframes, reorderKeyframes],
   );
 
-  // Build items with gaps interleaved
+  // Build items with gaps interleaved. Only timeline keyframes are sortable;
+  // candidates are excluded so they never participate in drag/gap interleaving.
   const stripItems: React.ReactNode[] = [];
-  const sortableIds = rawKeyframes.map((kf) => kf.id);
+  const sortableIds = timelineKeyframes.map((kf) => kf.id);
 
   displayKeyframes.forEach((kf, i) => {
     if (i > 0) {
@@ -188,6 +213,23 @@ export const KeyframeStrip: React.FC<Props> = ({
             <StripContainer>{stripItems}</StripContainer>
           </SortableContext>
         </DndContext>
+      )}
+
+      {candidateKeyframes.length > 0 && (
+        <VariationsSection>
+          <VariationsLabel>Variations</VariationsLabel>
+          <VariationsRow>
+            {candidateKeyframes.map((kf, i) => (
+              <KeyframeCard
+                key={kf.id}
+                keyframe={kf}
+                index={i}
+                onAcceptI2iCandidate={onAcceptI2iCandidate}
+                onDiscardI2iCandidate={onDiscardI2iCandidate}
+              />
+            ))}
+          </VariationsRow>
+        </VariationsSection>
       )}
 
       <StripControls>

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -219,11 +219,13 @@ export const KeyframeStrip: React.FC<Props> = ({
         <VariationsSection>
           <VariationsLabel>Variations</VariationsLabel>
           <VariationsRow>
-            {candidateKeyframes.map((kf, i) => (
+            {candidateKeyframes.map((kf) => (
               <KeyframeCard
                 key={kf.id}
                 keyframe={kf}
-                index={i}
+                // `index` is unused for candidates: they show a "Variation"
+                // badge instead of a numbered label.
+                index={0}
                 onAcceptI2iCandidate={onAcceptI2iCandidate}
                 onDiscardI2iCandidate={onDiscardI2iCandidate}
               />
@@ -245,7 +247,10 @@ export const KeyframeStrip: React.FC<Props> = ({
           </AddButton>
         </AddButtons>
 
-        {rawKeyframes.length >= 2 && (
+        {/* Loop only engages when there are >= 2 real timeline keyframes;
+            i2i candidates are excluded from the transition derivation, so the
+            toggle must gate on the candidate-free count (matches displayKeyframes). */}
+        {timelineKeyframes.length >= 2 && (
           <LoopToggle>
             <LoopCheckbox
               type="checkbox"

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -42,7 +42,6 @@ interface Props {
   onAddFromPlaylist: () => void;
   onAddFromLibrary: () => void;
   onRetry: (index: number) => void;
-  onRequestVariations?: (keyframeId: string) => void;
   onOpenVariationLightbox?: (transitionIndex: number) => void;
   onRequestI2iVariation?: (keyframe: FlowKeyframe) => void;
   onAcceptI2iCandidate?: (keyframe: FlowKeyframe) => void;
@@ -54,7 +53,6 @@ export const KeyframeStrip: React.FC<Props> = ({
   onAddFromPlaylist,
   onAddFromLibrary,
   onRetry,
-  onRequestVariations,
   onOpenVariationLightbox,
   onRequestI2iVariation,
   onAcceptI2iCandidate,
@@ -181,7 +179,6 @@ export const KeyframeStrip: React.FC<Props> = ({
         keyframe={kf}
         index={i}
         onDelete={removeKeyframe}
-        onRequestVariations={onRequestVariations}
         onRequestI2iVariation={onRequestI2iVariation}
         onAcceptI2iCandidate={onAcceptI2iCandidate}
         onDiscardI2iCandidate={onDiscardI2iCandidate}

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -75,6 +75,15 @@ export function TransitionSettingsPanel({
 
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
+  // i2i candidates are a staging area excluded from the store's `transitions`
+  // derivation, so gate/look up against the non-candidate list only — otherwise
+  // a single real keyframe + a candidate would render this panel with zero
+  // real transitions (matches keyframe-strip's timelineKeyframes filter).
+  const realKeyframes = useMemo(
+    () => keyframes.filter((kf) => !kf.i2iCandidate),
+    [keyframes],
+  );
+
   // Per-transition mode?
   const isPerTransition = selectedTransitionIndex !== null;
   const selectedTransition =
@@ -293,14 +302,14 @@ export function TransitionSettingsPanel({
 
   const generateOneDisabled = isGenerating || needsPrompt;
 
-  // Don't show if fewer than 2 keyframes
-  if (keyframes.length < 2) return null;
+  // Don't show if fewer than 2 real (non-candidate) keyframes
+  if (realKeyframes.length < 2) return null;
 
-  // Transition header info — __loop__ maps back to the first keyframe
+  // Transition header info — __loop__ maps back to the first real keyframe
   const findName = (id: string | undefined) =>
     id === LOOP_KEYFRAME_ID
-      ? keyframes[0]?.name
-      : keyframes.find((kf) => kf.id === id)?.name;
+      ? realKeyframes[0]?.name
+      : realKeyframes.find((kf) => kf.id === id)?.name;
   const fromName =
     selectedTransition && findName(selectedTransition.fromKeyframeId);
   const toName =

--- a/src/components/pages/studio/components/variation-settings-panel.tsx
+++ b/src/components/pages/studio/components/variation-settings-panel.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { useStudioStore, DEFAULT_VARIATION_SEED } from "@/stores/studio.store";
+import { useFlowStore } from "@/stores/flow.store";
+import { useUserApiEndpoints } from "@/api/user-api-endpoints/useUserApiEndpoints";
 import type { ImageModel } from "@/types/studio.types";
 import {
   VARIATION_PRESETS,
@@ -47,6 +49,17 @@ export const VariationSettingsPanel: React.FC = () => {
   const variationSeed = useStudioStore((s) => s.variationSeed);
   const setVariationSeed = useStudioStore((s) => s.setVariationSeed);
 
+  // BYO image-to-image endpoints (user-configured API keys). Selecting one in
+  // the Model dropdown routes Vary through that endpoint instead of a built-in
+  // text-to-image model. The selection lives on the flow store so the
+  // per-keyframe Vary handler can read it.
+  const { data: endpointsData } = useUserApiEndpoints();
+  const i2iEndpoints = (endpointsData?.data?.endpoints ?? []).filter(
+    (ep) => ep.capabilities.imageToImage,
+  );
+  const i2iEndpointUuid = useFlowStore((s) => s.i2iEndpointUuid);
+  const setI2iEndpoint = useFlowStore((s) => s.setI2iEndpoint);
+
   // Custom variations are optional and collapsed by default.
   const [expanded, setExpanded] = useState(false);
 
@@ -70,9 +83,18 @@ export const VariationSettingsPanel: React.FC = () => {
         <FieldGroup>
           <FieldLabel>Model</FieldLabel>
           <Select
-            value={model}
+            value={i2iEndpointUuid ? `endpoint:${i2iEndpointUuid}` : model}
             onChange={(e) => {
-              const newModel = e.target.value as ImageModel;
+              const value = e.target.value;
+              if (value.startsWith("endpoint:")) {
+                // BYO i2i endpoint: route Vary through it; leave the built-in
+                // model untouched so switching back restores the prior choice.
+                setI2iEndpoint(value.slice("endpoint:".length));
+                return;
+              }
+              // Built-in model: clear any i2i endpoint so Vary uses the model.
+              setI2iEndpoint(null);
+              const newModel = value as ImageModel;
               setImageGenParams({
                 model: newModel,
                 size: clampSizeToModel(size, newModel),
@@ -84,6 +106,15 @@ export const VariationSettingsPanel: React.FC = () => {
                 {MODEL_LABELS[m]}
               </option>
             ))}
+            {i2iEndpoints.length > 0 && (
+              <optgroup label="My i2i endpoints">
+                {i2iEndpoints.map((ep) => (
+                  <option key={ep.uuid} value={`endpoint:${ep.uuid}`}>
+                    {ep.name}
+                  </option>
+                ))}
+              </optgroup>
+            )}
           </Select>
         </FieldGroup>
         <FieldGroup>

--- a/src/components/pages/studio/hooks/useFlowJobProgress.ts
+++ b/src/components/pages/studio/hooks/useFlowJobProgress.ts
@@ -43,6 +43,9 @@ type PendingEntry = {
   variationType?: "keyframe" | "transition";
   variationKeyframeId?: string;
   variationId?: string;
+  // i2i candidate tracking — when set, the entry is a staged i2i candidate
+  // keyframe (top-level keyframe with i2iParentId), not a kf.variations entry.
+  i2iCandidateId?: string;
 };
 
 export function useFlowJobProgress() {
@@ -101,6 +104,22 @@ export function useFlowJobProgress() {
           });
         }
       });
+
+      // i2i candidate keyframes — staged top-level keyframes whose own dream is
+      // still generating. Track them so we can swap the placeholder source image
+      // for each candidate's distinct result once it is processed.
+      if (
+        kf.i2iCandidate &&
+        kf.dreamUuid &&
+        (kf.i2iStatus === "queue" || kf.i2iStatus === "processing")
+      ) {
+        entries.push({
+          uuid: kf.dreamUuid,
+          index: -1,
+          isUprez: false,
+          i2iCandidateId: kf.id,
+        });
+      }
     });
 
     const uuids = entries.map((e) => e.uuid);
@@ -125,6 +144,38 @@ export function useFlowJobProgress() {
 
         const mappedStatus = mapStatus(data.status ?? "");
         if (!mappedStatus) return;
+
+        // i2i candidate keyframe progress — swap the placeholder source image
+        // for this candidate's own result once its dream is processed.
+        if (entry.i2iCandidateId) {
+          const patch: {
+            i2iStatus: typeof mappedStatus;
+            imageUrl?: string;
+          } = { i2iStatus: mappedStatus };
+          if (mappedStatus === "processed") {
+            try {
+              const headers = getRequestHeaders({
+                contentType: ContentType.json,
+              });
+              const { data: dreamData } = await axiosClient.get(
+                `/v1/dream/${uuid}`,
+                { headers },
+              );
+              const dream = dreamData?.data?.dream;
+              if (dream) {
+                patch.imageUrl =
+                  dream.video || dream.original_video || dream.thumbnail || "";
+              }
+            } catch {
+              // Non-fatal — imageUrl will be resolved by the next poll cycle.
+            }
+            // If the result URL didn't resolve, stay pending so the poll
+            // fallback retries instead of freezing on the placeholder image.
+            if (!patch.imageUrl) patch.i2iStatus = "processing";
+          }
+          useFlowStore.getState().updateKeyframe(entry.i2iCandidateId, patch);
+          return;
+        }
 
         // Variation candidate progress
         if (entry.variationType && entry.variationId) {
@@ -262,6 +313,21 @@ export function useFlowJobProgress() {
 
           const mappedStatus = mapStatus(dream.status);
           if (!mappedStatus) continue;
+
+          // i2i candidate keyframe — swap the placeholder source image for this
+          // candidate's own result once processed.
+          if (entry.i2iCandidateId) {
+            const patch: {
+              i2iStatus: typeof mappedStatus;
+              imageUrl?: string;
+            } = { i2iStatus: mappedStatus };
+            if (mappedStatus === "processed") {
+              patch.imageUrl =
+                dream.video || dream.original_video || dream.thumbnail || "";
+            }
+            useFlowStore.getState().updateKeyframe(entry.i2iCandidateId, patch);
+            continue;
+          }
 
           // Variation candidate — update with status + imageUrl when processed
           if (entry.variationType && entry.variationId) {

--- a/src/components/shared/profile-card/profile-card.tsx
+++ b/src/components/shared/profile-card/profile-card.tsx
@@ -67,6 +67,7 @@ import router from "@/routes/router";
 import { ROUTES } from "@/constants/routes.constants";
 import { joinPaths } from "@/utils/router.util";
 import { filterNsfwOption } from "@/utils/select.util";
+import { ApiEndpointsSection } from "@/components/pages/profile/api-endpoints-section";
 
 type ProfileDetailsProps = {
   user?: Omit<User, "token">;
@@ -283,6 +284,12 @@ const ProfileDetails: React.FC<ProfileDetailsProps> = ({
         >
           <ApiKeyCard user={user} />
         </Row>
+      )}
+
+      {showApiKeyCard && (
+        <Column flex={["0 0 100%", "0 0 100%"]}>
+          <ApiEndpointsSection />
+        </Column>
       )}
     </Row>
   );

--- a/src/constants/endpoint-presets.ts
+++ b/src/constants/endpoint-presets.ts
@@ -1,0 +1,60 @@
+import type {
+  EndpointProviderType,
+  EndpointCapabilities,
+} from "@/types/user-api-endpoint.types";
+
+export interface EndpointPreset {
+  id: string;
+  name: string;
+  providerType: EndpointProviderType;
+  endpointUrl: string;
+  modelId: string;
+  capabilities: EndpointCapabilities;
+  description: string;
+  keyUrl: string;
+}
+
+export const ENDPOINT_PRESETS: EndpointPreset[] = [
+  {
+    id: "flux-schnell",
+    name: "FAL — Flux Schnell",
+    providerType: "fal",
+    endpointUrl: "https://fal.run/fal-ai/flux/schnell",
+    modelId: "fal-ai/flux/schnell",
+    capabilities: {
+      textToImage: true,
+      imageToImage: true,
+      sizes: ["1024x1024", "1280x720", "720x1280"],
+    },
+    description: "Fast image generation & i2i · ~$0.003/image",
+    keyUrl: "https://fal.ai/dashboard/keys",
+  },
+  {
+    id: "flux-pro",
+    name: "FAL — Flux Pro",
+    providerType: "fal",
+    endpointUrl: "https://fal.run/fal-ai/flux-pro",
+    modelId: "fal-ai/flux-pro",
+    capabilities: {
+      textToImage: true,
+      imageToImage: true,
+      sizes: ["1024x1024", "1280x720", "720x1280"],
+    },
+    description: "Higher quality, slower · ~$0.05/image",
+    keyUrl: "https://fal.ai/dashboard/keys",
+  },
+  {
+    id: "openai-gpt-image-1",
+    name: "OpenAI — gpt-image-1",
+    providerType: "openai",
+    endpointUrl: "https://api.openai.com/v1",
+    modelId: "gpt-image-1",
+    capabilities: {
+      textToImage: true,
+      imageToImage: true,
+      sizes: ["1024x1024", "1536x1024", "1024x1536"],
+    },
+    description: "High quality image generation & editing · ~$0.02–0.19/image",
+    keyUrl: "https://platform.openai.com/api-keys",
+  },
+];

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -410,6 +410,76 @@ describe("Phase 1: transitions", () => {
     });
   });
 
+  describe("i2i candidates", () => {
+    it("does not create transitions between candidates", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe(makeKf("a"));
+      store.addKeyframe(makeKf("b"));
+      store.recomputeTransitions();
+      expect(useFlowStore.getState().transitions).toHaveLength(1);
+
+      // Add 4 candidates varied from "b" — they must not add transitions.
+      store.addI2iCandidates("b", [
+        makeKf("c1"),
+        makeKf("c2"),
+        makeKf("c3"),
+        makeKf("c4"),
+      ]);
+
+      const state = useFlowStore.getState();
+      // Candidates are appended to keyframes (rendered as cards)...
+      expect(state.keyframes).toHaveLength(6);
+      expect(state.keyframes.filter((k) => k.i2iCandidate)).toHaveLength(4);
+      // ...but the timeline still only has the a→b transition.
+      expect(state.transitions).toHaveLength(1);
+      expect(state.transitions[0].fromKeyframeId).toBe("a");
+      expect(state.transitions[0].toKeyframeId).toBe("b");
+    });
+
+    it("flags candidates with i2iCandidate and i2iParentId", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe(makeKf("a"));
+      store.addI2iCandidates("a", [makeKf("c1")]);
+      const cand = useFlowStore
+        .getState()
+        .keyframes.find((k) => k.id === "c1");
+      expect(cand?.i2iCandidate).toBe(true);
+      expect(cand?.i2iParentId).toBe("a");
+    });
+
+    it("accept promotes a candidate into the timeline", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe(makeKf("a"));
+      store.addI2iCandidates("a", [makeKf("c1")]);
+      expect(useFlowStore.getState().transitions).toHaveLength(0);
+
+      store.acceptI2iCandidate("c1");
+      const state = useFlowStore.getState();
+      const promoted = state.keyframes.find((k) => k.id === "c1");
+      expect(promoted?.i2iCandidate).toBeUndefined();
+      expect(promoted?.i2iParentId).toBeUndefined();
+      // Now a→c1 is a real transition.
+      expect(state.transitions).toHaveLength(1);
+      expect(state.transitions[0].fromKeyframeId).toBe("a");
+      expect(state.transitions[0].toKeyframeId).toBe("c1");
+    });
+
+    it("discard removes a candidate without touching transitions", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe(makeKf("a"));
+      store.addKeyframe(makeKf("b"));
+      store.recomputeTransitions();
+      store.addI2iCandidates("b", [makeKf("c1"), makeKf("c2")]);
+
+      store.discardI2iCandidate("c1");
+      const state = useFlowStore.getState();
+      expect(state.keyframes.find((k) => k.id === "c1")).toBeUndefined();
+      expect(state.keyframes.find((k) => k.id === "c2")).toBeDefined();
+      // a→b transition untouched.
+      expect(state.transitions).toHaveLength(1);
+    });
+  });
+
   describe("hydration", () => {
     it("resets stale processing/queue transitions to failed on recompute", () => {
       const store = useFlowStore.getState();

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -440,9 +440,7 @@ describe("Phase 1: transitions", () => {
       const store = useFlowStore.getState();
       store.addKeyframe(makeKf("a"));
       store.addI2iCandidates("a", [makeKf("c1")]);
-      const cand = useFlowStore
-        .getState()
-        .keyframes.find((k) => k.id === "c1");
+      const cand = useFlowStore.getState().keyframes.find((k) => k.id === "c1");
       expect(cand?.i2iCandidate).toBe(true);
       expect(cand?.i2iParentId).toBe("a");
     });

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -38,6 +38,12 @@ export type FlowStoreState = {
   updateKeyframe: (id: string, patch: Partial<FlowKeyframe>) => void;
   removeKeyframe: (id: string) => void;
   reorderKeyframes: (orderedIds: string[]) => void;
+
+  // i2i candidate staging — candidates are excluded from transition derivation
+  // until accepted, so they never spawn generation jobs.
+  addI2iCandidates: (parentId: string, candidates: FlowKeyframe[]) => void;
+  acceptI2iCandidate: (id: string) => void;
+  discardI2iCandidate: (id: string) => void;
   setLoop: (loop: boolean) => void;
   keyframesWithLoop: () => FlowKeyframe[];
   resetFlow: () => void;
@@ -144,6 +150,20 @@ const PHASE_1_DEFAULTS = {
 };
 
 /**
+ * Build the keyframe sequence that drives transition derivation.
+ * i2i candidates are a staging area and must NOT participate in the timeline,
+ * so they are filtered out BEFORE the synthetic loop frame is appended.
+ * Transitions are therefore derived only over real (non-candidate) keyframes.
+ */
+function timelineKeyframesWithLoop(
+  keyframes: FlowKeyframe[],
+  loop: boolean,
+): FlowKeyframe[] {
+  const real = keyframes.filter((kf) => !kf.i2iCandidate);
+  return buildKeyframesWithLoop(real, loop);
+}
+
+/**
  * Build transitions from adjacent keyframe pairs.
  * Preserves existing transition state when pairs still match.
  */
@@ -196,7 +216,7 @@ export const useFlowStore = create<FlowStoreState>()(
           return {
             keyframes,
             transitions: deriveTransitions(
-              buildKeyframesWithLoop(keyframes, s.loop),
+              timelineKeyframesWithLoop(keyframes, s.loop),
               s.transitions,
             ),
           };
@@ -215,7 +235,7 @@ export const useFlowStore = create<FlowStoreState>()(
           return {
             keyframes,
             transitions: deriveTransitions(
-              buildKeyframesWithLoop(keyframes, s.loop),
+              timelineKeyframesWithLoop(keyframes, s.loop),
               s.transitions,
             ),
           };
@@ -230,7 +250,58 @@ export const useFlowStore = create<FlowStoreState>()(
           return {
             keyframes,
             transitions: deriveTransitions(
-              buildKeyframesWithLoop(keyframes, s.loop),
+              timelineKeyframesWithLoop(keyframes, s.loop),
+              s.transitions,
+            ),
+          };
+        }),
+
+      // Append i2i candidates flagged so derivation skips them. Recompute
+      // transitions: per the filter in timelineKeyframesWithLoop the candidates
+      // are excluded, so no garbage transitions appear between them.
+      addI2iCandidates: (parentId, candidates) =>
+        set((s) => {
+          const flagged = candidates.map((kf) => ({
+            ...kf,
+            i2iCandidate: true,
+            i2iParentId: parentId,
+          }));
+          const keyframes = [...s.keyframes, ...flagged];
+          return {
+            keyframes,
+            transitions: deriveTransitions(
+              timelineKeyframesWithLoop(keyframes, s.loop),
+              s.transitions,
+            ),
+          };
+        }),
+
+      // Promote a candidate to a real keyframe: clear the staging flags and
+      // re-derive so it is wired into the timeline transitions.
+      acceptI2iCandidate: (id) =>
+        set((s) => {
+          const keyframes = s.keyframes.map((kf) =>
+            kf.id === id
+              ? { ...kf, i2iCandidate: undefined, i2iParentId: undefined }
+              : kf,
+          );
+          return {
+            keyframes,
+            transitions: deriveTransitions(
+              timelineKeyframesWithLoop(keyframes, s.loop),
+              s.transitions,
+            ),
+          };
+        }),
+
+      // Remove a candidate entirely and re-derive (mirrors removeKeyframe).
+      discardI2iCandidate: (id) =>
+        set((s) => {
+          const keyframes = s.keyframes.filter((kf) => kf.id !== id);
+          return {
+            keyframes,
+            transitions: deriveTransitions(
+              timelineKeyframesWithLoop(keyframes, s.loop),
               s.transitions,
             ),
           };
@@ -240,7 +311,7 @@ export const useFlowStore = create<FlowStoreState>()(
         set((s) => ({
           loop,
           transitions: deriveTransitions(
-            buildKeyframesWithLoop(s.keyframes, loop),
+            timelineKeyframesWithLoop(s.keyframes, loop),
             s.transitions,
           ),
         })),
@@ -345,7 +416,7 @@ export const useFlowStore = create<FlowStoreState>()(
       recomputeTransitions: () =>
         set((s) => ({
           transitions: deriveTransitions(
-            buildKeyframesWithLoop(s.keyframes, s.loop),
+            timelineKeyframesWithLoop(s.keyframes, s.loop),
             s.transitions,
           ),
         })),
@@ -545,7 +616,15 @@ export const useFlowStore = create<FlowStoreState>()(
         // A finalized keyframe has either a backend Keyframe UUID (playlist)
         // or an image Dream UUID (uploaded).
         keyframes: state.keyframes
-          .filter((kf) => (kf.keyframeUuid || kf.dreamUuid) && !kf.uploadStatus)
+          // Exclude unsettled records AND i2i candidates. A candidate has no
+          // accepted place in the timeline yet; persisting one would resurrect
+          // a staging card on reload that no transition references.
+          .filter(
+            (kf) =>
+              (kf.keyframeUuid || kf.dreamUuid) &&
+              !kf.uploadStatus &&
+              !kf.i2iCandidate,
+          )
           .map((kf) => ({
             id: kf.id,
             keyframeUuid: kf.keyframeUuid,

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -60,6 +60,10 @@ export type FlowStoreState = {
   settingsExpanded: boolean;
   previewLightboxOpen: boolean;
 
+  // i2i — selected user API endpoint for image-to-image variations.
+  // Non-persisted UI state (resolved fresh from the user's endpoint list each session).
+  i2iEndpointUuid: string | null;
+
   // Phase 1 — actions
   setGlobalPreset: (id: string) => void;
   setGlobalPrompt: (prompt: string) => void;
@@ -77,6 +81,7 @@ export type FlowStoreState = {
   selectTransition: (index: number | null) => void;
   setSettingsExpanded: (expanded: boolean) => void;
   setPreviewLightboxOpen: (open: boolean) => void;
+  setI2iEndpoint: (uuid: string | null) => void;
   updateTransitionStatus: (
     index: number,
     status: TransitionStatus,
@@ -135,6 +140,7 @@ const PHASE_1_DEFAULTS = {
   selectedTransitionIndex: null as number | null,
   settingsExpanded: false,
   previewLightboxOpen: false,
+  i2iEndpointUuid: null as string | null,
 };
 
 /**
@@ -294,6 +300,7 @@ export const useFlowStore = create<FlowStoreState>()(
       selectTransition: (index) => set({ selectedTransitionIndex: index }),
       setSettingsExpanded: (expanded) => set({ settingsExpanded: expanded }),
       setPreviewLightboxOpen: (open) => set({ previewLightboxOpen: open }),
+      setI2iEndpoint: (uuid) => set({ i2iEndpointUuid: uuid }),
 
       updateTransitionStatus: (index, status, progress) =>
         set((s) => {

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -20,6 +20,10 @@ export interface FlowKeyframe {
   // derivation (and therefore from generation) until the user accepts one.
   i2iCandidate?: boolean;
   i2iParentId?: string; // FlowKeyframe.id this candidate was varied from
+  // Generation status of a candidate's own i2i/t2i dream. While "queue"/
+  // "processing" the card shows the parent's source image as a placeholder;
+  // job progress swaps in this candidate's distinct result once "processed".
+  i2iStatus?: "queue" | "processing" | "processed" | "failed";
 
   // Local-only upload state — never persisted to backend.
   uploadStatus?: "uploading" | "failed";

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -15,6 +15,12 @@ export interface FlowKeyframe {
   name: string; // display name
   isLoopKeyframe?: boolean; // true for auto-generated loop frame
 
+  // i2i staging — a pending image-to-image variation candidate. Candidates are
+  // a staging area: they render as cards but are EXCLUDED from transition
+  // derivation (and therefore from generation) until the user accepts one.
+  i2iCandidate?: boolean;
+  i2iParentId?: string; // FlowKeyframe.id this candidate was varied from
+
   // Local-only upload state — never persisted to backend.
   uploadStatus?: "uploading" | "failed";
   uploadProgress?: number; // 0-100

--- a/src/types/user-api-endpoint.types.ts
+++ b/src/types/user-api-endpoint.types.ts
@@ -1,0 +1,39 @@
+export type EndpointProviderType = "openai" | "fal";
+
+export interface EndpointCapabilities {
+  textToImage: boolean;
+  imageToImage: boolean;
+  sizes: string[];
+}
+
+export interface UserApiEndpoint {
+  uuid: string;
+  name: string;
+  providerType: EndpointProviderType;
+  presetId: string;
+  endpointUrl: string;
+  apiKeyLastFour: string;
+  modelId: string;
+  capabilities: EndpointCapabilities;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateUserApiEndpointParams {
+  name: string;
+  providerType: EndpointProviderType;
+  presetId: string;
+  endpointUrl: string;
+  apiKey: string;
+  modelId: string;
+  capabilities: EndpointCapabilities;
+}
+
+export interface UpdateUserApiEndpointParams {
+  uuid: string;
+  name?: string;
+  endpointUrl?: string;
+  apiKey?: string;
+  modelId?: string;
+  capabilities?: EndpointCapabilities;
+}


### PR DESCRIPTION
## Phase 1: API Key Config & i2i Variations — Frontend

Adds account-page management of user image-generation endpoints and wires them into the studio (model picker + i2i variations).

### What's in this PR
- **Types + preset constants** for user endpoints (Flux Schnell/Pro, OpenAI gpt-image-1) + a custom OpenAI-compatible option.
- **React Query hooks** — list/create/update/delete/test of `/v1/user/api-endpoints`.
- **Account page "API Endpoints" section** + add/edit modal (two-step preset flow, key entry, capabilities). Delete uses the shared `ConfirmModal`.
- **Studio integration** — user endpoints appended to the images-tab model picker; selection reconciled if an endpoint is deleted.
- **i2i variations** — a "Vary (i2i)" action on keyframe cards. Variations are generated as **gated candidates**: flagged `i2iCandidate`, excluded from transition derivation, generation, and `partialize`, rendered in a separate non-draggable "Variations" staging row with **Accept / Discard**. Source image is sent as a fetchable URL (not a Dream UUID), and the 4 generations fire concurrently.

### Notable design points
- Candidate gating keeps `generateAll` from firing real LTX video transitions between staging frames, and prevents ghost cards on reload.
- Transition-gap index mapping in the strip derives from the candidate-free timeline so it stays 1:1 with the store's `transitions`.
- Reads volatile store data via `getState()` in callbacks; Bugsnag (not console) for errors — per the project's anti-rationalization rules.

### Cross-repo dependency
This is **1 of 3** PRs and is not functional end-to-end alone:
- backend: endpoint CRUD/encryption + dream→`user-endpoint` queue routing
- worker: OpenAI/FAL adapters

Merge the three together.

### Verification
`pnpm type-check` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm test` (92 tests) ✓

Plan & design: `docs/superpowers/plans/2026-06-12-api-key-config-i2i-variations.md` (metarepo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
