### PR TITLE
fix(studio): keyframe strip scrolls to the start past ~8 frames (#693)

### DIFF
--- a/src/components/pages/studio/components/keyframe-strip.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.styled.tsx
@@ -24,7 +24,10 @@ export const SectionLabel = styled.div`
 export const StripContainer = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  /* "safe" centers when the strip fits, but falls back to start-alignment when
+     it overflows — otherwise the start-side overflow is unreachable by scrolling
+     (and by drag auto-scroll) once there are enough keyframes. */
+  justify-content: safe center;
   gap: 0;
   overflow-x: auto;
   padding-bottom: 8px;
@@ -48,7 +51,7 @@ export const GapLine = styled.div`
 export const StripControls = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: safe center;
   gap: 12px;
   margin-top: 20px;
   overflow-x: auto;

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -161,6 +161,10 @@ export const KeyframeStrip: React.FC<Props> = ({
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
+          // Horizontal-only auto-scroll: reveal off-screen keyframes when a
+          // dragged card nears the strip's left/right edge, without hijacking
+          // vertical page scroll. y: 0 disables the vertical axis.
+          autoScroll={{ threshold: { x: 0.2, y: 0 } }}
         >
           <SortableContext
             items={sortableIds}


### PR DESCRIPTION
Fixes #693.

## Problem
In the flow studio, after ~8 keyframes the horizontal strip couldn't scroll all the way back to the first keyframes. Root cause: `StripContainer` used `justify-content: center` on an `overflow-x: auto` flex row. When flex children overflow a **centered** container, the start-side overflow lands where `scrollLeft` can't reach (it can't go below 0), so the first keyframes become permanently unreachable — by manual scrolling **and** by drag auto-scroll.

## Fix
- `justify-content: center` → `justify-content: safe center` on `StripContainer` (the fix) and `StripControls` (identical latent pattern). `safe` keeps the centered look while the strip fits, but falls back to start-alignment on overflow, restoring the full scroll range.
- Made `DndContext` auto-scroll explicit and horizontal-only: `autoScroll={{ threshold: { x: 0.2, y: 0 } }}`. dnd-kit's auto-scroll is on by default; the centering bug was what starved it. Now dragging a card toward the left/right edge reveals off-screen keyframes without hijacking vertical page scroll.

Single-row layout is kept intentionally (the issue floated a boustrophedon/wrap redesign; we went with the minimal scroll fix).

## Demo
Before/after scroll contrast + drag-with-auto-scroll reorder across 12 keyframes:
https://drive.google.com/file/d/1MDNKiUqFZtf5y-DA01hph7xLnXBExNf6/view?usp=sharing

- **Scroll to start:** Before (`center`) bottoms out on the middle frames — keyframe 1 clipped & unreachable. After (`safe center`) shows keyframe 1 at the left edge.
- **Drag + auto-scroll:** picking up a keyframe and holding it at the right edge auto-scrolls across the hidden frames and drops it at the end.

## Verification
- `pnpm run type-check` ✅
- `pnpm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)