### PR TITLE
Flow builder: aspect-ratio-aware display + visual crop (#668)

### DIFF
--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -11,10 +11,13 @@ export const CardWrapper = styled.div<{
   $isDragging?: boolean;
   $uploading?: boolean;
   $failed?: boolean;
+  $ratio?: number;
 }>`
   flex-shrink: 0;
-  width: 140px;
-  height: 100px;
+  /* Width tracks the output aspect ratio at a fixed height, so the strip shows
+     each keyframe's true shape (#668). Falls back to ~140x100 when unknown. */
+  height: 104px;
+  width: ${(p) => Math.round(104 * (p.$ratio ?? 1.4))}px;
   border-radius: ${FLOW.radiusSm};
   overflow: hidden;
   isolation: isolate;
@@ -203,6 +206,34 @@ export const DeleteButton = styled.button`
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.2s;
+
+  ${CardWrapper}:hover & {
+    opacity: 1;
+  }
+`;
+
+export const CropButton = styled.button`
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.7);
+  color: ${FLOW.text};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.2s,
+    color 0.15s;
+
+  &:hover {
+    color: ${FLOW.accent};
+  }
 
   ${CardWrapper}:hover & {
     opacity: 1;

--- a/src/components/pages/studio/components/keyframe-card.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-card.styled.tsx
@@ -212,6 +212,25 @@ export const DeleteButton = styled.button`
   }
 `;
 
+export const CroppedBadge = styled.span`
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px 2px 5px;
+  border-radius: 5px;
+  background: ${FLOW.accentDim};
+  color: ${FLOW.accent};
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  backdrop-filter: blur(4px);
+  pointer-events: none;
+`;
+
 export const CropButton = styled.button`
   position: absolute;
   bottom: 4px;

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -6,7 +6,11 @@ import type { FlowKeyframe } from "@/types/flow.types";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
-import type { CropRegion } from "@/utils/aspect-crop";
+import {
+  type CropRegion,
+  defaultCenterCrop,
+  isFullFrameCrop,
+} from "@/utils/aspect-crop";
 import {
   CardWrapper,
   CardImage,
@@ -15,6 +19,7 @@ import {
   LoopBadge,
   DeleteButton,
   CropButton,
+  CroppedBadge,
   UploadOverlay,
   UploadRing,
   UploadRingTrack,
@@ -138,8 +143,22 @@ export const KeyframeCard: React.FC<Props> = ({
     }
   };
 
+  // Effective crop = the user's explicit crop, else a derived center crop for
+  // the flow's output ratio. Frames whose source already matches the ratio come
+  // out full-frame (untouched); only the odd-aspect frames are actually cropped.
+  const effectiveCrop: CropRegion | undefined =
+    keyframe.naturalWidth && keyframe.naturalHeight
+      ? keyframe.crop ??
+        defaultCenterCrop(
+          keyframe.naturalWidth,
+          keyframe.naturalHeight,
+          outputRatio,
+        )
+      : undefined;
+  const isCropped = !isLoop && !!effectiveCrop && !isFullFrameCrop(effectiveCrop);
+
   const imageStyle: React.CSSProperties = {
-    ...(keyframe.crop ? cropStyle(keyframe.crop) : {}),
+    ...(effectiveCrop ? cropStyle(effectiveCrop) : {}),
     ...(isClickable ? { cursor: "pointer" } : {}),
   };
 
@@ -191,6 +210,12 @@ export const KeyframeCard: React.FC<Props> = ({
           <AlertTriangle size={16} strokeWidth={2.2} />
           Upload failed
         </FailedOverlay>
+      )}
+
+      {isCropped && !isBusy && (
+        <CroppedBadge title="Cropped to match the flow's output shape">
+          <Crop size={9} strokeWidth={2.4} /> cropped
+        </CroppedBadge>
       )}
 
       <CardLabel>

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -155,7 +155,8 @@ export const KeyframeCard: React.FC<Props> = ({
           outputRatio,
         )
       : undefined;
-  const isCropped = !isLoop && !!effectiveCrop && !isFullFrameCrop(effectiveCrop);
+  const isCropped =
+    !isLoop && !!effectiveCrop && !isFullFrameCrop(effectiveCrop);
 
   const imageStyle: React.CSSProperties = {
     ...(effectiveCrop ? cropStyle(effectiveCrop) : {}),

--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Crop } from "lucide-react";
 import type { FlowKeyframe } from "@/types/flow.types";
 import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
+import type { CropRegion } from "@/utils/aspect-crop";
 import {
   CardWrapper,
   CardImage,
@@ -13,6 +14,7 @@ import {
   CardLabel,
   LoopBadge,
   DeleteButton,
+  CropButton,
   UploadOverlay,
   UploadRing,
   UploadRingTrack,
@@ -24,13 +26,31 @@ import {
 interface Props {
   keyframe: FlowKeyframe;
   index: number;
+  /** Output aspect ratio (width / height); drives the card shape. */
+  outputRatio: number;
   onDelete?: (id: string) => void;
+  onEditCrop?: (id: string) => void;
+}
+
+/** Position/scale an <img> so its stored crop region fills the card (undistorted). */
+function cropStyle(crop: CropRegion): React.CSSProperties {
+  return {
+    position: "absolute",
+    width: `${100 / crop.width}%`,
+    height: `${100 / crop.height}%`,
+    left: `${(-100 * crop.x) / crop.width}%`,
+    top: `${(-100 * crop.y) / crop.height}%`,
+    maxWidth: "none",
+    objectFit: "fill",
+  };
 }
 
 export const KeyframeCard: React.FC<Props> = ({
   keyframe,
   index,
+  outputRatio,
   onDelete,
+  onEditCrop,
 }) => {
   const isLoop = keyframe.isLoopKeyframe ?? false;
   const isUploading = keyframe.uploadStatus === "uploading";
@@ -38,6 +58,7 @@ export const KeyframeCard: React.FC<Props> = ({
   const isBusy = isUploading || isFailed;
 
   const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
+  const setKeyframeDimensions = useFlowStore((s) => s.setKeyframeDimensions);
   const [imgSrc, setImgSrc] = useState(keyframe.imageUrl);
 
   useEffect(() => {
@@ -104,6 +125,26 @@ export const KeyframeCard: React.FC<Props> = ({
     window.open(navigateTarget, "_blank");
   };
 
+  const handleImgLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    if (isLoop) return; // loop card mirrors the first frame; dims live on the real one
+    const { naturalWidth, naturalHeight } = e.currentTarget;
+    if (
+      naturalWidth &&
+      naturalHeight &&
+      (keyframe.naturalWidth !== naturalWidth ||
+        keyframe.naturalHeight !== naturalHeight)
+    ) {
+      setKeyframeDimensions(keyframe.id, naturalWidth, naturalHeight);
+    }
+  };
+
+  const imageStyle: React.CSSProperties = {
+    ...(keyframe.crop ? cropStyle(keyframe.crop) : {}),
+    ...(isClickable ? { cursor: "pointer" } : {}),
+  };
+
+  const canEditCrop = !isLoop && !isBusy && !!imgSrc && !!onEditCrop;
+
   return (
     <CardWrapper
       ref={setNodeRef}
@@ -112,6 +153,7 @@ export const KeyframeCard: React.FC<Props> = ({
       $isDragging={isDragging}
       $uploading={isUploading}
       $failed={isFailed}
+      $ratio={outputRatio}
       {...(isLoop || isBusy ? {} : { ...attributes, ...listeners })}
     >
       {imgSrc ? (
@@ -120,7 +162,8 @@ export const KeyframeCard: React.FC<Props> = ({
           alt={keyframe.name}
           $uploading={isUploading}
           onClick={isClickable ? handleOpen : undefined}
-          style={isClickable ? { cursor: "pointer" } : undefined}
+          style={imageStyle}
+          onLoad={handleImgLoad}
           onError={keyframe.dreamUuid ? handleImgError : undefined}
         />
       ) : (
@@ -169,6 +212,20 @@ export const KeyframeCard: React.FC<Props> = ({
         >
           &times;
         </DeleteButton>
+      )}
+
+      {canEditCrop && (
+        <CropButton
+          aria-label={`Crop ${keyframe.name}`}
+          title="Adjust crop"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEditCrop?.(keyframe.id);
+          }}
+        >
+          <Crop size={12} strokeWidth={2.2} />
+        </CropButton>
       )}
     </CardWrapper>
   );

--- a/src/components/pages/studio/components/keyframe-crop-modal.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-crop-modal.styled.tsx
@@ -106,8 +106,11 @@ export const Grid = styled.div`
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background-image:
-    linear-gradient(to right, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.22) 1px,
+      transparent 1px
+    ),
     linear-gradient(to right, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(255, 255, 255, 0.22) 1px, transparent 1px);

