### PR TITLE
fix(flow-preview): crossfade segments to hide blank screen between videos (#670)

### DIFF
--- a/src/components/pages/studio/components/flow-preview.styled.tsx
+++ b/src/components/pages/studio/components/flow-preview.styled.tsx
@@ -39,6 +39,22 @@ export const VideoWrapper = styled.div`
   }
 `;
 
+// One of two stacked <video> layers. The visible layer sits on top at full
+// opacity; the other preloads the next segment underneath. Swapping which layer
+// is visible crossfades between them — and because we only reveal a layer after
+// its first frame has decoded, the outgoing frame stays painted throughout, so
+// no blank/black frame is ever shown between segments (issue #670).
+export const VideoLayer = styled.video<{ $visible: boolean }>`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  opacity: ${(p) => (p.$visible ? 1 : 0)};
+  transition: opacity 0.45s ease;
+  z-index: ${(p) => (p.$visible ? 1 : 0)};
+`;
+
 // Hover-revealed nav arrows on the left/right edge of the video.
 export const NavButton = styled.button<{ $side: "left" | "right" }>`
   position: absolute;

--- a/src/components/pages/studio/components/flow-preview.tsx
+++ b/src/components/pages/studio/components/flow-preview.tsx
@@ -13,6 +13,7 @@ import {
   PreviewContainer,
   PreviewLabel,
   VideoWrapper,
+  VideoLayer,
   ClickHint,
   LightboxOverlay,
   LightboxVideo,
@@ -21,6 +22,13 @@ import {
   ChipRail,
   SegmentChip,
 } from "./flow-preview.styled";
+import {
+  initialPreviewBuffer,
+  backLayer,
+  requestIndex,
+  ready,
+  type Layer,
+} from "../utils/preview-buffer";
 
 async function fetchDream(
   uuid: string,
@@ -36,6 +44,8 @@ async function fetchDream(
 function pad(n: number) {
   return n.toString().padStart(2, "0");
 }
+
+const LAYERS: Layer[] = [0, 1];
 
 export function FlowPreview() {
   const { transitions, previewLightboxOpen, setPreviewLightboxOpen } =
@@ -72,36 +82,68 @@ export function FlowPreview() {
         .map((q, i) => {
           const url = q.data?.video;
           if (!url) return null;
-          return { dreamUuid: completedUuids[i], url };
+          return {
+            dreamUuid: completedUuids[i],
+            url,
+            // Poster is shown while the <video> loads — a still frame beats black
+            // if a segment is slow to buffer (issue #670 fallback).
+            poster: q.data?.thumbnail,
+          };
         })
-        .filter((s): s is { dreamUuid: string; url: string } => s !== null),
+        .filter(
+          (
+            s,
+          ): s is { dreamUuid: string; url: string; poster: string | undefined } =>
+            s !== null,
+        ),
     [dreamQueries, completedUuids],
   );
 
-  const [rawIndex, setCurrentIndex] = useState(0);
-  const videoRef = useRef<HTMLVideoElement>(null);
+  // targetIndex drives the chips/counter so they respond to a click immediately,
+  // even while the next segment is still buffering behind the visible frame.
+  const [rawTarget, setTargetIndex] = useState(0);
+  // buf owns which of the two <video> layers is visible and when they swap.
+  const [buf, setBuf] = useState(() => initialPreviewBuffer(0));
+
+  const videoRef0 = useRef<HTMLVideoElement>(null);
+  const videoRef1 = useRef<HTMLVideoElement>(null);
+  const videoRefs = useMemo(() => [videoRef0, videoRef1] as const, []);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const currentIndexRef = useRef(0);
 
-  // Clamp during render so segment churn never points at a dead index.
   const segmentCount = completedSegments.length;
-  const currentIndex = rawIndex >= segmentCount ? 0 : rawIndex;
-  currentIndexRef.current = currentIndex;
+  // Clamp during render so segment churn never points at a dead index.
+  const targetIndex = rawTarget >= segmentCount ? 0 : rawTarget;
 
-  const goTo = useCallback(
-    (next: number) => {
-      if (segmentCount === 0) return;
-      const wrapped = ((next % segmentCount) + segmentCount) % segmentCount;
-      setCurrentIndex(wrapped);
-    },
-    [segmentCount],
-  );
+  // Latest values for event handlers that must not close over stale renders.
+  const targetRef = useRef(targetIndex);
+  targetRef.current = targetIndex;
+  const bufRef = useRef(buf);
+  bufRef.current = buf;
+  const segCountRef = useRef(segmentCount);
+  segCountRef.current = segmentCount;
 
-  const handleEnded = useCallback(() => {
-    // Single segment: just loop. Multi: advance to next.
-    if (segmentCount > 1) goTo(currentIndex + 1);
-    else videoRef.current?.play().catch(() => undefined);
-  }, [currentIndex, segmentCount, goTo]);
+  const goTo = useCallback((next: number) => {
+    const count = segCountRef.current;
+    if (count === 0) return;
+    const wrapped = ((next % count) + count) % count;
+    setTargetIndex(wrapped);
+    setBuf((s) => requestIndex(s, wrapped));
+  }, []);
+
+  // If segments shrink underneath us, snap the buffer back to a valid index.
+  useEffect(() => {
+    if (segmentCount > 0 && rawTarget >= segmentCount) {
+      setTargetIndex(0);
+      setBuf((s) => requestIndex(s, 0));
+    }
+  }, [segmentCount, rawTarget]);
+
+  // Keep the visible layer playing; pause the hidden one so only the on-screen
+  // segment advances (and so a background clip can't fire onEnded and steal nav).
+  useEffect(() => {
+    videoRefs[buf.front].current?.play().catch(() => undefined);
+    videoRefs[backLayer(buf.front)].current?.pause();
+  }, [buf.front, videoRefs]);
 
   // Escape closes the lightbox; ←/→ navigate when the preview is focused.
   useEffect(() => {
@@ -110,21 +152,22 @@ export function FlowPreview() {
         setPreviewLightboxOpen(false);
         return;
       }
-      if (segmentCount < 2) return;
+      if (segCountRef.current < 2) return;
       const active = document.activeElement;
       const inWrapper = active && wrapperRef.current?.contains(active as Node);
       if (!inWrapper && !previewLightboxOpen) return;
-      if (e.key === "ArrowRight") goTo(currentIndexRef.current + 1);
-      else if (e.key === "ArrowLeft") goTo(currentIndexRef.current - 1);
+      if (e.key === "ArrowRight") goTo(targetRef.current + 1);
+      else if (e.key === "ArrowLeft") goTo(targetRef.current - 1);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [previewLightboxOpen, segmentCount, goTo]);
+  }, [previewLightboxOpen, goTo, setPreviewLightboxOpen]);
 
   if (segmentCount === 0) return null;
 
-  const currentUrl = completedSegments[currentIndex]?.url;
   const showNav = segmentCount > 1;
+  const currentUrl = completedSegments[targetIndex]?.url;
+  const currentPoster = completedSegments[targetIndex]?.poster;
 
   return (
     <>
@@ -136,16 +179,40 @@ export function FlowPreview() {
           tabIndex={0}
           onClick={() => setPreviewLightboxOpen(true)}
         >
-          <video
-            key={currentUrl}
-            ref={videoRef}
-            src={currentUrl}
-            autoPlay
-            muted
-            // Only loop when there's a single segment; otherwise advance to next on end.
-            loop={segmentCount === 1}
-            onEnded={handleEnded}
-          />
+          {LAYERS.map((layer) => {
+            const segIndex = buf.loaded[layer];
+            const segment =
+              segIndex == null ? undefined : completedSegments[segIndex];
+            return (
+              <VideoLayer
+                key={layer}
+                ref={videoRefs[layer]}
+                $visible={buf.front === layer}
+                src={segment?.url}
+                poster={segment?.poster}
+                autoPlay
+                muted
+                playsInline
+                // Only loop when there's a single segment; otherwise advance on end.
+                loop={segmentCount === 1}
+                onLoadedData={() =>
+                  setBuf((s) => {
+                    const idx = s.loaded[layer];
+                    return idx == null ? s : ready(s, layer, idx);
+                  })
+                }
+                onEnded={() => {
+                  // Only the on-screen segment advances the carousel.
+                  if (bufRef.current.front !== layer) return;
+                  if (segCountRef.current > 1) {
+                    const shown =
+                      bufRef.current.loaded[layer] ?? targetRef.current;
+                    goTo(shown + 1);
+                  }
+                }}
+              />
+            );
+          })}
 
           {showNav && (
             <>
@@ -153,7 +220,7 @@ export function FlowPreview() {
                 $side="left"
                 onClick={(e) => {
                   e.stopPropagation();
-                  goTo(currentIndex - 1);
+                  goTo(targetIndex - 1);
                 }}
                 aria-label="Previous segment"
               >
@@ -163,14 +230,14 @@ export function FlowPreview() {
                 $side="right"
                 onClick={(e) => {
                   e.stopPropagation();
-                  goTo(currentIndex + 1);
+                  goTo(targetIndex + 1);
                 }}
                 aria-label="Next segment"
               >
                 <ChevronRight size={16} strokeWidth={2.4} />
               </NavButton>
               <SegmentCounter>
-                {pad(currentIndex + 1)} / {pad(segmentCount)}
+                {pad(targetIndex + 1)} / {pad(segmentCount)}
               </SegmentCounter>
             </>
           )}
@@ -181,10 +248,10 @@ export function FlowPreview() {
             {completedSegments.map((_, i) => (
               <SegmentChip
                 key={i}
-                $active={i === currentIndex}
+                $active={i === targetIndex}
                 onClick={() => goTo(i)}
                 role="tab"
-                aria-selected={i === currentIndex}
+                aria-selected={i === targetIndex}
                 aria-label={`Segment ${i + 1}`}
               >
                 {pad(i + 1)}
@@ -205,7 +272,13 @@ export function FlowPreview() {
             aria-label="Video preview"
           >
             <LightboxVideo onClick={(e) => e.stopPropagation()}>
-              <video key={currentUrl} src={currentUrl} autoPlay controls />
+              <video
+                key={currentUrl}
+                src={currentUrl}
+                poster={currentPoster}
+                autoPlay
+                controls
+              />
             </LightboxVideo>
           </LightboxOverlay>,
           document.body,

--- a/src/components/pages/studio/components/flow-preview.tsx
+++ b/src/components/pages/studio/components/flow-preview.tsx
@@ -93,8 +93,11 @@ export function FlowPreview() {
         .filter(
           (
             s,
-          ): s is { dreamUuid: string; url: string; poster: string | undefined } =>
-            s !== null,
+          ): s is {
+            dreamUuid: string;
+            url: string;
+            poster: string | undefined;
+          } => s !== null,
         ),
     [dreamQueries, completedUuids],
   );

--- a/src/components/pages/studio/utils/preview-buffer.test.ts
+++ b/src/components/pages/studio/utils/preview-buffer.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  initialPreviewBuffer,
+  backLayer,
+  requestIndex,
+  ready,
+  type PreviewBufferState,
+} from "./preview-buffer";
+
+describe("preview-buffer", () => {
+  describe("initialPreviewBuffer", () => {
+    it("starts with layer 0 in front showing the start index", () => {
+      expect(initialPreviewBuffer()).toEqual({
+        front: 0,
+        loaded: [0, null],
+        ready: [false, false],
+      });
+    });
+
+    it("honours a custom start index", () => {
+      expect(initialPreviewBuffer(3)).toEqual({
+        front: 0,
+        loaded: [3, null],
+        ready: [false, false],
+      });
+    });
+  });
+
+  describe("backLayer", () => {
+    it("returns the opposite layer", () => {
+      expect(backLayer(0)).toBe(1);
+      expect(backLayer(1)).toBe(0);
+    });
+  });
+
+  describe("requestIndex", () => {
+    it("is a no-op when the requested index is already in front", () => {
+      const state = initialPreviewBuffer(0);
+      expect(requestIndex(state, 0)).toBe(state);
+    });
+
+    it("loads a new index into the back layer without swapping", () => {
+      const state = initialPreviewBuffer(0);
+      const next = requestIndex(state, 1);
+      // front unchanged, back layer now targets segment 1, not yet ready
+      expect(next.front).toBe(0);
+      expect(next.loaded).toEqual([0, 1]);
+      expect(next.ready).toEqual([false, false]);
+    });
+
+    it("does NOT swap immediately when the back layer holds the index but isn't ready yet", () => {
+      // request 1 (loads on back, not ready); requesting 1 again must wait, not flash black
+      const state = requestIndex(initialPreviewBuffer(0), 1);
+      const again = requestIndex(state, 1);
+      expect(again.front).toBe(0); // still showing front, no premature swap
+    });
+
+    it("swaps instantly when the back layer already has the index buffered and ready", () => {
+      // show 0 (front layer 0, ready), buffer + reveal 1, then go back to 0
+      let s: PreviewBufferState = initialPreviewBuffer(0);
+      s = ready(s, 0, 0); // front layer 0 decoded segment 0
+      s = requestIndex(s, 1); // back layer 1 loads segment 1
+      s = ready(s, 1, 1); // segment 1 ready -> swaps to front
+      expect(s.front).toBe(1);
+      // layer 0 still holds segment 0 and is ready -> revisiting is instant
+      const back = requestIndex(s, 0);
+      expect(back.front).toBe(0);
+      expect(back.loaded).toEqual([0, 1]);
+    });
+  });
+
+  describe("ready", () => {
+    it("swaps the front to the back layer once its first frame decodes", () => {
+      let s = requestIndex(initialPreviewBuffer(0), 1); // back = layer 1 loading seg 1
+      s = ready(s, 1, 1);
+      expect(s.front).toBe(1);
+      expect(s.ready[1]).toBe(true);
+    });
+
+    it("records readiness of the front layer without swapping", () => {
+      const s = ready(initialPreviewBuffer(0), 0, 0);
+      expect(s.front).toBe(0);
+      expect(s.ready[0]).toBe(true);
+    });
+
+    it("ignores a stale ready event superseded by a newer request", () => {
+      // request 1, then request 2 on the same back layer; the ready for 1 is stale
+      let s = requestIndex(initialPreviewBuffer(0), 1); // loaded = [0,1]
+      s = requestIndex(s, 2); // loaded = [0,2]
+      const afterStale = ready(s, 1, 1); // layer 1 now holds 2, not 1
+      expect(afterStale.front).toBe(0); // no swap
+      const afterReal = ready(s, 1, 2);
+      expect(afterReal.front).toBe(1); // real event swaps
+    });
+
+    it("does not swap if the front already shows that index", () => {
+      const s = ready(initialPreviewBuffer(2), 0, 2);
+      expect(s.front).toBe(0);
+    });
+  });
+});

--- a/src/components/pages/studio/utils/preview-buffer.ts
+++ b/src/components/pages/studio/utils/preview-buffer.ts
@@ -1,0 +1,78 @@
+/**
+ * Double-buffer state machine for the flow-preview carousel.
+ *
+ * Two stacked <video> layers share the frame. The layer in `front` is visible;
+ * the other preloads the next segment off-screen. We only reveal the back layer
+ * once its first frame has decoded, so the outgoing frame stays painted the whole
+ * time and no blank/black frame is ever shown between segments (issue #670).
+ *
+ * This module is pure — no React, no DOM — so the swap logic can be unit-tested
+ * in isolation. The component maps `front`/`loaded` onto opacity and the two
+ * <video> `src`s, and dispatches `ready()` from each layer's `loadeddata` event.
+ */
+
+export type Layer = 0 | 1;
+
+export interface PreviewBufferState {
+  /** Which layer is currently visible (front). */
+  front: Layer;
+  /** Segment index each layer has loaded as its <video> src (null = empty). */
+  loaded: [number | null, number | null];
+  /** Whether each layer's current src has decoded a displayable frame. */
+  ready: [boolean, boolean];
+}
+
+export const backLayer = (front: Layer): Layer => (front === 0 ? 1 : 0);
+
+export const initialPreviewBuffer = (startIndex = 0): PreviewBufferState => ({
+  front: 0,
+  loaded: [startIndex, null],
+  ready: [false, false],
+});
+
+/**
+ * Request that `index` becomes the visible segment.
+ * - Already in front → no change.
+ * - Already buffered AND ready on the back layer → reveal it now (instant crossfade).
+ * - Otherwise → assign it to the back layer so its <video> starts loading; the
+ *   swap happens later via `ready()`, keeping the current frame up until then.
+ */
+export function requestIndex(
+  state: PreviewBufferState,
+  index: number,
+): PreviewBufferState {
+  if (index === state.loaded[state.front]) return state;
+
+  const back = backLayer(state.front);
+  if (state.loaded[back] === index && state.ready[back]) {
+    return { ...state, front: back };
+  }
+
+  const loaded: [number | null, number | null] = [...state.loaded];
+  loaded[back] = index;
+  const ready: [boolean, boolean] = [...state.ready];
+  // New (or not-yet-ready) src on the back layer: it must re-prove readiness.
+  ready[back] = false;
+  return { front: state.front, loaded, ready };
+}
+
+/**
+ * A layer reported its first frame decoded (loadeddata) for `index`.
+ * Records readiness, then swaps that layer to the front only if it's the back
+ * layer, still holds that index (not superseded), and isn't already showing.
+ */
+export function ready(
+  state: PreviewBufferState,
+  layer: Layer,
+  index: number,
+): PreviewBufferState {
+  if (state.loaded[layer] !== index) return state; // stale / superseded event
+
+  const readyArr: [boolean, boolean] = [...state.ready];
+  readyArr[layer] = true;
+  const marked: PreviewBufferState = { ...state, ready: readyArr };
+
+  if (layer === state.front) return marked; // front readiness never swaps
+  if (state.loaded[state.front] === index) return marked; // front already shows it
+  return { ...marked, front: layer };
+}


### PR DESCRIPTION
## Problem

In the Studio flow **Preview** carousel, navigating between segment videos flashes a **blank/black screen** while the next clip loads (issue #670).

Root cause: the preview rendered a single `<video key={currentUrl}>`. Changing `currentUrl` forces React to **unmount the old `<video>` and mount a brand-new one** with no buffered data, so the wrapper's dark background shows through until the new clip decodes its first frame. No poster, no preload, no double-buffering.

## Fix

Double-buffer the preview with two stacked, crossfading `<video>` layers:

- The next segment preloads on the **hidden** layer while the current frame stays painted.
- It's only revealed once its **first frame has decoded** (`loadeddata`), then the layers crossfade (opacity, 0.45s). The outgoing frame is up the entire time — **no blank frame is ever shown**.
- Each layer also carries the dream `thumbnail` as a `poster`, a still-frame fallback if a segment is slow to buffer.

The swap logic is extracted into a **pure, unit-tested reducer** (`preview-buffer.ts`) that tracks the front/back layer pair and guards against stale/rapid navigation. Chips + counter update immediately on click (responsive), independent of load state.

## Demo

Side-by-side, same moment, same load latency — Before goes black; After holds the previous dream (Scott's) and crossfades:

[_Demo video: `metarepo/studio-670-crossfade-demo.mp4`._](https://drive.google.com/file/d/1_sJqMU7Seat8HxoEhp0k_FAqh0jNkKvx/view?usp=sharing)

## Testing

- New unit tests for the reducer: `preview-buffer.test.ts` (11 cases — swap-on-ready, instant revisit, stale-event rejection, rapid nav).
- `pnpm test` (studio + flow suites): 77 passing.
- `tsc --noEmit`: clean. `eslint` on changed files: clean.

## Files

- `components/pages/studio/utils/preview-buffer.ts` (+ test) — pure swap reducer
- `components/pages/studio/components/flow-preview.tsx` — two-layer render + wiring
- `components/pages/studio/components/flow-preview.styled.tsx` — `VideoLayer` crossfade

Fixes #670

claude --resume e2736451-8d43-4ce3-addb-67a60dc77abb