### PR TITLE
Show aspect ratio visually in studio size menus

### DIFF
--- a/src/components/pages/studio/components/generate-keyframes-modal.tsx
+++ b/src/components/pages/studio/components/generate-keyframes-modal.tsx
@@ -14,6 +14,7 @@ import {
   IMAGE_COUNT_OPTIONS,
   clampSizeToAllowed,
 } from "../constants/size-options";
+import { SizeSelect } from "./size-select";
 import {
   Overlay,
   Panel,
@@ -193,16 +194,11 @@ export const GenerateKeyframesModal: React.FC<Props> = ({ onClose }) => {
             </FieldGroup>
             <FieldGroup>
               <FieldLabel>Size</FieldLabel>
-              <Select
+              <SizeSelect
                 value={imageGenParams.size}
-                onChange={(e) => setImageGenParams({ size: e.target.value })}
-              >
-                {sizeOptions.map((s) => (
-                  <option key={s} value={s}>
-                    {s.replace("*", "x")}
-                  </option>
-                ))}
-              </Select>
+                options={sizeOptions}
+                onChange={(size) => setImageGenParams({ size })}
+              />
             </FieldGroup>
           </FieldRow>
           <CreditLimitNotice

--- a/src/components/pages/studio/components/images-tab.styled.tsx
+++ b/src/components/pages/studio/components/images-tab.styled.tsx
@@ -17,6 +17,17 @@ export const SectionTitle = styled.h3`
   margin-bottom: 1rem;
 `;
 
+export const SectionHeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+
+  ${SectionTitle} {
+    margin-bottom: 0;
+  }
+`;
+
 export const PromptTextarea = styled.textarea`
   width: 100%;
   min-height: 80px;

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -15,6 +15,7 @@ import {
   IMAGE_COUNT_OPTIONS,
   clampSizeToAllowed,
 } from "../constants/size-options";
+import { SizeSelect } from "./size-select";
 import {
   GenerateSection,
   SectionTitle,
@@ -22,6 +23,7 @@ import {
   FormRow,
   FormField,
   FieldLabel,
+  SectionHeaderRow,
   StyledSelect,
   GenerateButton,
   ImageGrid,
@@ -250,20 +252,12 @@ export const ImagesTab: React.FC = () => {
           </FormField>
           <FormField>
             <FieldLabel>Size:</FieldLabel>
-            <StyledSelect
+            <SizeSelect
               value={imageGenParams.size}
-              onChange={(e) => setImageGenParams({ size: e.target.value })}
-            >
-              {sizeOptions.map((s) => (
-                <option key={s} value={s}>
-                  {s.replace("*", "x")}
-                </option>
-              ))}
-            </StyledSelect>
+              options={sizeOptions}
+              onChange={(size) => setImageGenParams({ size })}
+            />
           </FormField>
-          <SecondaryNavButton onClick={() => fileInputRef.current?.click()}>
-            Upload
-          </SecondaryNavButton>
           <CostEstimate amountUsd={totalCostUsd} breakdown={costBreakdown} />
           <GenerateButton
             onClick={handleGenerate}
@@ -280,7 +274,17 @@ export const ImagesTab: React.FC = () => {
       </GenerateSection>
 
       <GenerateSection>
-        <SectionTitle>Image Library</SectionTitle>
+        <SectionHeaderRow>
+          <SectionTitle>Image Library</SectionTitle>
+          <ButtonRow>
+            <NavButton onClick={() => fileInputRef.current?.click()}>
+              + Upload
+            </NavButton>
+            <NavButton onClick={() => setShowPlaylistModal(true)}>
+              + Add from Playlist
+            </NavButton>
+          </ButtonRow>
+        </SectionHeaderRow>
         {images.length === 0 ? (
           <EmptyStateText>
             No images yet. Generate some above, upload, or add from a playlist.
@@ -349,9 +353,6 @@ export const ImagesTab: React.FC = () => {
             )}
           </ButtonRow>
           <ButtonRow>
-            <SecondaryNavButton onClick={() => setShowPlaylistModal(true)}>
-              + Add from Playlist
-            </SecondaryNavButton>
             <NavButton onClick={() => setActiveTab("actions")}>
               Continue to Actions &rarr;
             </NavButton>

--- a/src/components/pages/studio/components/size-select.styled.tsx
+++ b/src/components/pages/studio/components/size-select.styled.tsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+export const Wrapper = styled.div`
+  position: relative;
+`;
+
+export const Trigger = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  appearance: none;
+  background-color: ${FLOW.bgInput};
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='%238a8890' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  border: 1px solid ${FLOW.border};
+  border-radius: ${FLOW.radiusSm};
+  color: ${FLOW.text};
+  font-family: ${FLOW.fontFamily};
+  font-size: 13px;
+  padding: 6px 32px 6px 12px;
+  cursor: pointer;
+  min-width: 140px;
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${FLOW.accent};
+  }
+`;
+
+export const Dropdown = styled.ul`
+  position: fixed;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background-color: ${FLOW.bgElevated};
+  border: 1px solid ${FLOW.border};
+  border-radius: ${FLOW.radiusSm};
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  /* Above the modal overlay (z-index 1000) since the menu portals to body. */
+  z-index: 1100;
+`;
+
+export const OptionRow = styled.li<{ $selected: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 32px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  color: ${(p) => (p.$selected ? FLOW.accent : FLOW.text)};
+  font-family: ${FLOW.fontFamily};
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${FLOW.accentDim};
+  }
+`;
+
+export const RatioRect = styled.span`
+  display: inline-block;
+  flex-shrink: 0;
+  margin-left: auto;
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+  opacity: 0.85;
+`;

--- a/src/components/pages/studio/components/size-select.tsx
+++ b/src/components/pages/studio/components/size-select.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { formatSizeLabel, parseSize } from "../constants/size-options";
+import {
+  Dropdown,
+  OptionRow,
+  RatioRect,
+  Trigger,
+  Wrapper,
+} from "./size-select.styled";
+
+// Bounding box the aspect-ratio rectangle is fitted into, in px.
+const RECT_MAX_WIDTH = 28;
+const RECT_MAX_HEIGHT = 20;
+
+// Estimated per-item height + dropdown padding, used to decide whether the
+// menu fits below the trigger before it has rendered.
+const ITEM_HEIGHT = 32;
+const MENU_PADDING = 10;
+const MENU_GAP = 4;
+
+const AspectRatioRect: React.FC<{ size: string }> = ({ size }) => {
+  const parsed = parseSize(size);
+  if (!parsed) {
+    return null;
+  }
+  const scale = Math.min(
+    RECT_MAX_WIDTH / parsed.width,
+    RECT_MAX_HEIGHT / parsed.height,
+  );
+  return (
+    <RatioRect
+      style={{
+        width: Math.max(4, Math.round(parsed.width * scale)),
+        height: Math.max(4, Math.round(parsed.height * scale)),
+      }}
+    />
+  );
+};
+
+interface MenuPosition {
+  left: number;
+  minWidth: number;
+  top?: number;
+  bottom?: number;
+}
+
+interface Props {
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+}
+
+export const SizeSelect: React.FC<Props> = ({ value, options, onChange }) => {
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+  const isOpen = menuPosition !== null;
+
+  const toggleOpen = () => {
+    if (isOpen || !triggerRef.current) {
+      setMenuPosition(null);
+      return;
+    }
+    const rect = triggerRef.current.getBoundingClientRect();
+    const menuHeight = options.length * ITEM_HEIGHT + MENU_PADDING;
+    const fitsBelow =
+      rect.bottom + MENU_GAP + menuHeight <= window.innerHeight ||
+      rect.top - MENU_GAP - menuHeight < 0;
+    setMenuPosition({
+      left: rect.left,
+      minWidth: rect.width,
+      ...(fitsBelow
+        ? { top: rect.bottom + MENU_GAP }
+        : { bottom: window.innerHeight - rect.top + MENU_GAP }),
+    });
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        !triggerRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
+        setMenuPosition(null);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMenuPosition(null);
+      }
+    };
+    // The menu is position: fixed, so any scroll or resize desyncs it from
+    // the trigger; close instead of tracking.
+    const handleClose = () => setMenuPosition(null);
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("scroll", handleClose, true);
+    window.addEventListener("resize", handleClose);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("scroll", handleClose, true);
+      window.removeEventListener("resize", handleClose);
+    };
+  }, [isOpen]);
+
+  return (
+    <Wrapper>
+      <Trigger
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={toggleOpen}
+      >
+        {formatSizeLabel(value)}
+        <AspectRatioRect size={value} />
+      </Trigger>
+      {isOpen &&
+        createPortal(
+          <Dropdown ref={menuRef} role="listbox" style={menuPosition}>
+            {options.map((s) => (
+              <OptionRow
+                key={s}
+                role="option"
+                aria-selected={s === value}
+                $selected={s === value}
+                onClick={() => {
+                  onChange(s);
+                  setMenuPosition(null);
+                }}
+              >
+                {formatSizeLabel(s)}
+                <AspectRatioRect size={s} />
+              </OptionRow>
+            ))}
+          </Dropdown>,
+          document.body,
+        )}
+    </Wrapper>
+  );
+};

--- a/src/components/pages/studio/constants/size-options.test.ts
+++ b/src/components/pages/studio/constants/size-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clampSizeToAllowed } from "./size-options";
+import { clampSizeToAllowed, formatSizeLabel, parseSize } from "./size-options";
 
 const QWEN_SIZES = ["1280*720", "1024*1024", "720*1280", "512*512"];
 
@@ -18,5 +18,35 @@ describe("clampSizeToAllowed", () => {
 
   it("keeps the current size when no options are loaded yet", () => {
     expect(clampSizeToAllowed("768*768", [])).toBe("768*768");
+  });
+});
+
+describe("parseSize", () => {
+  it("parses star-separated sizes", () => {
+    expect(parseSize("1280*720")).toEqual({ width: 1280, height: 720 });
+  });
+
+  it("parses x-separated sizes", () => {
+    expect(parseSize("512x512")).toEqual({ width: 512, height: 512 });
+  });
+
+  it("parses unicode multiplication sign", () => {
+    expect(parseSize("720×1280")).toEqual({ width: 720, height: 1280 });
+  });
+
+  it("returns null for nonsense", () => {
+    expect(parseSize("nonsense")).toBeNull();
+    expect(parseSize("")).toBeNull();
+    expect(parseSize("0*720")).toBeNull();
+  });
+});
+
+describe("formatSizeLabel", () => {
+  it("replaces the star separator with x", () => {
+    expect(formatSizeLabel("1280*720")).toBe("1280x720");
+  });
+
+  it("leaves x-separated sizes unchanged", () => {
+    expect(formatSizeLabel("512x512")).toBe("512x512");
   });
 });

--- a/src/components/pages/studio/constants/size-options.ts
+++ b/src/components/pages/studio/constants/size-options.ts
@@ -1,5 +1,22 @@
 export const IMAGE_COUNT_OPTIONS = [1, 4, 8, 12, 16, 24] as const;
 
+export const parseSize = (
+  size: string,
+): { width: number; height: number } | null => {
+  const match = size.match(/^\s*(\d+)\s*[x×*]\s*(\d+)\s*$/i);
+  if (!match) {
+    return null;
+  }
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+};
+
+export const formatSizeLabel = (size: string): string => size.replace("*", "x");
+
 export const clampSizeToAllowed = (
   currentSize: string,
   sizes: readonly string[],


### PR DESCRIPTION
## Summary
- Replaces the native size `<select>` in the Flow **Generate Keyframes** dialog and the Batch **Images** tab with a custom `SizeSelect` dropdown that draws an outlined rectangle depicting each size's aspect ratio (right-aligned in a vertical column, taller rows for room)
- Renders the menu through a portal to `document.body` with fixed positioning so the modal's `overflow: hidden` can't truncate it; flips upward when there's no room below, and closes on outside-click, Escape, and scroll/resize
- Adds `parseSize()` / `formatSizeLabel()` helpers with unit tests (handles `*`, `x`, and `×` separators)
- Batch tab: moves the Upload button onto the Image Library header row next to "+ Add from Playlist", renamed "+ Upload" and restyled to match the primary buttons

Closes #667

## Test plan
- [x] `pnpm run type-check`, ESLint, and `vitest` (10 size-option tests) pass
- [x] Verified in-browser: Flow dialog menu no longer clipped by the dialog, selection updates the trigger, Batch tab menu and relocated buttons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)