### PR TITLE
feat(studio): negative prompt for still-image generation, under Advanced (#699)

### DIFF
--- a/src/components/pages/studio/components/generate-keyframes-modal.tsx
+++ b/src/components/pages/studio/components/generate-keyframes-modal.tsx
@@ -14,6 +14,7 @@ import {
   IMAGE_COUNT_OPTIONS,
   clampSizeToAllowed,
 } from "../constants/size-options";
+import { buildImageAlgoParams } from "../utils/build-image-algo-params";
 import { SizeSelect } from "./size-select";
 import {
   Overlay,
@@ -33,6 +34,7 @@ import {
   FieldLabel,
   Select,
   PromptTextarea,
+  AdvancedToggle,
 } from "./transition-settings-panel.styled";
 
 interface Props {
@@ -50,6 +52,7 @@ export const GenerateKeyframesModal: React.FC<Props> = ({ onClose }) => {
   const prompt = useStudioStore((s) => s.imagePrompt);
   const setPrompt = useStudioStore((s) => s.setImagePrompt);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   const { data: modelsData } = useModels({ mediaType: "image" });
   const modelOptions = useMemo(
@@ -84,12 +87,13 @@ export const GenerateKeyframesModal: React.FC<Props> = ({ onClose }) => {
     await Promise.all(
       Array.from({ length: imageGenParams.seedCount }, (_, i) => {
         const seed = baseSeed + i;
-        const algoParams = {
-          infinidream_algorithm: imageGenParams.model,
+        const algoParams = buildImageAlgoParams({
+          model: imageGenParams.model,
           prompt,
           size: imageGenParams.size,
           seed,
-        };
+          negativePrompt: imageGenParams.negativePrompt,
+        });
 
         return axiosClient
           .post("/v1/dream", {
@@ -201,6 +205,27 @@ export const GenerateKeyframesModal: React.FC<Props> = ({ onClose }) => {
               />
             </FieldGroup>
           </FieldRow>
+          <AdvancedToggle
+            type="button"
+            onClick={() => setAdvancedOpen((o) => !o)}
+            style={{ display: "block", marginTop: 12 }}
+          >
+            {advancedOpen ? "▾" : "▸"} Advanced
+          </AdvancedToggle>
+          {advancedOpen && (
+            <>
+              <FieldLabel style={{ display: "block", marginTop: 10 }}>
+                Negative prompt
+              </FieldLabel>
+              <PromptTextarea
+                placeholder="Describe what to avoid (optional)..."
+                value={imageGenParams.negativePrompt}
+                onChange={(e) =>
+                  setImageGenParams({ negativePrompt: e.target.value })
+                }
+              />
+            </>
+          )}
           <CreditLimitNotice
             overBudget={overBudget}
             canManageKey={canManageKey}

--- a/src/components/pages/studio/components/images-tab.styled.tsx
+++ b/src/components/pages/studio/components/images-tab.styled.tsx
@@ -48,6 +48,29 @@ export const PromptTextarea = styled.textarea`
   }
 `;
 
+export const AdvancedToggle = styled.button`
+  background: none;
+  border: none;
+  color: ${(props) => props.theme.textBodyColor};
+  font-family: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  padding: 0;
+  margin: -0.25rem 0 0.75rem;
+  text-align: left;
+
+  &:hover {
+    color: ${(props) => props.theme.textPrimaryColor};
+  }
+`;
+
+export const AdvancedFieldLabel = styled.label`
+  display: block;
+  font-size: 0.8125rem;
+  color: ${(props) => props.theme.textBodyColor};
+  margin-bottom: 0.4rem;
+`;
+
 export const FormRow = styled.div`
   display: flex;
   align-items: center;

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -15,11 +15,14 @@ import {
   IMAGE_COUNT_OPTIONS,
   clampSizeToAllowed,
 } from "../constants/size-options";
+import { buildImageAlgoParams } from "../utils/build-image-algo-params";
 import { SizeSelect } from "./size-select";
 import {
   GenerateSection,
   SectionTitle,
   PromptTextarea,
+  AdvancedToggle,
+  AdvancedFieldLabel,
   FormRow,
   FormField,
   FieldLabel,
@@ -65,6 +68,7 @@ export const ImagesTab: React.FC = () => {
   const isGenerating = useStudioStore((s) => s.isGenerating);
   const setIsGenerating = useStudioStore((s) => s.setIsGenerating);
   const [showPlaylistModal, setShowPlaylistModal] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [expandedImageUuid, setExpandedImageUuid] = useState<string | null>(
     null,
   );
@@ -114,12 +118,13 @@ export const ImagesTab: React.FC = () => {
       { length: imageGenParams.seedCount },
       (_, i) => {
         const seed = baseSeed + i;
-        const algoParams = {
-          infinidream_algorithm: imageGenParams.model,
+        const algoParams = buildImageAlgoParams({
+          model: imageGenParams.model,
           prompt: imagePrompt,
           size: imageGenParams.size,
           seed,
-        };
+          negativePrompt: imageGenParams.negativePrompt,
+        });
 
         return axiosClient
           .post("/v1/dream", {
@@ -213,6 +218,24 @@ export const ImagesTab: React.FC = () => {
           value={imagePrompt}
           onChange={(e) => setImagePrompt(e.target.value)}
         />
+        <AdvancedToggle
+          type="button"
+          onClick={() => setAdvancedOpen((o) => !o)}
+        >
+          {advancedOpen ? "▾" : "▸"} Advanced
+        </AdvancedToggle>
+        {advancedOpen && (
+          <>
+            <AdvancedFieldLabel>Negative prompt</AdvancedFieldLabel>
+            <PromptTextarea
+              placeholder="Describe what to avoid (optional)..."
+              value={imageGenParams.negativePrompt}
+              onChange={(e) =>
+                setImageGenParams({ negativePrompt: e.target.value })
+              }
+            />
+          </>
+        )}
         <FormRow>
           <FormField>
             <FieldLabel>Model:</FieldLabel>

--- a/src/components/pages/studio/utils/build-image-algo-params.test.ts
+++ b/src/components/pages/studio/utils/build-image-algo-params.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { buildImageAlgoParams } from "./build-image-algo-params";
+
+describe("buildImageAlgoParams", () => {
+  const base = {
+    model: "qwen-image" as const,
+    prompt: "a crystal cave",
+    size: "1280*720",
+    seed: 42,
+  };
+
+  it("builds the core image params", () => {
+    expect(buildImageAlgoParams(base)).toEqual({
+      infinidream_algorithm: "qwen-image",
+      prompt: "a crystal cave",
+      size: "1280*720",
+      seed: 42,
+    });
+  });
+
+  it("omits negative_prompt when not provided", () => {
+    expect(buildImageAlgoParams(base)).not.toHaveProperty("negative_prompt");
+  });
+
+  it("omits negative_prompt when empty or whitespace-only", () => {
+    expect(
+      buildImageAlgoParams({ ...base, negativePrompt: "   " }),
+    ).not.toHaveProperty("negative_prompt");
+    expect(
+      buildImageAlgoParams({ ...base, negativePrompt: "" }),
+    ).not.toHaveProperty("negative_prompt");
+  });
+
+  it("includes trimmed negative_prompt when provided", () => {
+    expect(
+      buildImageAlgoParams({ ...base, negativePrompt: "  blurry, text  " }),
+    ).toEqual({
+      infinidream_algorithm: "qwen-image",
+      prompt: "a crystal cave",
+      size: "1280*720",
+      seed: 42,
+      negative_prompt: "blurry, text",
+    });
+  });
+});

--- a/src/components/pages/studio/utils/build-image-algo-params.ts
+++ b/src/components/pages/studio/utils/build-image-algo-params.ts
@@ -1,0 +1,35 @@
+import type { ImageModel } from "@/types/studio.types";
+
+interface BuildImageAlgoParamsInput {
+  model: ImageModel;
+  prompt: string;
+  size: string;
+  seed: number;
+  negativePrompt?: string;
+}
+
+/**
+ * Build the `algoParams` payload for a still-image generation dream. Shared by
+ * the batch Images tab and the flow "Generate Keyframes" modal so both send an
+ * identical shape. `negative_prompt` is included only when a non-empty value is
+ * given (same convention as buildVideoAlgoParams).
+ */
+export const buildImageAlgoParams = ({
+  model,
+  prompt,
+  size,
+  seed,
+  negativePrompt,
+}: BuildImageAlgoParamsInput): Record<string, unknown> => {
+  const params: Record<string, unknown> = {
+    infinidream_algorithm: model,
+    prompt,
+    size,
+    seed,
+  };
+  const trimmedNegative = negativePrompt?.trim();
+  if (trimmedNegative) {
+    params.negative_prompt = trimmedNegative;
+  }
+  return params;
+};

--- a/src/stores/studio.store.test.ts
+++ b/src/stores/studio.store.test.ts
@@ -121,6 +121,7 @@ describe("studio.store", () => {
         model: "z-image-turbo",
         seedCount: 8,
         size: "1280*720",
+        negativePrompt: "",
       });
       expect(migrated.qwenParams).toBeUndefined();
     });
@@ -274,6 +275,7 @@ describe("studio.store", () => {
         model: "z-image-turbo",
         seedCount: 8,
         size: "1280*720",
+        negativePrompt: "",
       });
       expect(migrated.videoGenParams).toEqual({
         model: "ltx-i2v",

--- a/src/stores/studio.store.ts
+++ b/src/stores/studio.store.ts
@@ -64,6 +64,7 @@ const DEFAULT_IMAGE_GEN_PARAMS: ImageGenParams = {
   model: "z-image-turbo",
   seedCount: 8,
   size: "1280*720",
+  negativePrompt: "",
 };
 const DEFAULT_VIDEO_GEN_PARAMS: VideoGenParams = {
   model: "ltx-i2v",
@@ -234,7 +235,7 @@ export const useStudioStore = create<StudioState>()(
     }),
     {
       name: "studio-session",
-      version: 5,
+      version: 6,
       partialize: studioPartialize,
       storage: {
         getItem: (name) => {
@@ -318,6 +319,15 @@ export const useStudioStore = create<StudioState>()(
             videoGenParams?.guidance === 5.0
           ) {
             state.videoGenParams = { ...DEFAULT_VIDEO_GEN_PARAMS };
+          }
+        }
+        if (version < 6) {
+          // negativePrompt added to image generation (#699); backfill so the
+          // controlled textarea always has a string.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const imageGenParams = state.imageGenParams as any;
+          if (imageGenParams && imageGenParams.negativePrompt == null) {
+            imageGenParams.negativePrompt = "";
           }
         }
         return state as Record<string, unknown>;

--- a/src/types/studio.types.ts
+++ b/src/types/studio.types.ts
@@ -64,6 +64,7 @@ export interface ImageGenParams {
   model: ImageModel;
   seedCount: number;
   size: string;
+  negativePrompt: string;
 }
 
 export const createComboKey = (


### PR DESCRIPTION
Fixes #699.

## What
When prompting a still image, users can now specify an optional **negative prompt**, revealed only when they open an **"Advanced"** disclosure — in both still-image UIs (the batch Images tab and the flow "Generate Keyframes" modal, which share the same store state).

## Changes
- `studio.store`: `negativePrompt` added to the shared, persisted `ImageGenParams` (so it carries across both UIs and reloads); a v6 migration backfills `""` for existing sessions.
- Extracted a pure **`buildImageAlgoParams`** (mirrors `buildVideoAlgoParams`), used by both UIs so they send an identical payload. `negative_prompt` (snake_case) is included **only when non-empty** (whitespace trimmed) — same convention as the video builder. Unit-tested.
- Both UIs gain a collapsed-by-default "▾ Advanced" toggle with a Negative prompt textarea bound to the store.

Note: the field is shown for all image models and passed to the worker regardless — turbo/distilled models (`z-image-turbo`, `flux-schnell`) may ignore a negative prompt server-side, while `qwen-image` honors it. Happy to gate it to only supported models if preferred.

## Verification
- `pnpm run type-check` ✅, `pnpm run lint` ✅, `pnpm run test` ✅ (4 new builder tests; updated 2 migration assertions for the new default).
- Verified live against staging (credit-free): opening Advanced reveals the field, and the `POST /v1/dream` payload includes `negative_prompt` (request intercepted + aborted, no dream created).

## Demo
Opening Advanced → Negative prompt field, in both the Flow Generate dialog and the Batch Images tab:
https://drive.google.com/file/d/1t7fFy2RDhJpu9lIjdjZcwaPp8a7_61fl/view?usp=sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)