### PR TITLE
feat(studio): open keyframes in an in-app lightbox with arrows (#694)

### DIFF
--- a/src/components/pages/studio/components/keyframe-card.tsx
+++ b/src/components/pages/studio/components/keyframe-card.tsx
@@ -92,16 +92,11 @@ export const KeyframeCard: React.FC<Props> = ({
 
   const percent = Math.round(keyframe.uploadProgress ?? 0);
 
-  const navigateTarget = keyframe.dreamUuid
-    ? `/dream/${keyframe.dreamUuid}`
-    : keyframe.keyframeUuid
-      ? `/keyframe/${keyframe.keyframeUuid}`
-      : null;
-  const isClickable = !isLoop && !isBusy && !!navigateTarget;
+  const openKeyframeLightbox = useFlowStore((s) => s.openKeyframeLightbox);
+  const isClickable = !isLoop && !isBusy && !!imgSrc;
   const handleOpen = (e: React.MouseEvent) => {
-    if (!navigateTarget) return;
     e.stopPropagation();
-    window.open(navigateTarget, "_blank");
+    openKeyframeLightbox(index);
   };
 
   return (

--- a/src/components/pages/studio/components/keyframe-lightbox.styled.tsx
+++ b/src/components/pages/studio/components/keyframe-lightbox.styled.tsx
@@ -1,0 +1,122 @@
+import styled from "styled-components";
+import { FLOW, flowFadeIn } from "@/constants/flow-theme.constants";
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  z-index: 1000;
+  animation: ${flowFadeIn} 0.25s ease;
+  cursor: pointer;
+`;
+
+export const ImageFrame = styled.div`
+  cursor: default;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 90vw;
+  max-height: 80vh;
+
+  img {
+    max-width: 90vw;
+    max-height: 80vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    border-radius: ${FLOW.radius};
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  }
+`;
+
+export const Caption = styled.div`
+  cursor: default;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: ${FLOW.fontFamily};
+  color: ${FLOW.textDim};
+  font-size: 13px;
+`;
+
+export const CaptionName = styled.span`
+  max-width: 60vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const Counter = styled.span`
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  color: ${FLOW.textMuted};
+  font-variant-numeric: tabular-nums;
+`;
+
+// Left/right navigation arrows, pinned to the viewport edges and always visible.
+export const NavButton = styled.button<{ $side: "left" | "right" }>`
+  position: fixed;
+  top: 50%;
+  ${(p) => (p.$side === "left" ? "left: 24px" : "right: 24px")};
+  transform: translateY(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(12, 12, 14, 0.6);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: ${FLOW.text};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+  transition:
+    background 0.18s ease,
+    opacity 0.18s ease;
+
+  &:hover {
+    background: rgba(212, 168, 83, 0.85);
+    color: ${FLOW.bg};
+  }
+
+  &:disabled {
+    opacity: 0.2;
+    cursor: default;
+    pointer-events: none;
+  }
+`;
+
+export const CloseButton = styled.button`
+  position: fixed;
+  top: 20px;
+  right: 24px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(12, 12, 14, 0.6);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: ${FLOW.text};
+  font-size: 24px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+  transition: background 0.18s ease;
+
+  &:hover {
+    background: rgba(212, 168, 83, 0.85);
+    color: ${FLOW.bg};
+  }
+`;

--- a/src/components/pages/studio/components/keyframe-lightbox.tsx
+++ b/src/components/pages/studio/components/keyframe-lightbox.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useFlowStore } from "@/stores/flow.store";
+import { canStep } from "../utils/keyframe-lightbox.util";
+import {
+  Overlay,
+  ImageFrame,
+  Caption,
+  CaptionName,
+  Counter,
+  NavButton,
+  CloseButton,
+} from "./keyframe-lightbox.styled";
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Full-screen lightbox for a flow keyframe (#694). Click a keyframe card to
+ * open it here; ←/→ (or the on-screen arrows) move between keyframes, Escape /
+ * backdrop / × closes. Navigation clamps at the ends. The synthetic loop frame
+ * is never clickable, so this only ever shows real keyframes.
+ */
+export const KeyframeLightbox: React.FC = () => {
+  const keyframes = useFlowStore((s) => s.keyframes);
+  const index = useFlowStore((s) => s.keyframeLightboxIndex);
+  const close = useFlowStore((s) => s.closeKeyframeLightbox);
+  const step = useFlowStore((s) => s.stepKeyframeLightbox);
+
+  const count = keyframes.length;
+  const isOpen = index !== null;
+
+  // Keyboard: Escape closes, arrows navigate (only while open).
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+      else if (e.key === "ArrowRight") step(1);
+      else if (e.key === "ArrowLeft") step(-1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, close, step]);
+
+  // Lock body scroll while the lightbox is open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  // If the underlying keyframe vanished (deleted while open), close.
+  const keyframe = index !== null ? keyframes[index] : undefined;
+  useEffect(() => {
+    if (isOpen && !keyframe) close();
+  }, [isOpen, keyframe, close]);
+
+  if (index === null || !keyframe) return null;
+
+  const canPrev = canStep(index, -1, count);
+  const canNext = canStep(index, 1, count);
+
+  return createPortal(
+    <Overlay
+      onClick={close}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyframe preview"
+    >
+      <CloseButton
+        onClick={(e) => {
+          e.stopPropagation();
+          close();
+        }}
+        aria-label="Close"
+      >
+        &times;
+      </CloseButton>
+
+      <NavButton
+        $side="left"
+        disabled={!canPrev}
+        onClick={(e) => {
+          e.stopPropagation();
+          step(-1);
+        }}
+        aria-label="Previous keyframe"
+      >
+        <ChevronLeft size={22} strokeWidth={2.4} />
+      </NavButton>
+
+      <ImageFrame onClick={(e) => e.stopPropagation()}>
+        <img src={keyframe.imageUrl} alt={keyframe.name} />
+      </ImageFrame>
+
+      <Caption onClick={(e) => e.stopPropagation()}>
+        <CaptionName>{keyframe.name}</CaptionName>
+        {count > 1 && (
+          <Counter>
+            {pad(index + 1)} / {pad(count)}
+          </Counter>
+        )}
+      </Caption>
+
+      <NavButton
+        $side="right"
+        disabled={!canNext}
+        onClick={(e) => {
+          e.stopPropagation();
+          step(1);
+        }}
+        aria-label="Next keyframe"
+      >
+        <ChevronRight size={22} strokeWidth={2.4} />
+      </NavButton>
+    </Overlay>,
+    document.body,
+  );
+};

--- a/src/components/pages/studio/components/keyframe-strip.tsx
+++ b/src/components/pages/studio/components/keyframe-strip.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useFlowStore, LOOP_KEYFRAME_ID } from "@/stores/flow.store";
 import { KeyframeCard } from "./keyframe-card";
+import { KeyframeLightbox } from "./keyframe-lightbox";
 import { TransitionGapEnhanced } from "./transition-gap";
 import { FlowReset } from "./flow-reset";
 import {
@@ -202,6 +203,8 @@ export const KeyframeStrip: React.FC<Props> = ({
           </LoopToggle>
         )}
       </StripControls>
+
+      <KeyframeLightbox />
     </StripSection>
   );
 };

--- a/src/components/pages/studio/utils/keyframe-lightbox.util.test.ts
+++ b/src/components/pages/studio/utils/keyframe-lightbox.util.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampLightboxIndex,
+  stepLightboxIndex,
+  canStep,
+} from "./keyframe-lightbox.util";
+
+describe("keyframe-lightbox.util", () => {
+  describe("clampLightboxIndex", () => {
+    it("returns null when there are no keyframes", () => {
+      expect(clampLightboxIndex(0, 0)).toBeNull();
+      expect(clampLightboxIndex(3, 0)).toBeNull();
+    });
+
+    it("clamps below zero to the first index", () => {
+      expect(clampLightboxIndex(-2, 5)).toBe(0);
+    });
+
+    it("clamps past the end to the last index", () => {
+      expect(clampLightboxIndex(9, 5)).toBe(4);
+    });
+
+    it("passes an in-range index through unchanged", () => {
+      expect(clampLightboxIndex(2, 5)).toBe(2);
+    });
+  });
+
+  describe("stepLightboxIndex", () => {
+    it("returns null when the lightbox is closed", () => {
+      expect(stepLightboxIndex(null, 1, 5)).toBeNull();
+    });
+
+    it("advances to the next index", () => {
+      expect(stepLightboxIndex(1, 1, 5)).toBe(2);
+    });
+
+    it("goes back to the previous index", () => {
+      expect(stepLightboxIndex(3, -1, 5)).toBe(2);
+    });
+
+    it("clamps at the last index instead of wrapping", () => {
+      expect(stepLightboxIndex(4, 1, 5)).toBe(4);
+    });
+
+    it("clamps at the first index instead of wrapping", () => {
+      expect(stepLightboxIndex(0, -1, 5)).toBe(0);
+    });
+  });
+
+  describe("canStep", () => {
+    it("is false when the lightbox is closed", () => {
+      expect(canStep(null, 1, 5)).toBe(false);
+    });
+
+    it("is false stepping back from the first index", () => {
+      expect(canStep(0, -1, 5)).toBe(false);
+    });
+
+    it("is false stepping forward from the last index", () => {
+      expect(canStep(4, 1, 5)).toBe(false);
+    });
+
+    it("is true stepping within range", () => {
+      expect(canStep(2, 1, 5)).toBe(true);
+      expect(canStep(2, -1, 5)).toBe(true);
+    });
+
+    it("is false with a single keyframe", () => {
+      expect(canStep(0, 1, 1)).toBe(false);
+      expect(canStep(0, -1, 1)).toBe(false);
+    });
+  });
+});

