### PR TITLE
fix(studio): image pickers show true aspect ratio (#706)

### DIFF
--- a/src/components/pages/studio/components/add-from-playlist-modal.styled.tsx
+++ b/src/components/pages/studio/components/add-from-playlist-modal.styled.tsx
@@ -61,6 +61,9 @@ export const ImageSelectGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 0.5rem;
   margin-top: 1rem;
+  /* Cards vary in height now that each takes its image's shape, so don't
+     stretch a short one to match the tallest in its row. */
+  align-items: start;
 `;
 
 export const ImageSelectCard = styled.div<{ $selected?: boolean }>`
@@ -70,6 +73,21 @@ export const ImageSelectCard = styled.div<{ $selected?: boolean }>`
   border: 2px solid
     ${(props) => (props.$selected ? props.theme.colorPrimary : "transparent")};
   cursor: pointer;
-  aspect-ratio: 16 / 9;
+  /* No fixed aspect-ratio: the image inside sets the height, so the card is
+     the image's true shape. The floor only keeps a card whose image hasn't
+     resolved from collapsing to nothing. */
+  min-height: 60px;
   background: ${(props) => props.theme.colorBackgroundQuaternary};
+`;
+
+/* Local to this picker on purpose: images-tab's ImageThumbnail fills a fixed
+   box (height: 100%), which would measure zero inside an auto-height card. */
+export const ImageSelectThumbnail = styled.img<{ $ratio?: string }>`
+  width: 100%;
+  height: auto;
+  display: block;
+  /* Reserve the real box before the bitmap arrives when dimensions are known,
+     so the grid doesn't reflow as thumbnails load. Optional: keyframes carry no
+     dimensions, and those fall back to the intrinsic ratio. */
+  ${(p) => p.$ratio && `aspect-ratio: ${p.$ratio};`}
 `;

--- a/src/components/pages/studio/components/add-from-playlist-modal.tsx
+++ b/src/components/pages/studio/components/add-from-playlist-modal.tsx
@@ -3,13 +3,13 @@ import { axiosClient } from "@/client/axios.client";
 import { useStudioStore } from "@/stores/studio.store";
 import type { StudioImage } from "@/types/studio.types";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
+import { mediaAspectRatio } from "../utils/media-aspect-ratio";
 import {
   StyledSelect,
   NavButton,
   SecondaryNavButton,
 } from "./images-tab.styled";
 import { PresignedImage } from "@/components/shared/presigned-image";
-import { ImageThumbnail } from "./images-tab.styled";
 import {
   ModalOverlay,
   ModalContent,
@@ -20,6 +20,7 @@ import {
   ModalFooter,
   ImageSelectGrid,
   ImageSelectCard,
+  ImageSelectThumbnail,
 } from "./add-from-playlist-modal.styled";
 
 interface Props {
@@ -32,6 +33,10 @@ interface PlaylistItem {
     name: string;
     thumbnail: string;
     mediaType?: string;
+    /* Present because /v1/playlist/:uuid/items leftJoinAndSelects the whole
+       dream; nullable for dreams processed before the field existed. */
+    processedMediaWidth?: number | null;
+    processedMediaHeight?: number | null;
   };
 }
 
@@ -170,10 +175,14 @@ export const AddFromPlaylistModal: React.FC<Props> = ({ onClose }) => {
                     onClick={() => !alreadyAdded && toggleSelected(dream.uuid)}
                     style={{ opacity: alreadyAdded ? 0.4 : 1 }}
                   >
-                    <ImageThumbnail
+                    <ImageSelectThumbnail
                       as={PresignedImage}
                       dreamUuid={dream.uuid}
                       alt={dream.name}
+                      $ratio={mediaAspectRatio(
+                        dream.processedMediaWidth,
+                        dream.processedMediaHeight,
+                      )}
                     />
                   </ImageSelectCard>
                 );

--- a/src/components/pages/studio/components/add-keyframes-from-playlist-modal.tsx
+++ b/src/components/pages/studio/components/add-keyframes-from-playlist-modal.tsx
@@ -9,7 +9,6 @@ import {
   StyledSelect,
   NavButton,
   SecondaryNavButton,
-  ImageThumbnail,
 } from "./images-tab.styled";
 import {
   ModalOverlay,
@@ -21,6 +20,7 @@ import {
   ModalFooter,
   ImageSelectGrid,
   ImageSelectCard,
+  ImageSelectThumbnail,
 } from "./add-from-playlist-modal.styled";
 
 interface Props {
@@ -125,7 +125,7 @@ export const AddKeyframesFromPlaylistModal: React.FC<Props> = ({ onClose }) => {
                   $selected={selectedUuids.has(item.keyframe!.uuid)}
                   onClick={() => toggleSelected(item.keyframe!.uuid)}
                 >
-                  <ImageThumbnail
+                  <ImageSelectThumbnail
                     src={item.keyframe!.image}
                     alt={item.keyframe!.name}
                   />

--- a/src/components/pages/studio/components/select-image-dream-modal.styled.tsx
+++ b/src/components/pages/studio/components/select-image-dream-modal.styled.tsx
@@ -122,6 +122,9 @@ export const Grid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   gap: 10px;
+  /* Cards vary in height now that each takes its image's shape, so don't
+     stretch a short one to match the tallest in its row. */
+  align-items: start;
 `;
 
 const shimmer = keyframes`
@@ -144,7 +147,11 @@ export const SkeletonCard = styled.div`
 
 export const Card = styled.div<{ $selected: boolean }>`
   position: relative;
-  aspect-ratio: 1;
+  /* No fixed aspect-ratio: the image inside sets the height, so the card is
+     the image's true shape. The floor only keeps a card that has no image yet
+     from collapsing to nothing (which would also starve InfiniteScroll of a
+     scrollable height); it sits below every common ratio at this column width. */
+  min-height: 60px;
   border-radius: 10px;
   overflow: hidden;
   cursor: pointer;
@@ -160,11 +167,17 @@ export const Card = styled.div<{ $selected: boolean }>`
   }
 `;
 
-export const CardImg = styled.img`
+export const CardImg = styled.img<{ $ratio?: string }>`
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  /* height follows the intrinsic ratio instead of filling a fixed box, so
+     nothing is cropped. */
+  height: auto;
   display: block;
+  /* When the dream's dimensions are known, reserve the exact box before the
+     bitmap arrives so the grid doesn't reflow on load. Same value the intrinsic
+     ratio resolves to, so the two agree once it does. Sits on the image rather
+     than the card to keep the card's 2px border out of the ratio math. */
+  ${(p) => p.$ratio && `aspect-ratio: ${p.$ratio};`}
 `;
 
 export const CardCheckmark = styled.div`

--- a/src/components/pages/studio/components/select-image-dream-modal.tsx
+++ b/src/components/pages/studio/components/select-image-dream-modal.tsx
@@ -4,6 +4,7 @@ import InfiniteScroll from "react-infinite-scroll-component";
 import { useMyImageDreams } from "@/api/dream/query/useMyImageDreams";
 import { useFlowStore } from "@/stores/flow.store";
 import { useDebounce } from "@/hooks/useDebounce";
+import { mediaAspectRatio } from "../utils/media-aspect-ratio";
 import {
   Overlay,
   Panel,
@@ -155,7 +156,16 @@ export const SelectImageDreamModal: React.FC<Props> = ({ onClose }) => {
                       }
                       title={alreadyAdded ? "Already in strip" : dream.name}
                     >
-                      {imageUrl && <CardImg src={imageUrl} alt={dream.name} />}
+                      {imageUrl && (
+                        <CardImg
+                          src={imageUrl}
+                          alt={dream.name}
+                          $ratio={mediaAspectRatio(
+                            dream.processedMediaWidth,
+                            dream.processedMediaHeight,
+                          )}
+                        />
+                      )}
                       {isSelected && <CardCheckmark>✓</CardCheckmark>}
                       <CardName>{dream.name}</CardName>
                     </Card>

--- a/src/components/pages/studio/utils/media-aspect-ratio.test.ts
+++ b/src/components/pages/studio/utils/media-aspect-ratio.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { mediaAspectRatio } from "./media-aspect-ratio";
+
+describe("mediaAspectRatio", () => {
+  it("builds a CSS aspect-ratio from recorded dimensions", () => {
+    expect(mediaAspectRatio(1392, 752)).toBe("1392 / 752");
+    expect(mediaAspectRatio(720, 1280)).toBe("720 / 1280");
+    expect(mediaAspectRatio(512, 512)).toBe("512 / 512");
+  });
+
+  it("returns undefined when either dimension is missing", () => {
+    expect(mediaAspectRatio(undefined, undefined)).toBeUndefined();
+    expect(mediaAspectRatio(1280, undefined)).toBeUndefined();
+    expect(mediaAspectRatio(undefined, 720)).toBeUndefined();
+    expect(mediaAspectRatio(null, null)).toBeUndefined();
+  });
+
+  it("returns undefined for degenerate dimensions rather than an invalid ratio", () => {
+    expect(mediaAspectRatio(0, 720)).toBeUndefined();
+    expect(mediaAspectRatio(1280, 0)).toBeUndefined();
+    expect(mediaAspectRatio(-1280, 720)).toBeUndefined();
+  });
+});

--- a/src/components/pages/studio/utils/media-aspect-ratio.ts
+++ b/src/components/pages/studio/utils/media-aspect-ratio.ts
@@ -1,0 +1,21 @@
+/**
+ * CSS `aspect-ratio` for a dream's processed media, or undefined when the
+ * backend has no dimensions for it.
+ *
+ * The picker cards take their shape from the image itself, which means the
+ * grid would reflow as each thumbnail loads. `processedMediaWidth`/`Height`
+ * (set by the video service — see video/utils/process_image.py) let us reserve
+ * the correct box up front. They are nullable for older dreams, dreams still
+ * processing, and keyframes, so callers must tolerate undefined: the image's
+ * intrinsic ratio still takes over once it loads.
+ */
+export const mediaAspectRatio = (
+  width?: number | null,
+  height?: number | null,
+): string | undefined =>
+  typeof width === "number" &&
+  typeof height === "number" &&
+  width > 0 &&
+  height > 0
+    ? `${width} / ${height}`
+    : undefined;


### PR DESCRIPTION
Closes #706

## Problem

The issue reports still images showing as **squares** in the studio gallery. That grid is `select-image-dream-modal` ("+ My Images"), which hard-coded `aspect-ratio: 1` with `object-fit: cover` — so every thumbnail was center-cropped to a square regardless of its real shape. `add-from-playlist-modal` ("+ Add from Playlist") had the same bug at `aspect-ratio: 16 / 9`.

## Fix

Cards take their shape from the image instead of forcing the image into a box:

- `Card` / `ImageSelectCard`: drop the fixed `aspect-ratio`; keep a small `min-height` so a card whose image hasn't resolved doesn't collapse to zero (which would also starve `InfiniteScroll` of a scrollable height).
- `CardImg` / `ImageSelectThumbnail`: `height: 100%` + `object-fit: cover` → `height: auto`. Nothing is cropped.
- `Grid` / `ImageSelectGrid`: `align-items: start`, so a short card isn't stretched to its row's tallest neighbour.

**No reflow where we can avoid it.** `processedMediaWidth`/`processedMediaHeight` are set by the video service (`video/utils/process_image.py`) and returned by both `/v1/dream/my-dreams` and `/v1/playlist/:uuid/items`, so the correct box is reserved before the bitmap loads. New `mediaAspectRatio()` helper, unit-tested. It's optional by design — keyframes carry no dimensions and fall back to the intrinsic ratio.

The ratio is applied to the image rather than the card so the card's 2px border stays out of the ratio math.

`add-keyframes-from-playlist-modal` shares these card styles, so it moves to the same local thumbnail instead of `images-tab`'s `ImageThumbnail` — that one fills a fixed box (`height: 100%`) and would measure zero inside an auto-height card.

## Relationship to #712

#712 also targets #706 but changes the **Images tab** grid, which was 16:9 — it never produced the squares the issue describes. This PR fixes the grids that actually render squares. The two touch disjoint files, so they don't conflict, but #706 should be closed by this one.

The Images tab is deliberately left alone here.

## Not covered

"+ From Playlist" in the flow builder renders blank cards, but that is a **different, pre-existing bug**: it lists `Keyframe` entities whose `image` column is `null` (Studio creates keyframes with a name only). Filed separately.

## Testing

- `tsc --noEmit` clean, ESLint clean, 165/165 Vitest pass (3 new).
- Verified against staging through the local dev server; "+ My Images" now renders portrait, square, and landscape thumbnails uncropped at their true shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)