### PR TITLE
fix(studio): poll pending transitions so generated edges never stick (#696)

### DIFF
--- a/src/components/pages/studio/hooks/useFlowJobProgress.ts
+++ b/src/components/pages/studio/hooks/useFlowJobProgress.ts
@@ -14,6 +14,11 @@ import {
   shouldApplyStatus,
   isPendingStatus,
 } from "./mapSocketStatus";
+import { findTransitionIndexByDream } from "../utils/flow-progress.util";
+
+// How often to re-check pending transition dreams as a fallback for missed
+// socket events. Fast enough to feel live, slow enough to avoid hammering.
+const RECONCILE_POLL_MS = 5000;
 
 export function useFlowJobProgress() {
   const { socket, isConnected } = useSocket();
@@ -139,36 +144,63 @@ export function useFlowJobProgress() {
 
   const activeSessionId = useSessionStore((s) => s.activeSessionId);
 
+  // Fallback reconciliation. A generated transition only advances
+  // queue -> processing -> processed via live socket `job:progress` events. If a
+  // completion event is ever missed — the dream room is joined after the worker
+  // already emitted, a reconnect gap, a dropped event — the edge would otherwise
+  // stay stuck at queue/processing until a full page reload. So while anything
+  // is pending, poll the backend on an interval and apply the real status. This
+  // self-heals within a session (issue #696).
   useEffect(() => {
     if (pendingUuids.length === 0) return;
 
-    for (const entry of pendingEntriesRef.current) {
-      fetchDream(entry.uuid)
-        .then((dream) => {
-          if (!dream) return;
+    let cancelled = false;
 
-          const mappedStatus = mapSocketStatus(dream.status);
-          if (!mappedStatus) return;
+    const reconcileOnce = () => {
+      for (const entry of pendingEntriesRef.current) {
+        fetchDream(entry.uuid)
+          .then((dream) => {
+            if (cancelled || !dream) return;
 
-          if (mappedStatus === "failed") toastFailure(entry.uuid, dream.error);
+            const mappedStatus = mapSocketStatus(dream.status);
+            if (!mappedStatus) return;
 
-          const transition = useFlowStore.getState().transitions[entry.index];
-          const current = entry.isUprez
-            ? transition?.uprezStatus
-            : transition?.status;
-          if (!shouldApplyStatus(current, mappedStatus)) return;
+            if (mappedStatus === "failed")
+              toastFailure(entry.uuid, dream.error);
 
-          if (entry.isUprez) {
-            useFlowStore
-              .getState()
-              .updateTransitionUprezStatus(entry.index, mappedStatus);
-          } else {
-            useFlowStore
-              .getState()
-              .updateTransitionStatus(entry.index, mappedStatus);
-          }
-        })
-        .catch(() => {});
-    }
+            // Re-resolve the transition by dream UUID (not the captured index):
+            // a reorder/insert can shift positions, and routing the update by
+            // index would land it on the wrong edge.
+            const { transitions: current } = useFlowStore.getState();
+            const idx = findTransitionIndexByDream(
+              current,
+              entry.uuid,
+              entry.isUprez,
+            );
+            if (idx === -1) return;
+
+            const currentStatus = entry.isUprez
+              ? current[idx].uprezStatus
+              : current[idx].status;
+            if (!shouldApplyStatus(currentStatus, mappedStatus)) return;
+
+            if (entry.isUprez) {
+              useFlowStore
+                .getState()
+                .updateTransitionUprezStatus(idx, mappedStatus);
+            } else {
+              useFlowStore.getState().updateTransitionStatus(idx, mappedStatus);
+            }
+          })
+          .catch(() => {});
+      }
+    };
+
+    reconcileOnce();
+    const timer = setInterval(reconcileOnce, RECONCILE_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
   }, [pendingUuids.length, activeSessionId, isConnected, toastFailure]);
 }

--- a/src/components/pages/studio/utils/flow-progress.util.test.ts
+++ b/src/components/pages/studio/utils/flow-progress.util.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { findTransitionIndexByDream } from "./flow-progress.util";
+import type { FlowTransition } from "@/types/flow.types";
+
+const t = (over: Partial<FlowTransition>): FlowTransition => ({
+  fromKeyframeId: "a",
+  toKeyframeId: "b",
+  status: "queue",
+  ...over,
+});
+
+describe("findTransitionIndexByDream", () => {
+  it("finds a transition by its video dream uuid", () => {
+    const transitions = [t({ dreamUuid: "v1" }), t({ dreamUuid: "v2" })];
+    expect(findTransitionIndexByDream(transitions, "v2", false)).toBe(1);
+  });
+
+  it("finds a transition by its uprez dream uuid", () => {
+    const transitions = [
+      t({ dreamUuid: "v1", uprezDreamUuid: "u1" }),
+      t({ dreamUuid: "v2", uprezDreamUuid: "u2" }),
+    ];
+    expect(findTransitionIndexByDream(transitions, "u1", true)).toBe(0);
+  });
+
+  it("returns -1 when no transition owns the uuid", () => {
+    const transitions = [t({ dreamUuid: "v1" })];
+    expect(findTransitionIndexByDream(transitions, "missing", false)).toBe(-1);
+  });
+
+  it("resolves the correct edge after a reorder shifts positions", () => {
+    // A pending edge that was at index 0 is now at index 2 after an insert.
+    // Routing by uuid still lands on the right edge; routing by the old index
+    // (0) would have hit the wrong one.
+    const reordered = [
+      t({ dreamUuid: "new-a" }),
+      t({ dreamUuid: "new-b" }),
+      t({ dreamUuid: "v-pending" }),
+    ];
+    expect(findTransitionIndexByDream(reordered, "v-pending", false)).toBe(2);
+  });
+});

--- a/src/components/pages/studio/utils/flow-progress.util.ts
+++ b/src/components/pages/studio/utils/flow-progress.util.ts
@@ -1,0 +1,18 @@
+import type { FlowTransition } from "@/types/flow.types";
+
+/**
+ * Locate the transition currently carrying `dreamUuid` (its video dream, or its
+ * uprez dream when `isUprez`). Status updates from socket events / the polling
+ * fallback resolve the target edge by UUID — not by a captured array index —
+ * so inserting or reordering keyframes can never misroute an update onto the
+ * wrong edge (#696). Returns -1 when no transition owns the UUID.
+ */
+export function findTransitionIndexByDream(
+  transitions: FlowTransition[],
+  dreamUuid: string,
+  isUprez: boolean,
+): number {
+  return transitions.findIndex((t) =>
+    isUprez ? t.uprezDreamUuid === dreamUuid : t.dreamUuid === dreamUuid,
+  );
+}


### PR DESCRIPTION
Fixes #696.

## Problem
Repro: put up a bunch of keyframes, Generate All the edges and let them complete. Add a new image, drag it to the middle, click Generate All. The two new edges POST correctly and go to `queue` — but then stay stuck at queue/processing forever, even though the backend has them `processed`. The flow "doesn't update correctly" until a full page reload.

## Root cause
The state logic is fine — `deriveTransitions` / `generateAll` / the preview are all correct (verified with a deterministic test of the exact flow). The bug is in `useFlowJobProgress`: a generated transition only advances `queue → processing → processed` via live socket `job:progress` events. The one fallback fetched each pending dream **once** (right when it became pending, i.e. still processing) and never refetched. If a completion event is missed — the dream room is joined after the worker already emitted (join-after-emit race), a reconnect gap, or a dropped event — the edge is stuck until the mount reconcile re-runs (only on reload).

## Fix
- **Poll pending transitions every 5s** and apply the real backend status, so missed socket events self-heal within the session. The socket stays the fast primary path; polling is the durable fallback.
- **Resolve the target edge by dream UUID** (new pure `findTransitionIndexByDream`, unit-tested) instead of a captured array index, so an insert/reorder can't misroute a late status update onto the wrong edge.

## Verification
Reproduced live against staging with real image keyframes + real Kling generation:
- **Before:** the two new edges sat at `queue` for 12 minutes while the backend showed them `processed`.
- **After:** they reach `processed` in-session (33–34 fallback polls each) and the preview shows all 3 segments.

Also: `pnpm run type-check` ✅, `pnpm run lint` ✅, `pnpm run test` ✅ (incl. 4 new `findTransitionIndexByDream` tests).

## Demo
Before/after of the stuck-vs-self-healing behaviour (faithful transition-gap status reproduction):
https://drive.google.com/file/d/17QTNTLrf5UPeGgOou-q751gaU9lqvj4N/view?usp=sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)