--- a/src/components/pages/studio/utils/keyframe-lightbox.util.ts
+++ b/src/components/pages/studio/utils/keyframe-lightbox.util.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure index math for the keyframe lightbox (#694).
+ *
+ * The lightbox navigates the real keyframes list with ←/→ arrows. Navigation
+ * clamps at the ends (no wrap-around) — the arrows are disabled once you reach
+ * the first or last keyframe. Index is a position into the real keyframes; the
+ * synthetic loop frame is not clickable and is excluded by the caller.
+ *
+ * No React, no DOM — so the navigation logic can be unit-tested in isolation.
+ */
+
+/** Clamp an index into [0, count-1]; returns null when there is nothing to show. */
+export function clampLightboxIndex(
+  index: number,
+  count: number,
+): number | null {
+  if (count <= 0) return null;
+  if (index < 0) return 0;
+  if (index > count - 1) return count - 1;
+  return index;
+}
+
+/**
+ * Step the current index by `delta`, clamped to the valid range.
+ * Returns null when the lightbox is closed (`current === null`) or empty.
+ */
+export function stepLightboxIndex(
+  current: number | null,
+  delta: number,
+  count: number,
+): number | null {
+  if (current === null) return null;
+  return clampLightboxIndex(current + delta, count);
+}
+
+/** Whether a prev/next step of `delta` is available from `current`. */
+export function canStep(
+  current: number | null,
+  delta: number,
+  count: number,
+): boolean {
+  if (current === null || count <= 0) return false;
+  const next = current + delta;
+  return next >= 0 && next <= count - 1;
+}

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -449,3 +449,55 @@ describe("Phase 1: transitions", () => {
     });
   });
 });
