### PR TITLE
fix(studio): gallery thumbnails show true aspect ratio (#706)

### DIFF
--- a/src/components/pages/studio/components/images-tab.styled.tsx
+++ b/src/components/pages/studio/components/images-tab.styled.tsx
@@ -138,23 +138,28 @@ export const ImageGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 0.75rem;
+  /* Don't stretch a short thumbnail to its row's tallest neighbour — each card
+     hugs its own image so mixed aspect ratios render true. */
+  align-items: start;
 `;
 
-export const ImageCard = styled.div<{ $selected?: boolean }>`
+export const ImageCard = styled.div<{ $selected?: boolean; $ratio?: string }>`
   position: relative;
   border-radius: 8px;
   overflow: hidden;
   border: 2px solid
     ${(props) => (props.$selected ? props.theme.colorPrimary : "transparent")};
   cursor: pointer;
-  aspect-ratio: 16 / 9;
   background: ${(props) => props.theme.colorBackgroundQuaternary};
+  /* Only image-less placeholders (queue / failed) get a fixed box; cards with a
+     real image take their height from the image, showing its true aspect ratio. */
+  ${(props) => props.$ratio && `aspect-ratio: ${props.$ratio};`}
 `;
 
 export const ImageThumbnail = styled.img`
+  display: block;
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
 `;
 
 export const StarBadge = styled.button<{ $active?: boolean }>`

--- a/src/components/pages/studio/components/images-tab.tsx
+++ b/src/components/pages/studio/components/images-tab.tsx
@@ -13,6 +13,7 @@ import { useCostEstimate } from "@/hooks/useCostEstimate";
 import { useCreditGuard } from "@/hooks/useCreditGuard";
 import {
   IMAGE_COUNT_OPTIONS,
+  aspectRatioFromSize,
   clampSizeToAllowed,
 } from "../constants/size-options";
 import { buildImageAlgoParams } from "../utils/build-image-algo-params";
@@ -334,50 +335,63 @@ export const ImagesTab: React.FC = () => {
           </EmptyStateText>
         ) : (
           <ImageGrid>
-            {images.map((img) => (
-              <ImageCard key={img.uuid} $selected={img.selected}>
-                {img.status === "processed" ? (
-                  img.url.startsWith("http") ? (
+            {images.map((img) => {
+              // A processed image (http url or presigned-by-uuid) or a
+              // processing image with a preview url shows a real thumbnail, so
+              // the card takes its shape from the image. Otherwise it's an
+              // image-less placeholder that needs a box to occupy.
+              const hasImage =
+                img.status === "processed" ||
+                (img.status === "processing" && !!img.url);
+              return (
+                <ImageCard
+                  key={img.uuid}
+                  $selected={img.selected}
+                  $ratio={hasImage ? undefined : aspectRatioFromSize(img.size)}
+                >
+                  {img.status === "processed" ? (
+                    img.url.startsWith("http") ? (
+                      <ImageThumbnail
+                        src={img.url}
+                        alt={img.name}
+                        onClick={() => setExpandedImageUuid(img.uuid)}
+                        style={{ cursor: "zoom-in" }}
+                      />
+                    ) : (
+                      <ImageThumbnail
+                        as={PresignedImage}
+                        dreamUuid={img.uuid}
+                        alt={img.name}
+                        onClick={() => setExpandedImageUuid(img.uuid)}
+                        style={{ cursor: "zoom-in" }}
+                      />
+                    )
+                  ) : img.status === "processing" && img.url ? (
                     <ImageThumbnail
                       src={img.url}
                       alt={img.name}
-                      onClick={() => setExpandedImageUuid(img.uuid)}
-                      style={{ cursor: "zoom-in" }}
+                      style={{ opacity: 0.5 }}
                     />
                   ) : (
-                    <ImageThumbnail
-                      as={PresignedImage}
-                      dreamUuid={img.uuid}
-                      alt={img.name}
-                      onClick={() => setExpandedImageUuid(img.uuid)}
-                      style={{ cursor: "zoom-in" }}
-                    />
-                  )
-                ) : img.status === "processing" && img.url ? (
-                  <ImageThumbnail
-                    src={img.url}
-                    alt={img.name}
-                    style={{ opacity: 0.5 }}
-                  />
-                ) : (
-                  <ImageStatus>
-                    {img.status === "queue" && "Queued..."}
-                    {img.status === "processing" && `${img.progress ?? 0}%`}
-                    {img.status === "failed" && "Failed"}
-                  </ImageStatus>
-                )}
-                {img.seed != null && <SeedLabel>#{img.seed}</SeedLabel>}
-                <StarBadge
-                  $active={img.selected}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleImageSelected(img.uuid);
-                  }}
-                >
-                  {img.selected ? "\u2605" : "\u2606"}
-                </StarBadge>
-              </ImageCard>
-            ))}
+                    <ImageStatus>
+                      {img.status === "queue" && "Queued..."}
+                      {img.status === "processing" && `${img.progress ?? 0}%`}
+                      {img.status === "failed" && "Failed"}
+                    </ImageStatus>
+                  )}
+                  {img.seed != null && <SeedLabel>#{img.seed}</SeedLabel>}
+                  <StarBadge
+                    $active={img.selected}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleImageSelected(img.uuid);
+                    }}
+                  >
+                    {img.selected ? "\u2605" : "\u2606"}
+                  </StarBadge>
+                </ImageCard>
+              );
+            })}
           </ImageGrid>
         )}
         <BottomRow>

--- a/src/components/pages/studio/constants/size-options.test.ts
+++ b/src/components/pages/studio/constants/size-options.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { clampSizeToAllowed, formatSizeLabel, parseSize } from "./size-options";
+import {
+  aspectRatioFromSize,
+  clampSizeToAllowed,
+  formatSizeLabel,
+  parseSize,
+} from "./size-options";
 
 const QWEN_SIZES = ["1280*720", "1024*1024", "720*1280", "512*512"];
 
@@ -38,6 +43,21 @@ describe("parseSize", () => {
     expect(parseSize("nonsense")).toBeNull();
     expect(parseSize("")).toBeNull();
     expect(parseSize("0*720")).toBeNull();
+  });
+});
+
+describe("aspectRatioFromSize", () => {
+  it("derives a CSS aspect-ratio from a parseable size", () => {
+    expect(aspectRatioFromSize("1280*720")).toBe("1280 / 720");
+    expect(aspectRatioFromSize("720x1280")).toBe("720 / 1280");
+    expect(aspectRatioFromSize("512×512")).toBe("512 / 512");
+  });
+
+  it("falls back to 1 / 1 when the size is missing or unparseable", () => {
+    expect(aspectRatioFromSize(undefined)).toBe("1 / 1");
+    expect(aspectRatioFromSize("")).toBe("1 / 1");
+    expect(aspectRatioFromSize("nonsense")).toBe("1 / 1");
+    expect(aspectRatioFromSize("0*720")).toBe("1 / 1");
   });
 });
 

--- a/src/components/pages/studio/constants/size-options.ts
+++ b/src/components/pages/studio/constants/size-options.ts
@@ -17,6 +17,14 @@ export const parseSize = (
 
 export const formatSizeLabel = (size: string): string => size.replace("*", "x");
 
+// CSS `aspect-ratio` string ("w / h") derived from a size like "1280*720".
+// Falls back to a square when the size is absent or unparseable — used to give
+// image-less gallery placeholders a sensible box before the real image loads.
+export const aspectRatioFromSize = (size?: string): string => {
+  const parsed = size ? parseSize(size) : null;
+  return parsed ? `${parsed.width} / ${parsed.height}` : "1 / 1";
+};
+
 export const clampSizeToAllowed = (
   currentSize: string,
   sizes: readonly string[],


### PR DESCRIPTION
Closes #706

## Problem

In the studio still-image gallery, every thumbnail rendered as the same fixed box — `ImageCard` hard-coded `aspect-ratio: 16 / 9` and `ImageThumbnail` used `object-fit: cover`. Portrait and square images were force-cropped (tops/bottoms cut off).

## Fix

The image now drives the card's height, so each thumbnail shows its true aspect ratio:

- `ImageThumbnail`: `height: 100%; object-fit: cover` → `display: block; width: 100%; height: auto;`
- `ImageCard`: drop the fixed `aspect-ratio: 16 / 9`; add a `$ratio` prop applied **only** to image-less placeholders (queue / failed) so they don't collapse
- `ImageGrid`: `align-items: start` so a short card isn't stretched to its row's tallest neighbour
- New pure helper `aspectRatioFromSize()` (derives the placeholder box from a generated image's `size`), TDD'd in `size-options.test.ts`

No cropping anywhere; works uniformly for generated, uploaded, and playlist images. The lightbox (already `object-fit: contain`) is unaffected.

## Verification

- Confirmed against staging that thumbnails **preserve source aspect ratio** (a 1392×752 image's thumbnail is 1392×752, not squared), so `height: auto` genuinely shows the real shape.
- Rendered real portrait / square / landscape staging thumbnails through the exact gallery CSS (before vs after).
- `pnpm type-check`, `eslint`, and `size-options` unit tests pass.

## Demo

Before → after (portrait lighthouse + square mandala cropped into 16:9 boxes, then shown full at true aspect):
https://drive.google.com/file/d/1HozD-aHnc10_rGsmCSRL23_vkYjT0--7/view?usp=sharing

https://github.com/e-dream-ai/frontend/pull/712