--- a/src/components/pages/studio/components/keyframe-crop-modal.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-crop-modal.styled.tsx
@@ -1,0 +1,204 @@
+import styled, { keyframes } from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
+const slideUp = keyframes`
+  from { opacity: 0; transform: translateY(16px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+`;
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 6, 8, 0.85);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: ${fadeIn} 0.18s ease;
+`;
+
+export const Panel = styled.div`
+  background: ${FLOW.bgCard};
+  border: 1px solid ${FLOW.border};
+  border-radius: 16px;
+  width: 90%;
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: ${slideUp} 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid ${FLOW.border};
+`;
+
+export const Title = styled.h3`
+  font-family: ${FLOW.fontFamily};
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: ${FLOW.textMuted};
+  margin: 0;
+`;
+
+export const CloseBtn = styled.button`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: ${FLOW.bgInput};
+  color: ${FLOW.textDim};
+  font-size: 16px;
+  cursor: pointer;
+  transition: color 0.15s;
+  &:hover {
+    color: ${FLOW.text};
+  }
+`;
+
+export const Body = styled.div`
+  padding: 22px 22px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+`;
+
+/** The crop viewport — a fixed aspect-ratio window; the image pans/zooms behind it. */
+export const Frame = styled.div<{ $w: number; $h: number }>`
+  position: relative;
+  width: ${(p) => p.$w}px;
+  height: ${(p) => p.$h}px;
+  overflow: hidden;
+  border-radius: ${FLOW.radiusSm};
+  background: #000;
+  cursor: grab;
+  touch-action: none;
+  box-shadow: 0 0 0 1px ${FLOW.border};
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+export const FrameImg = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  user-select: none;
+  pointer-events: none;
+  -webkit-user-drag: none;
+`;
+
+/** Rule-of-thirds grid drawn over the frame for framing guidance. */
+export const Grid = styled.div`
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
+    linear-gradient(to right, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.22) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.22) 1px, transparent 1px);
+  background-position:
+    33.33% 0,
+    66.66% 0,
+    0 33.33%,
+    0 66.66%;
+  background-size:
+    1px 100%,
+    1px 100%,
+    100% 1px,
+    100% 1px;
+  background-repeat: no-repeat;
+`;
+
+export const ZoomRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  color: ${FLOW.textDim};
+  font-family: ${FLOW.fontFamily};
+  font-size: 11px;
+`;
+
+export const ZoomSlider = styled.input`
+  flex: 1;
+  accent-color: ${FLOW.accent};
+  cursor: pointer;
+`;
+
+export const Hint = styled.p`
+  font-family: ${FLOW.fontFamily};
+  font-size: 11px;
+  color: ${FLOW.textMuted};
+  margin: 0;
+  text-align: center;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 22px 20px;
+`;
+
+export const ResetBtn = styled.button`
+  background: none;
+  border: none;
+  color: ${FLOW.textDim};
+  font-family: ${FLOW.fontFamily};
+  font-size: 12px;
+  cursor: pointer;
+  &:hover {
+    color: ${FLOW.text};
+  }
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const SecondaryBtn = styled.button`
+  background: ${FLOW.bgInput};
+  border: 1px solid ${FLOW.border};
+  color: ${FLOW.text};
+  font-family: ${FLOW.fontFamily};
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: ${FLOW.radiusSm};
+  cursor: pointer;
+  &:hover {
+    border-color: ${FLOW.borderHover};
+  }
+`;
+
+export const PrimaryBtn = styled.button`
+  background: ${FLOW.accent};
+  border: 1px solid ${FLOW.accent};
+  color: #1a1408;
+  font-family: ${FLOW.fontFamily};
+  font-size: 12px;
+  font-weight: 700;
+  padding: 8px 18px;
+  border-radius: ${FLOW.radiusSm};
+  cursor: pointer;
+  transition: filter 0.15s;
+  &:hover {
+    filter: brightness(1.08);
+  }
+`;

--- a/src/components/pages/studio/components/keyframe-crop-modal.tsx
+++ b/src/components/pages/studio/components/keyframe-crop-modal.tsx
@@ -58,9 +58,7 @@ export const KeyframeCropModal: React.FC<Props> = ({
   const [offset, setOffset] = useState({ x: 0, y: 0 }); // image top-left vs frame
   const initialized = useRef(false);
 
-  const coverScale = dims
-    ? Math.max(frame.w / dims.w, frame.h / dims.h)
-    : 1;
+  const coverScale = dims ? Math.max(frame.w / dims.w, frame.h / dims.h) : 1;
 
   const clampOffset = useCallback(
     (x: number, y: number, s: number, d: { w: number; h: number }) => {
@@ -85,20 +83,18 @@ export const KeyframeCropModal: React.FC<Props> = ({
     const dispW = frame.w / crop.width;
     const s = Math.max(cover, dispW / dims.w);
     const dispH = dims.h * s;
-    const next = clampOffset(
-      -crop.x * (dims.w * s),
-      -crop.y * dispH,
-      s,
-      dims,
-    );
+    const next = clampOffset(-crop.x * (dims.w * s), -crop.y * dispH, s, dims);
     setScale(s);
     setOffset(next);
   }, [dims, keyframe.crop, outputRatio, frame.w, frame.h, clampOffset]);
 
   // Pointer drag to pan.
-  const drag = useRef<{ px: number; py: number; ox: number; oy: number } | null>(
-    null,
-  );
+  const drag = useRef<{
+    px: number;
+    py: number;
+    ox: number;
+    oy: number;
+  } | null>(null);
   const onPointerDown = (e: React.PointerEvent) => {
     (e.target as Element).setPointerCapture?.(e.pointerId);
     drag.current = { px: e.clientX, py: e.clientY, ox: offset.x, oy: offset.y };

--- a/src/components/pages/studio/components/keyframe-crop-modal.tsx
+++ b/src/components/pages/studio/components/keyframe-crop-modal.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import type { FlowKeyframe } from "@/types/flow.types";
+import {
+  clampCropRegion,
+  defaultCenterCrop,
+  type CropRegion,
+} from "@/utils/aspect-crop";
+import {
+  Overlay,
+  Panel,
+  Header,
+  Title,
+  CloseBtn,
+  Body,
+  Frame,
+  FrameImg,
+  Grid,
+  ZoomRow,
+  ZoomSlider,
+  Hint,
+  Footer,
+  ResetBtn,
+  Actions,
+  SecondaryBtn,
+  PrimaryBtn,
+} from "./keyframe-crop-modal.styled";
+
+interface Props {
+  keyframe: FlowKeyframe;
+  /** Numeric output ratio (width / height) the crop is locked to. */
+  outputRatio: number;
+  onSave: (crop: CropRegion) => void;
+  onClose: () => void;
+}
+
+const MAX_FRAME = 380;
+const MAX_ZOOM_MULTIPLE = 4;
+
+/** Frame pixel dimensions for a given output ratio, bounded by MAX_FRAME. */
+function frameSize(ratio: number): { w: number; h: number } {
+  if (ratio >= 1) return { w: MAX_FRAME, h: Math.round(MAX_FRAME / ratio) };
+  return { w: Math.round(MAX_FRAME * ratio), h: MAX_FRAME };
+}
+
+export const KeyframeCropModal: React.FC<Props> = ({
+  keyframe,
+  outputRatio,
+  onSave,
+  onClose,
+}) => {
+  const frame = frameSize(outputRatio);
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(
+    keyframe.naturalWidth && keyframe.naturalHeight
+      ? { w: keyframe.naturalWidth, h: keyframe.naturalHeight }
+      : null,
+  );
+  const [scale, setScale] = useState(1); // displayed px per source px
+  const [offset, setOffset] = useState({ x: 0, y: 0 }); // image top-left vs frame
+  const initialized = useRef(false);
+
+  const coverScale = dims
+    ? Math.max(frame.w / dims.w, frame.h / dims.h)
+    : 1;
+
+  const clampOffset = useCallback(
+    (x: number, y: number, s: number, d: { w: number; h: number }) => {
+      const dispW = d.w * s;
+      const dispH = d.h * s;
+      return {
+        x: Math.min(0, Math.max(frame.w - dispW, x)),
+        y: Math.min(0, Math.max(frame.h - dispH, y)),
+      };
+    },
+    [frame.w, frame.h],
+  );
+
+  // Initialize scale/offset from an existing crop (or a fresh center crop) once
+  // the source dimensions are known.
+  useEffect(() => {
+    if (!dims || initialized.current) return;
+    initialized.current = true;
+    const cover = Math.max(frame.w / dims.w, frame.h / dims.h);
+    const crop =
+      keyframe.crop ?? defaultCenterCrop(dims.w, dims.h, outputRatio);
+    const dispW = frame.w / crop.width;
+    const s = Math.max(cover, dispW / dims.w);
+    const dispH = dims.h * s;
+    const next = clampOffset(
+      -crop.x * (dims.w * s),
+      -crop.y * dispH,
+      s,
+      dims,
+    );
+    setScale(s);
+    setOffset(next);
+  }, [dims, keyframe.crop, outputRatio, frame.w, frame.h, clampOffset]);
+
+  // Pointer drag to pan.
+  const drag = useRef<{ px: number; py: number; ox: number; oy: number } | null>(
+    null,
+  );
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    drag.current = { px: e.clientX, py: e.clientY, ox: offset.x, oy: offset.y };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current || !dims) return;
+    const nx = drag.current.ox + (e.clientX - drag.current.px);
+    const ny = drag.current.oy + (e.clientY - drag.current.py);
+    setOffset(clampOffset(nx, ny, scale, dims));
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+
+  // Zoom about the frame center.
+  const onZoom = (nextScale: number) => {
+    if (!dims) return;
+    const cx = (frame.w / 2 - offset.x) / scale;
+    const cy = (frame.h / 2 - offset.y) / scale;
+    const nx = frame.w / 2 - cx * nextScale;
+    const ny = frame.h / 2 - cy * nextScale;
+    setScale(nextScale);
+    setOffset(clampOffset(nx, ny, nextScale, dims));
+  };
+
+  const handleReset = () => {
+    if (!dims) return;
+    const crop = defaultCenterCrop(dims.w, dims.h, outputRatio);
+    const s = coverScale;
+    const dispH = dims.h * s;
+    setScale(s);
+    setOffset(clampOffset(-crop.x * (dims.w * s), -crop.y * dispH, s, dims));
+  };
+
+  const handleSave = () => {
+    if (!dims) {
+      onClose();
+      return;
+    }
+    const dispW = dims.w * scale;
+    const dispH = dims.h * scale;
+    const crop = clampCropRegion(
+      {
+        x: -offset.x / dispW,
+        y: -offset.y / dispH,
+        width: frame.w / dispW,
+        height: frame.h / dispH,
+      },
+      dims.w,
+      dims.h,
+      outputRatio,
+    );
+    onSave(crop);
+  };
+
+  return (
+    <Overlay onClick={onClose}>
+      <Panel onClick={(e) => e.stopPropagation()}>
+        <Header>
+          <Title>Crop — {keyframe.name || "frame"}</Title>
+          <CloseBtn onClick={onClose} aria-label="Close">
+            &times;
+          </CloseBtn>
+        </Header>
+
+        <Body>
+          <Frame
+            $w={frame.w}
+            $h={frame.h}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerLeave={onPointerUp}
+          >
+            {dims ? (
+              <FrameImg
+                src={keyframe.imageUrl}
+                alt={keyframe.name}
+                draggable={false}
+                style={{
+                  width: dims.w * scale,
+                  height: dims.h * scale,
+                  transform: `translate(${offset.x}px, ${offset.y}px)`,
+                }}
+              />
+            ) : (
+              <FrameImg
+                src={keyframe.imageUrl}
+                alt={keyframe.name}
+                draggable={false}
+                onLoad={(e) =>
+                  setDims({
+                    w: e.currentTarget.naturalWidth,
+                    h: e.currentTarget.naturalHeight,
+                  })
+                }
+                style={{ width: frame.w, height: frame.h, objectFit: "cover" }}
+              />
+            )}
+            <Grid />
+          </Frame>
+
+          <ZoomRow>
+            <span>Zoom</span>
+            <ZoomSlider
+              type="range"
+              min={coverScale}
+              max={coverScale * MAX_ZOOM_MULTIPLE}
+              step={coverScale / 100}
+              value={scale}
+              onChange={(e) => onZoom(Number(e.target.value))}
+              disabled={!dims}
+            />
+          </ZoomRow>
+          <Hint>Drag to reposition · slide to zoom</Hint>
+        </Body>
+
+        <Footer>
+          <ResetBtn onClick={handleReset}>Reset to center</ResetBtn>
+          <Actions>
+            <SecondaryBtn onClick={onClose}>Cancel</SecondaryBtn>
+            <PrimaryBtn onClick={handleSave}>Save crop</PrimaryBtn>
+          </Actions>
+        </Footer>
+      </Panel>
+    </Overlay>
+  );
+};

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -14,7 +14,7 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
-import { parseAspectRatio, type Dimensions } from "@/utils/aspect-crop";
+import { resolveFlowRatio } from "@/utils/aspect-crop";
 import { KeyframeCard } from "./keyframe-card";
 import { KeyframeCropModal } from "./keyframe-crop-modal";
 import { TransitionGapEnhanced } from "./transition-gap";
@@ -64,14 +64,19 @@ export const KeyframeStrip: React.FC<Props> = ({
   const globalDuration = useFlowStore((s) => s.globalDuration);
   const globalAspectRatio = useFlowStore((s) => s.globalAspectRatio);
 
-  // Resolve the numeric output ratio (auto = first sized keyframe's shape).
-  const outputRatio = useMemo(() => {
-    const sized = rawKeyframes.find((k) => k.naturalWidth && k.naturalHeight);
-    const fallback: Dimensions | undefined = sized
-      ? { width: sized.naturalWidth!, height: sized.naturalHeight! }
-      : undefined;
-    return parseAspectRatio(globalAspectRatio, fallback);
-  }, [rawKeyframes, globalAspectRatio]);
+  // Resolve the numeric output ratio (auto = the majority keyframe shape).
+  const outputRatio = useMemo(
+    () =>
+      resolveFlowRatio(
+        rawKeyframes.map((k) =>
+          k.naturalWidth && k.naturalHeight
+            ? { width: k.naturalWidth, height: k.naturalHeight }
+            : undefined,
+        ),
+        globalAspectRatio,
+      ),
+    [rawKeyframes, globalAspectRatio],
+  );
 
   // Crop editor state
   const [cropEditId, setCropEditId] = useState<string | null>(null);

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -14,7 +14,9 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
+import { parseAspectRatio, type Dimensions } from "@/utils/aspect-crop";
 import { KeyframeCard } from "./keyframe-card";
+import { KeyframeCropModal } from "./keyframe-crop-modal";
 import { TransitionGapEnhanced } from "./transition-gap";
 import { FlowReset } from "./flow-reset";
 import {
@@ -53,12 +55,30 @@ export const KeyframeStrip: React.FC<Props> = ({
   const reorderKeyframes = useFlowStore((s) => s.reorderKeyframes);
   const setLoop = useFlowStore((s) => s.setLoop);
   const selectTransition = useFlowStore((s) => s.selectTransition);
+  const setKeyframeCrop = useFlowStore((s) => s.setKeyframeCrop);
 
   // Data
   const rawKeyframes = useFlowStore((s) => s.keyframes);
   const loop = useFlowStore((s) => s.loop);
   const transitions = useFlowStore((s) => s.transitions);
   const globalDuration = useFlowStore((s) => s.globalDuration);
+  const globalAspectRatio = useFlowStore((s) => s.globalAspectRatio);
+
+  // Resolve the numeric output ratio (auto = first sized keyframe's shape).
+  const outputRatio = useMemo(() => {
+    const sized = rawKeyframes.find((k) => k.naturalWidth && k.naturalHeight);
+    const fallback: Dimensions | undefined = sized
+      ? { width: sized.naturalWidth!, height: sized.naturalHeight! }
+      : undefined;
+    return parseAspectRatio(globalAspectRatio, fallback);
+  }, [rawKeyframes, globalAspectRatio]);
+
+  // Crop editor state
+  const [cropEditId, setCropEditId] = useState<string | null>(null);
+  const cropEditKeyframe =
+    cropEditId !== null
+      ? rawKeyframes.find((kf) => kf.id === cropEditId) ?? null
+      : null;
 
   // Derive display keyframes from raw data to avoid new-array-every-render
   const displayKeyframes = useMemo(() => {
@@ -139,7 +159,9 @@ export const KeyframeStrip: React.FC<Props> = ({
         key={kf.id}
         keyframe={kf}
         index={i}
+        outputRatio={outputRatio}
         onDelete={removeKeyframe}
+        onEditCrop={setCropEditId}
       />,
     );
   });
@@ -198,6 +220,18 @@ export const KeyframeStrip: React.FC<Props> = ({
           </LoopToggle>
         )}
       </StripControls>
+
+      {cropEditKeyframe && (
+        <KeyframeCropModal
+          keyframe={cropEditKeyframe}
+          outputRatio={outputRatio}
+          onSave={(crop) => {
+            setKeyframeCrop(cropEditKeyframe.id, crop);
+            setCropEditId(null);
+          }}
+          onClose={() => setCropEditId(null)}
+        />
+      )}
     </StripSection>
   );
 };

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/components/pages/studio/constants/duration-options";
 import { resolvePresetAction } from "@/components/pages/studio/utils/resolve-flow-settings";
 import {
+  ASPECT_RATIO_OPTIONS,
+  type AspectRatioSetting,
+  nearestPresetRatio,
+} from "@/utils/aspect-crop";
+import {
   PanelContainer,
   PanelHeader,
   PanelTitle,
@@ -61,6 +66,7 @@ export function TransitionSettingsPanel({
     globalNumInferenceSteps,
     globalGuidance,
     globalLora,
+    globalAspectRatio,
   } = useFlowStore(
     useShallow((s) => ({
       transitions: s.transitions,
@@ -75,8 +81,18 @@ export function TransitionSettingsPanel({
       globalNumInferenceSteps: s.globalNumInferenceSteps,
       globalGuidance: s.globalGuidance,
       globalLora: s.globalLora,
+      globalAspectRatio: s.globalAspectRatio,
     })),
   );
+
+  // Aspect ratio is a per-flow setting (not per-transition). The `auto` option
+  // shows the ratio it resolves to, derived from the first sized keyframe.
+  const autoRatioLabel = useMemo(() => {
+    const sized = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
+    return sized
+      ? `Auto (${nearestPresetRatio(sized.naturalWidth!, sized.naturalHeight!)})`
+      : "Auto";
+  }, [keyframes]);
 
   const { data: modelsData } = useModels({ mediaType: "video" });
   const modelOptions = modelsData?.data?.models ?? [];
@@ -428,6 +444,25 @@ export function TransitionSettingsPanel({
             {allowedDurations.map((d) => (
               <option key={d} value={d}>
                 {d}s
+              </option>
+            ))}
+          </Select>
+        </FieldGroup>
+
+        <FieldGroup>
+          <FieldLabel>Aspect</FieldLabel>
+          <Select
+            value={globalAspectRatio}
+            onChange={(e) =>
+              useFlowStore
+                .getState()
+                .setGlobalAspectRatio(e.target.value as AspectRatioSetting)
+            }
+            title="Output aspect ratio. Keyframes are cropped to this shape."
+          >
+            {ASPECT_RATIO_OPTIONS.map((r) => (
+              <option key={r} value={r}>
+                {r === "auto" ? autoRatioLabel : r}
               </option>
             ))}
           </Select>

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -17,7 +17,7 @@ import { resolvePresetAction } from "@/components/pages/studio/utils/resolve-flo
 import {
   ASPECT_RATIO_OPTIONS,
   type AspectRatioSetting,
-  nearestPresetRatio,
+  majorityPresetRatio,
 } from "@/utils/aspect-crop";
 import {
   PanelContainer,
@@ -86,12 +86,16 @@ export function TransitionSettingsPanel({
   );
 
   // Aspect ratio is a per-flow setting (not per-transition). The `auto` option
-  // shows the ratio it resolves to, derived from the first sized keyframe.
+  // shows the ratio it resolves to — the majority shape of the keyframes.
   const autoRatioLabel = useMemo(() => {
-    const sized = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
-    return sized
-      ? `Auto (${nearestPresetRatio(sized.naturalWidth!, sized.naturalHeight!)})`
-      : "Auto";
+    const majority = majorityPresetRatio(
+      keyframes.map((k) =>
+        k.naturalWidth && k.naturalHeight
+          ? { width: k.naturalWidth, height: k.naturalHeight }
+          : undefined,
+      ),
+    );
+    return majority ? `Auto (${majority})` : "Auto";
   }, [keyframes]);
 
   const { data: modelsData } = useModels({ mediaType: "video" });

--- a/src/components/pages/studio/hooks/useFlowGeneration.test.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.test.ts
@@ -8,7 +8,18 @@ const mocks = vi.hoisted(() => {
   );
   const setTransitionDream = vi.fn();
   const updateTransitionStatus = vi.fn();
+  const updateKeyframe = vi.fn();
+  const uploadImage = vi.fn();
+  const buildVideoAlgoParams = vi.fn(() => ({
+    infinidream_algorithm: "ltx-i2v",
+  }));
+  const cropImageToFile = vi.fn(async () => ({ name: "crop.jpg" }));
+  const loadImageDimensions = vi.fn(async () => ({
+    width: 1080,
+    height: 1920,
+  }));
   const store = {
+    globalAspectRatio: "auto",
     transitions: [
       {
         fromKeyframeId: "frame-1",
@@ -41,6 +52,11 @@ const mocks = vi.hoisted(() => {
     ensureFlowKeyframe,
     setTransitionDream,
     updateTransitionStatus,
+    updateKeyframe,
+    uploadImage,
+    buildVideoAlgoParams,
+    cropImageToFile,
+    loadImageDimensions,
     store,
   };
 });
@@ -74,6 +90,7 @@ vi.mock("../../../../stores/flow.store", () => ({
         state: typeof mocks.store & {
           setTransitionDream: typeof mocks.setTransitionDream;
           updateTransitionStatus: typeof mocks.updateTransitionStatus;
+          updateKeyframe: typeof mocks.updateKeyframe;
         },
       ) => unknown,
     ) =>
@@ -81,13 +98,23 @@ vi.mock("../../../../stores/flow.store", () => ({
         ...mocks.store,
         setTransitionDream: mocks.setTransitionDream,
         updateTransitionStatus: mocks.updateTransitionStatus,
+        updateKeyframe: mocks.updateKeyframe,
       }),
     { getState: () => mocks.store },
   ),
 }));
 
+vi.mock("../../../../api/dream/mutation/useUploadImageDream", () => ({
+  useUploadImageDream: () => ({ mutateAsync: mocks.uploadImage }),
+}));
+
 vi.mock("../utils/build-video-algo-params", () => ({
-  buildVideoAlgoParams: () => ({ infinidream_algorithm: "ltx-i2v" }),
+  buildVideoAlgoParams: mocks.buildVideoAlgoParams,
+}));
+
+vi.mock("../../../../utils/crop-image", () => ({
+  cropImageToFile: mocks.cropImageToFile,
+  loadImageDimensions: mocks.loadImageDimensions,
 }));
 
 vi.mock("../utils/resolve-flow-settings", () => ({
@@ -122,5 +149,60 @@ describe("useFlowGeneration", () => {
 
     expect(mocks.post).toHaveBeenCalledTimes(2);
     expect(mocks.invalidateQueries).toHaveBeenCalledWith(["getUser"]);
+  });
+
+  it("crops portrait keyframes to the output ratio and feeds the cropped Dream to generation", async () => {
+    // Override the shared store: portrait frames + a landscape output override.
+    const prevKeyframes = mocks.store.keyframes;
+    const prevRatio = mocks.store.globalAspectRatio;
+    const prevTransitions = mocks.store.transitions;
+    mocks.store.globalAspectRatio = "16:9";
+    mocks.store.keyframes = [
+      {
+        id: "frame-1",
+        dreamUuid: "dream-1",
+        name: "One",
+        imageUrl: "https://cdn.example.com/1.jpg",
+        naturalWidth: 1080,
+        naturalHeight: 1920,
+      },
+      {
+        id: "frame-2",
+        dreamUuid: "dream-2",
+        name: "Two",
+        imageUrl: "https://cdn.example.com/2.jpg",
+        naturalWidth: 1080,
+        naturalHeight: 1920,
+      },
+    ];
+    mocks.store.transitions = [
+      { fromKeyframeId: "frame-1", toKeyframeId: "frame-2", status: "idle" },
+    ];
+    mocks.uploadImage
+      .mockResolvedValueOnce({ dreamUuid: "cropped-1" })
+      .mockResolvedValueOnce({ dreamUuid: "cropped-2" });
+
+    try {
+      const { generateOne } = useFlowGeneration();
+      await generateOne(0);
+
+      // Both frames were cropped and re-uploaded.
+      expect(mocks.cropImageToFile).toHaveBeenCalledTimes(2);
+      expect(mocks.uploadImage).toHaveBeenCalledTimes(2);
+      // The cache was written with the new cropped Dream UUID.
+      expect(mocks.updateKeyframe).toHaveBeenCalledWith(
+        "frame-1",
+        expect.objectContaining({ croppedDreamUuid: "cropped-1" }),
+      );
+      // Generation used the cropped Dreams, not the originals.
+      const call = mocks.buildVideoAlgoParams.mock.calls[0][0];
+      expect(call.imageUuid).toBe("cropped-1");
+      expect(call.endImageUuid).toBe("cropped-2");
+      expect(call.imageSize).toBe("1280*720");
+    } finally {
+      mocks.store.keyframes = prevKeyframes;
+      mocks.store.globalAspectRatio = prevRatio;
+      mocks.store.transitions = prevTransitions;
+    }
   });
 });

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -12,11 +12,10 @@ import { ensureFlowKeyframe } from "@/components/pages/studio/utils/flow-keyfram
 import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
 import {
   type AspectRatioSetting,
-  type Dimensions,
   cropSignature,
   defaultCenterCrop,
   isFullFrameCrop,
-  parseAspectRatio,
+  resolveFlowRatio,
   sizeStringForRatio,
 } from "@/utils/aspect-crop";
 import { cropImageToFile, loadImageDimensions } from "@/utils/crop-image";
@@ -24,16 +23,19 @@ import { cropImageToFile, loadImageDimensions } from "@/utils/crop-image";
 // Cap concurrent dream creations so "Generate All" doesn't fan out 50+ requests at once.
 const GENERATE_CONCURRENCY = 4;
 
-/** Resolve the flow's numeric output ratio from the setting + first sized keyframe. */
+/** Resolve the flow's numeric output ratio (auto = the majority keyframe shape). */
 function resolveOutputRatio(
   keyframes: FlowKeyframe[],
   setting: AspectRatioSetting,
 ): number {
-  const sized = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
-  const fallback: Dimensions | undefined = sized
-    ? { width: sized.naturalWidth!, height: sized.naturalHeight! }
-    : undefined;
-  return parseAspectRatio(setting, fallback);
+  return resolveFlowRatio(
+    keyframes.map((k) =>
+      k.naturalWidth && k.naturalHeight
+        ? { width: k.naturalWidth, height: k.naturalHeight }
+        : undefined,
+    ),
+    setting,
+  );
 }
 
 export function useFlowGeneration() {

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -96,9 +96,7 @@ export function useFlowGeneration() {
       // the video isn't distorted (#668). Returns the UUID/URL to feed the job;
       // falls back to the original reference on any crop/upload failure so a
       // CORS or network hiccup degrades gracefully rather than blocking.
-      const ensureCroppedDream = async (
-        kf: FlowKeyframe,
-      ): Promise<string> => {
+      const ensureCroppedDream = async (kf: FlowKeyframe): Promise<string> => {
         const original = kf.dreamUuid || kf.imageUrl;
         if (!kf.imageUrl) return original;
         try {

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -5,13 +5,36 @@ import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { buildVideoAlgoParams } from "@/components/pages/studio/utils/build-video-algo-params";
 import { resolveEffectiveSettings } from "@/components/pages/studio/utils/resolve-flow-settings";
-import type { FlowTransition } from "@/types/flow.types";
+import type { FlowKeyframe, FlowTransition } from "@/types/flow.types";
 import queryClient from "@/api/query-client";
 import { USER_QUERY_KEY } from "@/api/user/query/useUser";
 import { ensureFlowKeyframe } from "@/components/pages/studio/utils/flow-keyframes";
+import { useUploadImageDream } from "@/api/dream/mutation/useUploadImageDream";
+import {
+  type AspectRatioSetting,
+  type Dimensions,
+  cropSignature,
+  defaultCenterCrop,
+  isFullFrameCrop,
+  parseAspectRatio,
+  sizeStringForRatio,
+} from "@/utils/aspect-crop";
+import { cropImageToFile, loadImageDimensions } from "@/utils/crop-image";
 
 // Cap concurrent dream creations so "Generate All" doesn't fan out 50+ requests at once.
 const GENERATE_CONCURRENCY = 4;
+
+/** Resolve the flow's numeric output ratio from the setting + first sized keyframe. */
+function resolveOutputRatio(
+  keyframes: FlowKeyframe[],
+  setting: AspectRatioSetting,
+): number {
+  const sized = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
+  const fallback: Dimensions | undefined = sized
+    ? { width: sized.naturalWidth!, height: sized.naturalHeight! }
+    : undefined;
+  return parseAspectRatio(setting, fallback);
+}
 
 export function useFlowGeneration() {
   const [isGenerating, setIsGenerating] = useState(false);
@@ -20,6 +43,8 @@ export function useFlowGeneration() {
   // Actions are stable refs — subscribe individually, not via useShallow.
   const setTransitionDream = useFlowStore((s) => s.setTransitionDream);
   const updateTransitionStatus = useFlowStore((s) => s.updateTransitionStatus);
+  const updateKeyframe = useFlowStore((s) => s.updateKeyframe);
+  const { mutateAsync: uploadImage } = useUploadImageDream();
 
   const generateTransition = useCallback(
     async (index: number, transition: FlowTransition) => {
@@ -48,8 +73,6 @@ export function useFlowGeneration() {
         return;
       }
 
-      const imageRef = fromKf.dreamUuid || fromKf.imageUrl;
-
       const toKf = store.keyframes.find(
         (kf) => kf.id === transition.toKeyframeId,
       );
@@ -60,14 +83,69 @@ export function useFlowGeneration() {
         updateTransitionStatus(index, "failed");
         return;
       }
-      const endImageRef = toKf.dreamUuid || toKf.imageUrl;
+
+      const targetRatio = resolveOutputRatio(
+        store.keyframes,
+        store.globalAspectRatio,
+      );
+
+      // Crop each keyframe to the flow's output ratio and re-upload it as an
+      // image Dream, so the i2v model receives a correctly-shaped source and
+      // the video isn't distorted (#668). Returns the UUID/URL to feed the job;
+      // falls back to the original reference on any crop/upload failure so a
+      // CORS or network hiccup degrades gracefully rather than blocking.
+      const ensureCroppedDream = async (
+        kf: FlowKeyframe,
+      ): Promise<string> => {
+        const original = kf.dreamUuid || kf.imageUrl;
+        if (!kf.imageUrl) return original;
+        try {
+          let { naturalWidth, naturalHeight } = kf;
+          if (!naturalWidth || !naturalHeight) {
+            const dims = await loadImageDimensions(kf.imageUrl);
+            naturalWidth = dims.width;
+            naturalHeight = dims.height;
+          }
+          const crop =
+            kf.crop ??
+            defaultCenterCrop(naturalWidth, naturalHeight, targetRatio);
+
+          // Source already matches the output shape — no crop needed.
+          if (isFullFrameCrop(crop)) return original;
+
+          const sig = cropSignature(original, crop, targetRatio);
+          if (kf.croppedSignature === sig && kf.croppedDreamUuid) {
+            return kf.croppedDreamUuid;
+          }
+
+          const file = await cropImageToFile(
+            kf.imageUrl,
+            crop,
+            kf.name || "frame",
+          );
+          const result = await uploadImage({ file });
+          updateKeyframe(kf.id, {
+            naturalWidth,
+            naturalHeight,
+            croppedDreamUuid: result.dreamUuid,
+            croppedSignature: sig,
+          });
+          return result.dreamUuid;
+        } catch (error) {
+          Bugsnag.notify(error as Error);
+          return original;
+        }
+      };
+
+      const imageRef = await ensureCroppedDream(fromKf);
+      const endImageRef = await ensureCroppedDream(toKf);
 
       const algoParams = buildVideoAlgoParams({
         model: settings.model,
         action: settings.action,
         imageUuid: imageRef,
         endImageUuid: endImageRef,
-        imageSize: undefined,
+        imageSize: sizeStringForRatio(targetRatio),
         duration: settings.duration,
         numInferenceSteps: settings.numInferenceSteps,
         guidance: settings.guidance,
@@ -104,7 +182,7 @@ export function useFlowGeneration() {
         updateTransitionStatus(index, "failed");
       }
     },
-    [setTransitionDream, updateTransitionStatus],
+    [setTransitionDream, updateTransitionStatus, updateKeyframe, uploadImage],
   );
 
   const startGenerating = useCallback(() => {

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -440,7 +440,12 @@ describe("Phase 1: transitions", () => {
         name: "square",
       });
       store.setKeyframeDimensions("kf-1", 1000, 1000);
-      store.setKeyframeCrop("kf-1", { x: 0.1, y: 0.1, width: 0.5, height: 0.5 });
+      store.setKeyframeCrop("kf-1", {
+        x: 0.1,
+        y: 0.1,
+        width: 0.5,
+        height: 0.5,
+      });
       store.updateKeyframe("kf-1", {
         croppedDreamUuid: "cropped-1",
         croppedSignature: "sig-1",

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -22,7 +22,7 @@ beforeAll(() => {
 });
 
 // Dynamic import after localStorage is set up (persist middleware needs it)
-const { useFlowStore } = await import("./flow.store");
+const { useFlowStore, flowPartialize } = await import("./flow.store");
 
 // Reset store between tests
 beforeEach(() => {
@@ -407,6 +407,104 @@ describe("Phase 1: transitions", () => {
       expect(useFlowStore.getState().settingsExpanded).toBe(true);
       store.setSettingsExpanded(false);
       expect(useFlowStore.getState().settingsExpanded).toBe(false);
+    });
+  });
+
+  describe("aspect ratio / crop (#668)", () => {
+    it("defaults globalAspectRatio to auto", () => {
+      expect(useFlowStore.getState().globalAspectRatio).toBe("auto");
+    });
+
+    it("seeds a default center crop when dimensions load", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe({
+        id: "kf-1",
+        dreamUuid: "dream-1",
+        imageUrl: "https://cdn.example.com/1.jpg",
+        name: "portrait",
+      });
+      // auto ratio resolves from this image (1080x1920 -> 9:16)
+      store.setKeyframeDimensions("kf-1", 1080, 1920);
+      const kf = useFlowStore.getState().keyframes[0];
+      expect(kf.naturalWidth).toBe(1080);
+      expect(kf.naturalHeight).toBe(1920);
+      // 9:16 output from a 9:16 source is a full frame
+      expect(kf.crop?.width).toBeCloseTo(1, 3);
+      expect(kf.crop?.height).toBeCloseTo(1, 3);
+    });
+
+    it("re-fits crops and clears the reupload cache when the ratio changes", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe({
+        id: "kf-1",
+        dreamUuid: "dream-1",
+        imageUrl: "https://cdn.example.com/1.jpg",
+        name: "square",
+      });
+      store.setKeyframeDimensions("kf-1", 1000, 1000);
+      // pretend a cropped Dream was cached
+      store.updateKeyframe("kf-1", {
+        croppedDreamUuid: "cropped-1",
+        croppedSignature: "sig-1",
+      });
+
+      store.setGlobalAspectRatio("16:9");
+
+      const kf = useFlowStore.getState().keyframes[0];
+      expect(useFlowStore.getState().globalAspectRatio).toBe("16:9");
+      // square source -> 16:9 crop is a centered horizontal band
+      expect(kf.crop?.width).toBeCloseTo(1, 3);
+      expect(kf.crop?.height).toBeCloseTo(9 / 16, 3);
+      expect(kf.croppedDreamUuid).toBeUndefined();
+      expect(kf.croppedSignature).toBeUndefined();
+    });
+
+    it("setKeyframeCrop stores the crop and invalidates the cache", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe({
+        id: "kf-1",
+        dreamUuid: "dream-1",
+        imageUrl: "https://cdn.example.com/1.jpg",
+        name: "square",
+        croppedDreamUuid: "cropped-1",
+        croppedSignature: "sig-1",
+      });
+      const crop = { x: 0.1, y: 0.2, width: 0.5, height: 0.5 };
+      store.setKeyframeCrop("kf-1", crop);
+      const kf = useFlowStore.getState().keyframes[0];
+      expect(kf.crop).toEqual(crop);
+      expect(kf.croppedDreamUuid).toBeUndefined();
+      expect(kf.croppedSignature).toBeUndefined();
+    });
+
+    it("persists crop fields only for settled keyframes", () => {
+      const store = useFlowStore.getState();
+      store.addKeyframe({
+        id: "kf-settled",
+        dreamUuid: "dream-1",
+        imageUrl: "https://cdn.example.com/1.jpg",
+        name: "settled",
+        naturalWidth: 1000,
+        naturalHeight: 1000,
+        crop: { x: 0, y: 0.2, width: 1, height: 0.5625 },
+      });
+      store.addKeyframe({
+        id: "kf-uploading",
+        imageUrl: "blob:local",
+        name: "ghost",
+        uploadStatus: "uploading",
+      });
+
+      const persisted = flowPartialize(useFlowStore.getState());
+      expect(persisted.globalAspectRatio).toBe("auto");
+      expect(persisted.keyframes).toHaveLength(1);
+      expect(persisted.keyframes[0].id).toBe("kf-settled");
+      expect(persisted.keyframes[0].crop).toEqual({
+        x: 0,
+        y: 0.2,
+        width: 1,
+        height: 0.5625,
+      });
     });
   });
 

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -415,7 +415,7 @@ describe("Phase 1: transitions", () => {
       expect(useFlowStore.getState().globalAspectRatio).toBe("auto");
     });
 
-    it("seeds a default center crop when dimensions load", () => {
+    it("stores dimensions without seeding a crop (crops are derived)", () => {
       const store = useFlowStore.getState();
       store.addKeyframe({
         id: "kf-1",
@@ -423,17 +423,15 @@ describe("Phase 1: transitions", () => {
         imageUrl: "https://cdn.example.com/1.jpg",
         name: "portrait",
       });
-      // auto ratio resolves from this image (1080x1920 -> 9:16)
       store.setKeyframeDimensions("kf-1", 1080, 1920);
       const kf = useFlowStore.getState().keyframes[0];
       expect(kf.naturalWidth).toBe(1080);
       expect(kf.naturalHeight).toBe(1920);
-      // 9:16 output from a 9:16 source is a full frame
-      expect(kf.crop?.width).toBeCloseTo(1, 3);
-      expect(kf.crop?.height).toBeCloseTo(1, 3);
+      // No eager crop — it's derived from dims + majority ratio at use time.
+      expect(kf.crop).toBeUndefined();
     });
 
-    it("re-fits crops and clears the reupload cache when the ratio changes", () => {
+    it("clears user crops + reupload cache when the ratio changes", () => {
       const store = useFlowStore.getState();
       store.addKeyframe({
         id: "kf-1",
@@ -442,7 +440,7 @@ describe("Phase 1: transitions", () => {
         name: "square",
       });
       store.setKeyframeDimensions("kf-1", 1000, 1000);
-      // pretend a cropped Dream was cached
+      store.setKeyframeCrop("kf-1", { x: 0.1, y: 0.1, width: 0.5, height: 0.5 });
       store.updateKeyframe("kf-1", {
         croppedDreamUuid: "cropped-1",
         croppedSignature: "sig-1",
@@ -452,9 +450,8 @@ describe("Phase 1: transitions", () => {
 
       const kf = useFlowStore.getState().keyframes[0];
       expect(useFlowStore.getState().globalAspectRatio).toBe("16:9");
-      // square source -> 16:9 crop is a centered horizontal band
-      expect(kf.crop?.width).toBeCloseTo(1, 3);
-      expect(kf.crop?.height).toBeCloseTo(9 / 16, 3);
+      // A shape change invalidates the old crop; it reverts to the derived one.
+      expect(kf.crop).toBeUndefined();
       expect(kf.croppedDreamUuid).toBeUndefined();
       expect(kf.croppedSignature).toBeUndefined();
     });

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -6,10 +6,7 @@ import type {
   TransitionStatus,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
-import type {
-  AspectRatioSetting,
-  CropRegion,
-} from "@/utils/aspect-crop";
+import type { AspectRatioSetting, CropRegion } from "@/utils/aspect-crop";
 
 export const LOOP_KEYFRAME_ID = "__loop__";
 

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -6,42 +6,29 @@ import type {
   TransitionStatus,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
-import {
-  type AspectRatioSetting,
-  type CropRegion,
-  type Dimensions,
-  defaultCenterCrop,
-  parseAspectRatio,
+import type {
+  AspectRatioSetting,
+  CropRegion,
 } from "@/utils/aspect-crop";
 
 export const LOOP_KEYFRAME_ID = "__loop__";
 
-/** Dimensions of the first keyframe (in order) that has loaded pixel dims. */
-function firstKeyframeDims(keyframes: FlowKeyframe[]): Dimensions | undefined {
-  const kf = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
-  return kf ? { width: kf.naturalWidth!, height: kf.naturalHeight! } : undefined;
-}
-
 /**
- * Re-fit every keyframe's crop to a fresh center crop for the given output
- * ratio. Keyframes without loaded dimensions are left untouched (their crop is
- * computed lazily when the image loads). Changing the crop invalidates any
- * cached cropped-and-reuploaded Dream, so clear that cache too.
+ * Drop any user-defined crop + cached upload from every keyframe. Used when the
+ * output shape changes (explicit ratio pick) — a crop chosen for the old shape
+ * is meaningless for the new one, so we fall back to the derived center crop.
  */
-function refitKeyframeCrops(
-  keyframes: FlowKeyframe[],
-  setting: AspectRatioSetting,
-): FlowKeyframe[] {
-  const ratio = parseAspectRatio(setting, firstKeyframeDims(keyframes));
-  return keyframes.map((kf) => {
-    if (!kf.naturalWidth || !kf.naturalHeight) return kf;
-    return {
-      ...kf,
-      crop: defaultCenterCrop(kf.naturalWidth, kf.naturalHeight, ratio),
-      croppedDreamUuid: undefined,
-      croppedSignature: undefined,
-    };
-  });
+function clearKeyframeCrops(keyframes: FlowKeyframe[]): FlowKeyframe[] {
+  return keyframes.map((kf) =>
+    kf.crop || kf.croppedDreamUuid
+      ? {
+          ...kf,
+          crop: undefined,
+          croppedDreamUuid: undefined,
+          croppedSignature: undefined,
+        }
+      : kf,
+  );
 }
 
 /** Derive the display keyframes list, appending a synthetic loop frame when enabled. */
@@ -319,32 +306,22 @@ export const useFlowStore = create<FlowStoreState>()(
       setGlobalAspectRatio: (ratio) =>
         set((s) => ({
           globalAspectRatio: ratio,
-          // Re-derive dependent state (crops) in the same set() — a ratio
-          // change means every crop must re-fit to the new output shape.
-          keyframes: refitKeyframeCrops(s.keyframes, ratio),
+          // A new output shape invalidates crops picked for the old one — drop
+          // them so every frame falls back to a fresh derived center crop.
+          keyframes: clearKeyframeCrops(s.keyframes),
         })),
 
+      // Record a keyframe's source pixel dimensions. Crops are derived from
+      // dims + the (majority) output ratio at render/generation time, so there
+      // is nothing to seed here.
       setKeyframeDimensions: (id, width, height) =>
-        set((s) => {
-          const ratio = parseAspectRatio(
-            s.globalAspectRatio,
-            firstKeyframeDims(s.keyframes) ?? { width, height },
-          );
-          return {
-            keyframes: s.keyframes.map((kf) => {
-              if (kf.id !== id) return kf;
-              const next: FlowKeyframe = {
-                ...kf,
-                naturalWidth: width,
-                naturalHeight: height,
-              };
-              if (!next.crop) {
-                next.crop = defaultCenterCrop(width, height, ratio);
-              }
-              return next;
-            }),
-          };
-        }),
+        set((s) => ({
+          keyframes: s.keyframes.map((kf) =>
+            kf.id === id
+              ? { ...kf, naturalWidth: width, naturalHeight: height }
+              : kf,
+          ),
+        })),
 
       setKeyframeCrop: (id, crop) =>
         set((s) => ({

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -6,8 +6,43 @@ import type {
   TransitionStatus,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
+import {
+  type AspectRatioSetting,
+  type CropRegion,
+  type Dimensions,
+  defaultCenterCrop,
+  parseAspectRatio,
+} from "@/utils/aspect-crop";
 
 export const LOOP_KEYFRAME_ID = "__loop__";
+
+/** Dimensions of the first keyframe (in order) that has loaded pixel dims. */
+function firstKeyframeDims(keyframes: FlowKeyframe[]): Dimensions | undefined {
+  const kf = keyframes.find((k) => k.naturalWidth && k.naturalHeight);
+  return kf ? { width: kf.naturalWidth!, height: kf.naturalHeight! } : undefined;
+}
+
+/**
+ * Re-fit every keyframe's crop to a fresh center crop for the given output
+ * ratio. Keyframes without loaded dimensions are left untouched (their crop is
+ * computed lazily when the image loads). Changing the crop invalidates any
+ * cached cropped-and-reuploaded Dream, so clear that cache too.
+ */
+function refitKeyframeCrops(
+  keyframes: FlowKeyframe[],
+  setting: AspectRatioSetting,
+): FlowKeyframe[] {
+  const ratio = parseAspectRatio(setting, firstKeyframeDims(keyframes));
+  return keyframes.map((kf) => {
+    if (!kf.naturalWidth || !kf.naturalHeight) return kf;
+    return {
+      ...kf,
+      crop: defaultCenterCrop(kf.naturalWidth, kf.naturalHeight, ratio),
+      croppedDreamUuid: undefined,
+      croppedSignature: undefined,
+    };
+  });
+}
 
 /** Derive the display keyframes list, appending a synthetic loop frame when enabled. */
 function buildKeyframesWithLoop(
@@ -40,6 +75,14 @@ type FlowStoreState = {
   setLoop: (loop: boolean) => void;
   keyframesWithLoop: () => FlowKeyframe[];
   resetFlow: () => void;
+
+  // Aspect ratio / crop (#668)
+  globalAspectRatio: AspectRatioSetting;
+  setGlobalAspectRatio: (ratio: AspectRatioSetting) => void;
+  // Record a keyframe's source pixel dimensions and seed a default center crop.
+  setKeyframeDimensions: (id: string, width: number, height: number) => void;
+  // Persist a user-selected crop (from the crop editor) and invalidate its cache.
+  setKeyframeCrop: (id: string, crop: CropRegion) => void;
 
   // Phase 1 — global transition settings
   globalPresetId: string;
@@ -98,6 +141,7 @@ type FlowStoreState = {
 };
 
 const PHASE_1_DEFAULTS = {
+  globalAspectRatio: "auto" as AspectRatioSetting,
   globalPresetId: "Abstract",
   globalPrompt: "",
   globalNegativePrompt: "",
@@ -164,8 +208,14 @@ export const flowPartialize = (state: FlowStoreState) => ({
       imageUrl: kf.imageUrl,
       name: kf.name,
       isLoopKeyframe: kf.isLoopKeyframe,
+      naturalWidth: kf.naturalWidth,
+      naturalHeight: kf.naturalHeight,
+      crop: kf.crop,
+      croppedDreamUuid: kf.croppedDreamUuid,
+      croppedSignature: kf.croppedSignature,
     })),
   loop: state.loop,
+  globalAspectRatio: state.globalAspectRatio,
   transitions: state.transitions,
   savedPlaylistUuid: state.savedPlaylistUuid,
   syncedPlaylistDreamUuids: state.syncedPlaylistDreamUuids,
@@ -265,6 +315,50 @@ export const useFlowStore = create<FlowStoreState>()(
         set({ globalNumInferenceSteps: steps }),
       setGlobalGuidance: (guidance) => set({ globalGuidance: guidance }),
       setGlobalLora: (lora) => set({ globalLora: lora }),
+
+      setGlobalAspectRatio: (ratio) =>
+        set((s) => ({
+          globalAspectRatio: ratio,
+          // Re-derive dependent state (crops) in the same set() — a ratio
+          // change means every crop must re-fit to the new output shape.
+          keyframes: refitKeyframeCrops(s.keyframes, ratio),
+        })),
+
+      setKeyframeDimensions: (id, width, height) =>
+        set((s) => {
+          const ratio = parseAspectRatio(
+            s.globalAspectRatio,
+            firstKeyframeDims(s.keyframes) ?? { width, height },
+          );
+          return {
+            keyframes: s.keyframes.map((kf) => {
+              if (kf.id !== id) return kf;
+              const next: FlowKeyframe = {
+                ...kf,
+                naturalWidth: width,
+                naturalHeight: height,
+              };
+              if (!next.crop) {
+                next.crop = defaultCenterCrop(width, height, ratio);
+              }
+              return next;
+            }),
+          };
+        }),
+
+      setKeyframeCrop: (id, crop) =>
+        set((s) => ({
+          keyframes: s.keyframes.map((kf) =>
+            kf.id === id
+              ? {
+                  ...kf,
+                  crop,
+                  croppedDreamUuid: undefined,
+                  croppedSignature: undefined,
+                }
+              : kf,
+          ),
+        })),
 
       // Phase 1 — transition actions
       setTransitionOverride: (index, overrides) =>
@@ -382,7 +476,7 @@ export const useFlowStore = create<FlowStoreState>()(
     }),
     {
       name: "flow-session",
-      version: 4,
+      version: 5,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version < 2) {
@@ -404,6 +498,14 @@ export const useFlowStore = create<FlowStoreState>()(
             ...state,
             globalModel: "kling-25-i2v",
             globalDuration: 5,
+          };
+        }
+        if (version < 5) {
+          // Aspect-ratio crop feature (#668): default to auto; crops recompute
+          // lazily as keyframe images load.
+          return {
+            ...state,
+            globalAspectRatio: "auto",
           };
         }
         return state;

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -1,4 +1,5 @@
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
+import type { CropRegion } from "@/utils/aspect-crop";
 
 export type StudioMode = "flow" | "batch";
 
@@ -14,6 +15,19 @@ export interface FlowKeyframe {
   imageUrl: string; // presigned URL or local objectURL while uploading
   name: string; // display name
   isLoopKeyframe?: boolean; // true for auto-generated loop frame
+
+  // Source image pixel dimensions, captured on <img> load. Used to compute a
+  // default center crop and to render the crop honestly in the strip.
+  naturalWidth?: number;
+  naturalHeight?: number;
+  // User-selected crop region (normalized to the source image), aspect-locked
+  // to the flow's output ratio. Undefined = fall back to a center crop.
+  crop?: CropRegion;
+  // Cache of the cropped-and-reuploaded image Dream used for generation, plus
+  // the signature that produced it (source uuid + crop + ratio). When the
+  // signature still matches, generation reuses this instead of re-uploading.
+  croppedDreamUuid?: string;
+  croppedSignature?: string;
 
   // Local-only upload state — never persisted to backend.
   uploadStatus?: "uploading" | "failed";

--- a/src/utils/aspect-crop.test.ts
+++ b/src/utils/aspect-crop.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESET_RATIOS,
+  ASPECT_RATIO_OPTIONS,
+  parseAspectRatio,
+  aspectRatioFromDimensions,
+  nearestPresetRatio,
+  defaultCenterCrop,
+  clampCropRegion,
+  cropRegionToPixels,
+  sizeStringForRatio,
+  cropSignature,
+  isFullFrameCrop,
+} from "./aspect-crop";
+
+describe("aspectRatioFromDimensions", () => {
+  it("returns width/height", () => {
+    expect(aspectRatioFromDimensions(1920, 1080)).toBeCloseTo(16 / 9, 5);
+    expect(aspectRatioFromDimensions(1080, 1920)).toBeCloseTo(9 / 16, 5);
+    expect(aspectRatioFromDimensions(1000, 1000)).toBe(1);
+  });
+});
+
+describe("parseAspectRatio", () => {
+  it("parses presets to numeric ratios", () => {
+    expect(parseAspectRatio("16:9")).toBeCloseTo(16 / 9, 5);
+    expect(parseAspectRatio("9:16")).toBeCloseTo(9 / 16, 5);
+    expect(parseAspectRatio("1:1")).toBe(1);
+    expect(parseAspectRatio("4:3")).toBeCloseTo(4 / 3, 5);
+    expect(parseAspectRatio("3:4")).toBeCloseTo(3 / 4, 5);
+  });
+
+  it("resolves auto from fallback dimensions (snapped to nearest preset)", () => {
+    expect(parseAspectRatio("auto", { width: 1080, height: 1920 })).toBeCloseTo(
+      9 / 16,
+      5,
+    );
+    expect(parseAspectRatio("auto", { width: 1920, height: 1080 })).toBeCloseTo(
+      16 / 9,
+      5,
+    );
+  });
+
+  it("falls back to 16:9 for auto with no dimensions", () => {
+    expect(parseAspectRatio("auto")).toBeCloseTo(16 / 9, 5);
+  });
+});
+
+describe("nearestPresetRatio", () => {
+  it("snaps common resolutions to the right preset", () => {
+    expect(nearestPresetRatio(1920, 1080)).toBe("16:9");
+    expect(nearestPresetRatio(1080, 1920)).toBe("9:16");
+    expect(nearestPresetRatio(1000, 1000)).toBe("1:1");
+    expect(nearestPresetRatio(1024, 768)).toBe("4:3");
+    expect(nearestPresetRatio(768, 1024)).toBe("3:4");
+  });
+
+  it("snaps off-ratio dimensions to the closest preset", () => {
+    // 800x1000 = 0.8 -> closest to 3:4 (0.75)
+    expect(nearestPresetRatio(800, 1000)).toBe("3:4");
+    // 1600x900 = 1.777 -> 16:9
+    expect(nearestPresetRatio(1600, 900)).toBe("16:9");
+  });
+});
+
+describe("defaultCenterCrop", () => {
+  it("returns a full-frame crop when source already matches target", () => {
+    const c = defaultCenterCrop(1920, 1080, 16 / 9);
+    expect(c.x).toBeCloseTo(0, 4);
+    expect(c.y).toBeCloseTo(0, 4);
+    expect(c.width).toBeCloseTo(1, 4);
+    expect(c.height).toBeCloseTo(1, 4);
+  });
+
+  it("crops a square into a centered horizontal band for 16:9", () => {
+    const c = defaultCenterCrop(1000, 1000, 16 / 9);
+    expect(c.width).toBeCloseTo(1, 4);
+    expect(c.height).toBeCloseTo(9 / 16, 4);
+    expect(c.x).toBeCloseTo(0, 4);
+    expect(c.y).toBeCloseTo((1 - 9 / 16) / 2, 4);
+  });
+
+  it("crops a square into a centered vertical band for 9:16", () => {
+    const c = defaultCenterCrop(1000, 1000, 9 / 16);
+    expect(c.height).toBeCloseTo(1, 4);
+    expect(c.width).toBeCloseTo(9 / 16, 4);
+    expect(c.y).toBeCloseTo(0, 4);
+    expect(c.x).toBeCloseTo((1 - 9 / 16) / 2, 4);
+  });
+
+  it("crops a portrait source to a landscape band (the #668 case)", () => {
+    // 1080x1920 portrait -> 16:9 landscape output
+    const c = defaultCenterCrop(1080, 1920, 16 / 9);
+    expect(c.width).toBeCloseTo(1, 4);
+    const srcRatio = 1080 / 1920;
+    expect(c.height).toBeCloseTo(srcRatio / (16 / 9), 4);
+    expect(c.x).toBeCloseTo(0, 4);
+    expect(c.y).toBeCloseTo((1 - c.height) / 2, 4);
+  });
+
+  it("produces a box whose pixel aspect matches the target", () => {
+    const srcW = 1080;
+    const srcH = 1920;
+    const target = 16 / 9;
+    const c = defaultCenterCrop(srcW, srcH, target);
+    const pxRatio = (c.width * srcW) / (c.height * srcH);
+    expect(pxRatio).toBeCloseTo(target, 3);
+  });
+});
+
+describe("clampCropRegion", () => {
+  it("keeps an in-bounds region unchanged (aspect already correct)", () => {
+    const region = { x: 0, y: 0.21875, width: 1, height: 9 / 16 };
+    const c = clampCropRegion(region, 1000, 1000, 16 / 9);
+    expect(c.x).toBeCloseTo(0, 4);
+    expect(c.width).toBeCloseTo(1, 4);
+    expect(c.height).toBeCloseTo(9 / 16, 4);
+  });
+
+  it("re-derives height to satisfy the target aspect ratio", () => {
+    // width 0.6 on a square source, target square -> height must equal 0.6
+    const region = { x: 0.1, y: 0.1, width: 0.6, height: 0.1 };
+    const c = clampCropRegion(region, 1000, 1000, 1);
+    expect(c.height).toBeCloseTo(0.6, 4);
+  });
+
+  it("clamps position so the box stays within the source", () => {
+    const region = { x: 0.9, y: 0.9, width: 0.5, height: 0.5 };
+    const c = clampCropRegion(region, 1000, 1000, 1);
+    expect(c.x).toBeCloseTo(0.5, 4);
+    expect(c.y).toBeCloseTo(0.5, 4);
+    expect(c.x + c.width).toBeLessThanOrEqual(1.0001);
+    expect(c.y + c.height).toBeLessThanOrEqual(1.0001);
+  });
+
+  it("shrinks an oversized box to fit and re-centers", () => {
+    const region = { x: -0.2, y: 0, width: 1.4, height: 1.4 };
+    const c = clampCropRegion(region, 1000, 1000, 1);
+    expect(c.width).toBeLessThanOrEqual(1.0001);
+    expect(c.height).toBeLessThanOrEqual(1.0001);
+    expect(c.x).toBeGreaterThanOrEqual(-0.0001);
+    expect(c.y).toBeGreaterThanOrEqual(-0.0001);
+  });
+});
+
+describe("cropRegionToPixels", () => {
+  it("converts a normalized region to integer source pixels", () => {
+    const px = cropRegionToPixels(
+      { x: 0.25, y: 0, width: 0.5, height: 1 },
+      1000,
+      1000,
+    );
+    expect(px).toEqual({ sx: 250, sy: 0, sw: 500, sh: 1000 });
+  });
+
+  it("clamps to image bounds and rounds", () => {
+    const px = cropRegionToPixels(
+      { x: 0.3333, y: 0.3333, width: 0.5, height: 0.5 },
+      1920,
+      1080,
+    );
+    expect(px.sx).toBe(640);
+    expect(px.sy).toBe(360);
+    expect(px.sx + px.sw).toBeLessThanOrEqual(1920);
+    expect(px.sy + px.sh).toBeLessThanOrEqual(1080);
+  });
+});
+
+describe("sizeStringForRatio", () => {
+  it("maps each preset ratio to its nearest supported generation bucket", () => {
+    expect(sizeStringForRatio(16 / 9)).toBe("1280*720");
+    expect(sizeStringForRatio(9 / 16)).toBe("720*1280");
+    expect(sizeStringForRatio(1)).toBe("1280*1280");
+    expect(sizeStringForRatio(4 / 3)).toBe("1024*768");
+    expect(sizeStringForRatio(3 / 4)).toBe("768*1024");
+  });
+});
+
+describe("cropSignature", () => {
+  it("is stable for equal inputs", () => {
+    const r = { x: 0.1, y: 0.2, width: 0.5, height: 0.5 };
+    expect(cropSignature("dream-a", r, 1)).toBe(cropSignature("dream-a", r, 1));
+  });
+
+  it("changes when the source, region, or ratio changes", () => {
+    const r = { x: 0.1, y: 0.2, width: 0.5, height: 0.5 };
+    const base = cropSignature("dream-a", r, 1);
+    expect(cropSignature("dream-b", r, 1)).not.toBe(base);
+    expect(cropSignature("dream-a", { ...r, x: 0.11 }, 1)).not.toBe(base);
+    expect(cropSignature("dream-a", r, 16 / 9)).not.toBe(base);
+  });
+});
+
+describe("isFullFrameCrop", () => {
+  it("is true for a full-frame region", () => {
+    expect(isFullFrameCrop({ x: 0, y: 0, width: 1, height: 1 })).toBe(true);
+  });
+
+  it("is false when the region is a sub-rect", () => {
+    expect(
+      isFullFrameCrop({ x: 0, y: 0.2, width: 1, height: 0.5625 }),
+    ).toBe(false);
+  });
+});
+
+describe("PRESET_RATIOS / ASPECT_RATIO_OPTIONS", () => {
+  it("exposes the five presets plus auto", () => {
+    expect(Object.keys(PRESET_RATIOS)).toEqual([
+      "16:9",
+      "9:16",
+      "1:1",
+      "4:3",
+      "3:4",
+    ]);
+    expect(ASPECT_RATIO_OPTIONS).toContain("auto");
+    expect(ASPECT_RATIO_OPTIONS).toContain("16:9");
+  });
+});

--- a/src/utils/aspect-crop.test.ts
+++ b/src/utils/aspect-crop.test.ts
@@ -243,9 +243,9 @@ describe("isFullFrameCrop", () => {
   });
 
   it("is false when the region is a sub-rect", () => {
-    expect(
-      isFullFrameCrop({ x: 0, y: 0.2, width: 1, height: 0.5625 }),
-    ).toBe(false);
+    expect(isFullFrameCrop({ x: 0, y: 0.2, width: 1, height: 0.5625 })).toBe(
+      false,
+    );
   });
 });
 

--- a/src/utils/aspect-crop.test.ts
+++ b/src/utils/aspect-crop.test.ts
@@ -3,6 +3,8 @@ import {
   PRESET_RATIOS,
   ASPECT_RATIO_OPTIONS,
   parseAspectRatio,
+  majorityPresetRatio,
+  resolveFlowRatio,
   aspectRatioFromDimensions,
   nearestPresetRatio,
   defaultCenterCrop,
@@ -43,6 +45,50 @@ describe("parseAspectRatio", () => {
 
   it("falls back to 16:9 for auto with no dimensions", () => {
     expect(parseAspectRatio("auto")).toBeCloseTo(16 / 9, 5);
+  });
+});
+
+describe("majorityPresetRatio", () => {
+  const L = { width: 1920, height: 1080 }; // 16:9
+  const P = { width: 1080, height: 1920 }; // 9:16
+  const S = { width: 1000, height: 1000 }; // 1:1
+
+  it("returns the most common shape (the oddball loses)", () => {
+    expect(majorityPresetRatio([L, L, L, P])).toBe("16:9");
+    expect(majorityPresetRatio([P, P, L])).toBe("9:16");
+  });
+
+  it("ignores frames without dimensions", () => {
+    expect(majorityPresetRatio([undefined, L, undefined, L, P])).toBe("16:9");
+  });
+
+  it("breaks ties toward the earliest frame", () => {
+    expect(majorityPresetRatio([P, L])).toBe("9:16");
+    expect(majorityPresetRatio([L, P])).toBe("16:9");
+    expect(majorityPresetRatio([S, L, P])).toBe("1:1");
+  });
+
+  it("returns undefined when nothing is known", () => {
+    expect(majorityPresetRatio([undefined, undefined])).toBeUndefined();
+    expect(majorityPresetRatio([])).toBeUndefined();
+  });
+});
+
+describe("resolveFlowRatio", () => {
+  const L = { width: 1920, height: 1080 };
+  const P = { width: 1080, height: 1920 };
+
+  it("uses an explicit preset when set", () => {
+    expect(resolveFlowRatio([P, P, P], "16:9")).toBeCloseTo(16 / 9, 5);
+  });
+
+  it("uses the majority shape for auto", () => {
+    expect(resolveFlowRatio([L, L, P], "auto")).toBeCloseTo(16 / 9, 5);
+    expect(resolveFlowRatio([P, P, L], "auto")).toBeCloseTo(9 / 16, 5);
+  });
+
+  it("falls back to 16:9 for auto with no known dimensions", () => {
+    expect(resolveFlowRatio([undefined], "auto")).toBeCloseTo(16 / 9, 5);
   });
 });
 

--- a/src/utils/aspect-crop.ts
+++ b/src/utils/aspect-crop.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure helpers for the flow builder's aspect-ratio / crop feature (issue #668).
+ *
+ * A crop is stored as a normalized rectangle relative to the *source* image:
+ *   { x, y, width, height } each in [0, 1].
+ * The rectangle's pixel aspect ratio (width*srcW)/(height*srcH) is kept equal to
+ * the flow's output aspect ratio by `defaultCenterCrop` / `clampCropRegion`.
+ */
+
+export type PresetRatio = "16:9" | "9:16" | "1:1" | "4:3" | "3:4";
+export type AspectRatioSetting = "auto" | PresetRatio;
+
+export interface CropRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+/** Preset label -> numeric ratio (width / height). Insertion order is the UI order. */
+export const PRESET_RATIOS: Record<PresetRatio, number> = {
+  "16:9": 16 / 9,
+  "9:16": 9 / 16,
+  "1:1": 1,
+  "4:3": 4 / 3,
+  "3:4": 3 / 4,
+};
+
+/** Selector options, `auto` first. */
+export const ASPECT_RATIO_OPTIONS: readonly AspectRatioSetting[] = [
+  "auto",
+  ...(Object.keys(PRESET_RATIOS) as PresetRatio[]),
+];
+
+/** Supported generation output buckets, label -> ratio. */
+const SUPPORTED_SIZES: Record<string, number> = {
+  "1280*720": 1280 / 720,
+  "720*1280": 720 / 1280,
+  "1280*1280": 1,
+  "1024*768": 1024 / 768,
+  "768*1024": 768 / 1024,
+};
+
+const DEFAULT_RATIO = 16 / 9;
+
+export const aspectRatioFromDimensions = (
+  width: number,
+  height: number,
+): number => width / height;
+
+/** Snap arbitrary source dimensions to the closest preset ratio. */
+export const nearestPresetRatio = (width: number, height: number): PresetRatio => {
+  const ratio = aspectRatioFromDimensions(width, height);
+  let best: PresetRatio = "16:9";
+  let bestDist = Infinity;
+  for (const key of Object.keys(PRESET_RATIOS) as PresetRatio[]) {
+    const dist = Math.abs(PRESET_RATIOS[key] - ratio);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = key;
+    }
+  }
+  return best;
+};
+
+/**
+ * Resolve an aspect-ratio setting to a numeric ratio. `auto` uses the fallback
+ * dimensions (snapped to the nearest preset), or 16:9 when none are available.
+ */
+export const parseAspectRatio = (
+  setting: AspectRatioSetting,
+  fallback?: Dimensions,
+): number => {
+  if (setting !== "auto") return PRESET_RATIOS[setting];
+  if (fallback && fallback.width > 0 && fallback.height > 0) {
+    return PRESET_RATIOS[nearestPresetRatio(fallback.width, fallback.height)];
+  }
+  return DEFAULT_RATIO;
+};
+
+/**
+ * Largest centered crop of `targetRatio` that fits inside a source image
+ * (a "cover" crop of the output within the source).
+ */
+export const defaultCenterCrop = (
+  srcW: number,
+  srcH: number,
+  targetRatio: number,
+): CropRegion => {
+  const srcRatio = srcW / srcH;
+  if (srcRatio > targetRatio) {
+    // Source is wider than target -> full height, narrower width.
+    const width = targetRatio / srcRatio;
+    return { x: (1 - width) / 2, y: 0, width, height: 1 };
+  }
+  // Source is taller/narrower than target -> full width, shorter height.
+  const height = srcRatio / targetRatio;
+  return { x: 0, y: (1 - height) / 2, width: 1, height };
+};
+
+const clamp01 = (n: number): number => Math.min(1, Math.max(0, n));
+
+/**
+ * Force a region to satisfy the target aspect ratio and stay inside the source.
+ * Width is treated as the primary hint; height is re-derived from it. If the
+ * derived box is too tall it is shrunk to fit. The box center is preserved where
+ * possible, then position is clamped so the box stays within [0, 1].
+ */
+export const clampCropRegion = (
+  region: CropRegion,
+  srcW: number,
+  srcH: number,
+  targetRatio: number,
+): CropRegion => {
+  const srcRatio = srcW / srcH;
+  // height = width * srcRatio / targetRatio keeps (w*srcW)/(h*srcH) === targetRatio.
+  let width = clamp01(region.width <= 0 ? 1 : region.width);
+  let height = (width * srcRatio) / targetRatio;
+  if (height > 1) {
+    height = 1;
+    width = (height * targetRatio) / srcRatio;
+  }
+
+  const cx = region.x + region.width / 2;
+  const cy = region.y + region.height / 2;
+  let x = cx - width / 2;
+  let y = cy - height / 2;
+
+  x = Math.min(1 - width, Math.max(0, x));
+  y = Math.min(1 - height, Math.max(0, y));
+
+  return { x, y, width, height };
+};
+
+export interface PixelRect {
+  sx: number;
+  sy: number;
+  sw: number;
+  sh: number;
+}
+
+/** Convert a normalized region into an integer source-pixel rect for canvas draw. */
+export const cropRegionToPixels = (
+  region: CropRegion,
+  srcW: number,
+  srcH: number,
+): PixelRect => {
+  const sx = Math.round(clamp01(region.x) * srcW);
+  const sy = Math.round(clamp01(region.y) * srcH);
+  const sw = Math.min(srcW - sx, Math.round(region.width * srcW));
+  const sh = Math.min(srcH - sy, Math.round(region.height * srcH));
+  return { sx, sy, sw, sh };
+};
+
+/** Nearest supported generation size bucket for a target ratio. */
+export const sizeStringForRatio = (targetRatio: number): string => {
+  let best = "1280*720";
+  let bestDist = Infinity;
+  for (const [label, ratio] of Object.entries(SUPPORTED_SIZES)) {
+    const dist = Math.abs(ratio - targetRatio);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = label;
+    }
+  }
+  return best;
+};
+
+const round4 = (n: number): number => Math.round(n * 1e4) / 1e4;
+
+/** Stable cache key for a cropped-and-reuploaded Dream. */
+export const cropSignature = (
+  sourceDreamUuid: string,
+  region: CropRegion,
+  targetRatio: number,
+): string =>
+  [
+    sourceDreamUuid,
+    round4(region.x),
+    round4(region.y),
+    round4(region.width),
+    round4(region.height),
+    round4(targetRatio),
+  ].join(":");
+
+/** True when a region covers the whole source (no real crop needed). */
+export const isFullFrameCrop = (region: CropRegion, eps = 1e-3): boolean =>
+  Math.abs(region.x) < eps &&
+  Math.abs(region.y) < eps &&
+  Math.abs(region.width - 1) < eps &&
+  Math.abs(region.height - 1) < eps;

--- a/src/utils/aspect-crop.ts
+++ b/src/utils/aspect-crop.ts
@@ -54,7 +54,10 @@ export const aspectRatioFromDimensions = (
 ): number => width / height;
 
 /** Snap arbitrary source dimensions to the closest preset ratio. */
-export const nearestPresetRatio = (width: number, height: number): PresetRatio => {
+export const nearestPresetRatio = (
+  width: number,
+  height: number,
+): PresetRatio => {
   const ratio = aspectRatioFromDimensions(width, height);
   let best: PresetRatio = "16:9";
   let bestDist = Infinity;

--- a/src/utils/aspect-crop.ts
+++ b/src/utils/aspect-crop.ts
@@ -84,6 +84,50 @@ export const parseAspectRatio = (
 };
 
 /**
+ * The most common preset ratio across a set of image dimensions — the flow's
+ * "auto" output shape. Frames matching it are left uncropped; only the odd ones
+ * out get cropped. Ties break toward the earliest-appearing frame. Returns
+ * undefined when no dimensions are known yet.
+ */
+export const majorityPresetRatio = (
+  dims: Array<Dimensions | undefined>,
+): PresetRatio | undefined => {
+  const counts = new Map<PresetRatio, number>();
+  const firstIdx = new Map<PresetRatio, number>();
+  dims.forEach((d, i) => {
+    if (!d || !d.width || !d.height) return;
+    const p = nearestPresetRatio(d.width, d.height);
+    counts.set(p, (counts.get(p) ?? 0) + 1);
+    if (!firstIdx.has(p)) firstIdx.set(p, i);
+  });
+  let best: PresetRatio | undefined;
+  let bestN = -1;
+  let bestIdx = Infinity;
+  for (const [p, n] of counts) {
+    const idx = firstIdx.get(p)!;
+    if (n > bestN || (n === bestN && idx < bestIdx)) {
+      best = p;
+      bestN = n;
+      bestIdx = idx;
+    }
+  }
+  return best;
+};
+
+/**
+ * Resolve the flow's numeric output ratio. An explicit preset wins; `auto`
+ * derives from the majority of the keyframe dimensions (16:9 when unknown).
+ */
+export const resolveFlowRatio = (
+  dims: Array<Dimensions | undefined>,
+  setting: AspectRatioSetting,
+): number => {
+  if (setting !== "auto") return PRESET_RATIOS[setting];
+  const majority = majorityPresetRatio(dims);
+  return majority ? PRESET_RATIOS[majority] : DEFAULT_RATIO;
+};
+
+/**
  * Largest centered crop of `targetRatio` that fits inside a source image
  * (a "cover" crop of the output within the source).
  */

--- a/src/utils/crop-image.ts
+++ b/src/utils/crop-image.ts
@@ -1,0 +1,71 @@
+import { cropRegionToPixels, type CropRegion } from "./aspect-crop";
+
+/**
+ * Browser-only helpers that turn a source image URL + a normalized crop region
+ * into a cropped JPEG File, ready to upload as an image Dream. The pure crop
+ * geometry lives in `aspect-crop.ts` (unit tested); this module is the thin
+ * canvas/DOM shell around it.
+ */
+
+const loadImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    // Needed so the canvas isn't tainted when the image is served from the CDN.
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () =>
+      reject(new Error(`Failed to load image for cropping: ${url}`));
+    img.src = url;
+  });
+
+/** Read a source image's natural pixel dimensions. */
+export const loadImageDimensions = async (
+  url: string,
+): Promise<{ width: number; height: number }> => {
+  const img = await loadImage(url);
+  return { width: img.naturalWidth, height: img.naturalHeight };
+};
+
+const canvasToBlob = (
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number,
+): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) =>
+        blob
+          ? resolve(blob)
+          : reject(new Error("Canvas toBlob returned null")),
+      type,
+      quality,
+    );
+  });
+
+/**
+ * Crop `imageUrl` to `region` and return a JPEG File named `fileName`.
+ * Throws if the image can't be loaded or the canvas is tainted (CORS).
+ */
+export const cropImageToFile = async (
+  imageUrl: string,
+  region: CropRegion,
+  fileName: string,
+): Promise<File> => {
+  const img = await loadImage(imageUrl);
+  const { sx, sy, sw, sh } = cropRegionToPixels(
+    region,
+    img.naturalWidth,
+    img.naturalHeight,
+  );
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(1, sw);
+  canvas.height = Math.max(1, sh);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D canvas context unavailable");
+  ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+
+  const blob = await canvasToBlob(canvas, "image/jpeg", 0.95);
+  const safeName = fileName.replace(/\.[^.]+$/, "");
+  return new File([blob], `${safeName}.jpg`, { type: "image/jpeg" });
+};

--- a/src/utils/crop-image.ts
+++ b/src/utils/crop-image.ts
@@ -34,9 +34,7 @@ const canvasToBlob = (
   new Promise((resolve, reject) => {
     canvas.toBlob(
       (blob) =>
-        blob
-          ? resolve(blob)
-          : reject(new Error("Canvas toBlob returned null")),
+        blob ? resolve(blob) : reject(new Error("Canvas toBlob returned null")),
       type,
       quality,
     );


### PR DESCRIPTION
## What & why

Fixes [#668](https://github.com/e-dream-ai/frontend/issues/668) — the studio flow builder rendered every keyframe in a fixed 140×100 `object-fit: cover` box, hiding each image's true aspect ratio. A stray portrait image slipped through unnoticed and the generated video came out distorted.

Per the issue thread (crop to match the video output) the flow now commits to a single output shape and crops keyframes to it — a transition clip can't morph between two shapes, so one shape is required.

## 🎥 Demo (local, against staging)

https://drive.google.com/file/d/1G26joyxWXjn7Qnp-8n_wdBi0lB91w5aC/view?usp=sharing

## How it works

- **Majority wins.** The `auto` output ratio is the *most common* keyframe shape. Frames that already match are left **untouched** — only the odd-aspect image(s) get cropped, flagged with a `CROPPED` badge in the strip.
- **Honest strip.** Cards are sized to the output ratio and render each frame's effective crop, so the strip shows exactly what the video will use.
- **Visual crop editor.** Click a frame's crop button → aspect-locked frame with a rule-of-thirds grid; drag to reposition, slide to zoom, reset-to-center. Picks the exact region kept.
- **Output-ratio selector.** `Auto (…)` + `16:9 / 9:16 / 1:1 / 4:3 / 3:4` override in the settings panel.
- **Crop-on-generate.** Before each i2v job, keyframes are cropped client-side (canvas) to the output shape and re-uploaded as image Dreams — the only way to honor an arbitrary user-selected region across models (server can only center-crop). Cached by a `(sourceDream, crop, ratio)` signature so unchanged crops don't re-upload; full-frame (already-matching) frames skip re-upload; crop/upload failures fall back to the original image (Bugsnag-logged).

Crops are **derived** (`userCrop ?? centerCrop(for majority ratio)`), so a majority shift or ratio override just recomputes — no stale state.

## Scope notes

- Frontend-only; no worker/backend changes.
- `flow.store` bumped to v5 with a migration (defaults `globalAspectRatio: "auto"`); new per-keyframe fields persisted only for settled keyframes.

## Testing

- **136 unit tests pass** (Vitest), incl. 30 new for crop geometry / majority resolution and store behavior; `tsc --noEmit` and ESLint clean.
- Manually verified end-to-end against **staging** (proxy mode): honest strip, majority auto-shape with only the oddball cropped, crop editor drag/zoom, and ratio overrides — see video.

claude --resume bacf1207-b5e8-4df3-a36d-89b69e54bc91