+
+describe("keyframe lightbox (#694)", () => {
+  beforeEach(() => {
+    useFlowStore.getState().resetFlow();
+  });
+
+  it("is closed by default", () => {
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBeNull();
+  });
+
+  it("opens at a valid keyframe index", () => {
+    const store = useFlowStore.getState();
+    store.addKeyframe(makeKf("a"));
+    store.addKeyframe(makeKf("b"));
+    store.openKeyframeLightbox(1);
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBe(1);
+  });
+
+  it("ignores an out-of-range open (stays closed)", () => {
+    const store = useFlowStore.getState();
+    store.addKeyframe(makeKf("a"));
+    store.openKeyframeLightbox(5);
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBeNull();
+  });
+
+  it("steps forward and clamps at the last keyframe", () => {
+    const store = useFlowStore.getState();
+    store.addKeyframe(makeKf("a"));
+    store.addKeyframe(makeKf("b"));
+    store.openKeyframeLightbox(0);
+    store.stepKeyframeLightbox(1);
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBe(1);
+    store.stepKeyframeLightbox(1);
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBe(1);
+  });
+
+  it("closes", () => {
+    const store = useFlowStore.getState();
+    store.addKeyframe(makeKf("a"));
+    store.openKeyframeLightbox(0);
+    store.closeKeyframeLightbox();
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBeNull();
+  });
+
+  it("resetFlow closes the lightbox", () => {
+    const store = useFlowStore.getState();
+    store.addKeyframe(makeKf("a"));
+    store.openKeyframeLightbox(0);
+    store.resetFlow();
+    expect(useFlowStore.getState().keyframeLightboxIndex).toBeNull();
+  });
+});

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -6,6 +6,7 @@ import type {
   TransitionStatus,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
+import { stepLightboxIndex } from "@/components/pages/studio/utils/keyframe-lightbox.util";
 
 export const LOOP_KEYFRAME_ID = "__loop__";
 
@@ -58,6 +59,8 @@ type FlowStoreState = {
   selectedTransitionIndex: number | null;
   settingsExpanded: boolean;
   previewLightboxOpen: boolean;
+  // Index of the keyframe shown in the lightbox (#694); null = closed.
+  keyframeLightboxIndex: number | null;
 
   // Phase 1 — actions
   setGlobalPreset: (id: string) => void;
@@ -76,6 +79,9 @@ type FlowStoreState = {
   selectTransition: (index: number | null) => void;
   setSettingsExpanded: (expanded: boolean) => void;
   setPreviewLightboxOpen: (open: boolean) => void;
+  openKeyframeLightbox: (index: number) => void;
+  closeKeyframeLightbox: () => void;
+  stepKeyframeLightbox: (delta: number) => void;
   updateTransitionStatus: (
     index: number,
     status: TransitionStatus,
@@ -110,6 +116,7 @@ const PHASE_1_DEFAULTS = {
   selectedTransitionIndex: null as number | null,
   settingsExpanded: false,
   previewLightboxOpen: false,
+  keyframeLightboxIndex: null as number | null,
   savedPlaylistUuid: null as string | null,
   syncedPlaylistDreamUuids: [] as string[],
 };
@@ -296,6 +303,21 @@ export const useFlowStore = create<FlowStoreState>()(
       selectTransition: (index) => set({ selectedTransitionIndex: index }),
       setSettingsExpanded: (expanded) => set({ settingsExpanded: expanded }),
       setPreviewLightboxOpen: (open) => set({ previewLightboxOpen: open }),
+
+      openKeyframeLightbox: (index) =>
+        set((s) => ({
+          keyframeLightboxIndex:
+            index >= 0 && index < s.keyframes.length ? index : null,
+        })),
+      closeKeyframeLightbox: () => set({ keyframeLightboxIndex: null }),
+      stepKeyframeLightbox: (delta) =>
+        set((s) => ({
+          keyframeLightboxIndex: stepLightboxIndex(
+            s.keyframeLightboxIndex,
+            delta,
+            s.keyframes.length,
+          ),
+        })),
 
       updateTransitionStatus: (index, status, progress) =>
         set((s) => {


### PR DESCRIPTION
Fixes #694.

## Problem
Clicking a keyframe in the flow studio opened `/dream/{uuid}` (or `/keyframe/{uuid}`) in a new browser tab — a "regular view". The issue asks for an in-app lightbox with left/right arrows to move between keyframes.

## Change
Clicking a keyframe now opens a full-screen lightbox over the studio, mirroring the existing `flow-preview` lightbox pattern (portal, dark backdrop, Escape/←/→).

- **`utils/keyframe-lightbox.util.ts`** — pure `clampLightboxIndex` / `stepLightboxIndex` / `canStep` (clamp-at-ends navigation), unit-tested in isolation.
- **`flow.store.ts`** — `keyframeLightboxIndex` (transient UI state, not persisted; closes on `resetFlow`) + `openKeyframeLightbox` / `closeKeyframeLightbox` / `stepKeyframeLightbox`.
- **`keyframe-lightbox.tsx` / `.styled.tsx`** — portal to `document.body`, large `object-fit: contain` image, on-screen chevrons (disabled at the ends — no wrap), `03 / 10` counter, keyframe name. Closes on backdrop / × / Escape; ←/→ navigate; body scroll locked; auto-closes if the shown keyframe is deleted while open.
- **`keyframe-card.tsx`** — click opens the lightbox (drag-to-reorder still works via dnd-kit's activation distance); dropped the new-tab open.

Loop frame is excluded (never clickable), so navigation only spans real keyframes.

## Demo
Recorded against the real staging app (real auth/studio/routing) with real dream keyframes — open, chevron + ←/→ navigation, arrows disabling at both ends, Escape to close:
https://drive.google.com/file/d/1VL4cXjtlOhSSofJbgmCU5mrAbbNbHcn5/view?usp=sharing

## Verification
- `pnpm run type-check` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ (util: 14 tests, store: 6 new tests)
- Live-verified end-to-end against staging (see demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)