### PR TITLE
fix(studio): "+ From Playlist" browses dreams, not keyframes (#716)

### DIFF
--- a/src/components/pages/studio/components/add-keyframes-from-playlist-modal.tsx
+++ b/src/components/pages/studio/components/add-keyframes-from-playlist-modal.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { axiosClient } from "@/client/axios.client";
-import { ContentType, getRequestHeaders } from "@/constants/auth.constants";
 import { useFlowStore } from "@/stores/flow.store";
 import { useUserPlaylists } from "../hooks/useUserPlaylists";
-import type { PlaylistKeyframe } from "@/types/playlist.types";
+import { mediaAspectRatio } from "../utils/media-aspect-ratio";
 import {
   StyledSelect,
   NavButton,
@@ -27,33 +26,80 @@ interface Props {
   onClose: () => void;
 }
 
+/**
+ * The dream fields this picker needs from /v1/playlist/:uuid/items, which
+ * leftJoinAndSelects the whole dream and signs its media URLs.
+ */
+interface PlaylistDream {
+  uuid: string;
+  name: string;
+  thumbnail?: string | null;
+  video?: string | null;
+  original_video?: string | null;
+  mediaType?: string;
+  processedMediaWidth?: number | null;
+  processedMediaHeight?: number | null;
+}
+
+interface PlaylistItem {
+  dreamItem?: PlaylistDream;
+}
+
+/**
+ * Playlists mix video and still dreams; a flow keyframe is a still, so this
+ * picker shows the same subset "+ My Images" does. Older dreams predate
+ * mediaType and are images.
+ */
+const isImageDream = (dream?: PlaylistDream): dream is PlaylistDream =>
+  !!dream?.thumbnail && (!dream.mediaType || dream.mediaType === "image");
+
 export const AddKeyframesFromPlaylistModal: React.FC<Props> = ({ onClose }) => {
   const addKeyframe = useFlowStore((s) => s.addKeyframe);
   const existingKeyframes = useFlowStore((s) => s.keyframes);
   const { playlists } = useUserPlaylists();
   const [selectedPlaylistId, setSelectedPlaylistId] = useState("");
-  const [playlistKeyframes, setPlaylistKeyframes] = useState<
-    PlaylistKeyframe[]
-  >([]);
+  const [dreams, setDreams] = useState<PlaylistDream[]>([]);
   const [selectedUuids, setSelectedUuids] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
 
+  const existingDreamUuids = useMemo(
+    () =>
+      new Set(
+        existingKeyframes
+          .map((kf) => kf.dreamUuid)
+          .filter((v): v is string => Boolean(v)),
+      ),
+    [existingKeyframes],
+  );
+
   useEffect(() => {
     if (!selectedPlaylistId) {
-      setPlaylistKeyframes([]);
+      setDreams([]);
       return;
     }
+    let ignore = false;
     setLoading(true);
+    setSelectedUuids(new Set());
     axiosClient
-      .get(`/v1/playlist/${selectedPlaylistId}/keyframes`, {
-        headers: getRequestHeaders({ contentType: ContentType.json }),
+      .get(`/v1/playlist/${selectedPlaylistId}/items?take=100&skip=0`)
+      .then(({ data }) => {
+        if (ignore) return;
+        const items: PlaylistItem[] = data?.data?.items ?? [];
+        setDreams(
+          items
+            .map((item) => item.dreamItem)
+            .filter((dream): dream is PlaylistDream => isImageDream(dream)),
+        );
       })
-      .then((res) => {
-        const items: PlaylistKeyframe[] = res.data.data?.keyframes ?? [];
-        setPlaylistKeyframes(items);
+      .catch(() => {
+        if (!ignore) setDreams([]);
       })
-      .catch(() => setPlaylistKeyframes([]))
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!ignore) setLoading(false);
+      });
+    return () => {
+      ignore = true;
+    };
   }, [selectedPlaylistId]);
 
   const toggleSelected = useCallback((uuid: string) => {
@@ -66,32 +112,22 @@ export const AddKeyframesFromPlaylistModal: React.FC<Props> = ({ onClose }) => {
   }, []);
 
   const handleAdd = useCallback(() => {
-    const existingUuids = new Set(
-      existingKeyframes.map((kf) => kf.keyframeUuid),
-    );
-    for (const item of playlistKeyframes) {
-      const kf = item.keyframe;
-      if (!kf) continue;
-      if (selectedUuids.has(kf.uuid) && !existingUuids.has(kf.uuid)) {
-        addKeyframe({
-          id: uuidv4(),
-          keyframeUuid: kf.uuid,
-          imageUrl: kf.image,
-          name: kf.name,
-          dreamUuid: kf.dreams?.[0]?.uuid,
-        });
-      }
+    for (const dream of dreams) {
+      if (!selectedUuids.has(dream.uuid) || existingDreamUuids.has(dream.uuid))
+        continue;
+      addKeyframe({
+        id: uuidv4(),
+        dreamUuid: dream.uuid,
+        // Prefer the full-resolution source over the thumbnail, matching
+        // "+ My Images" — the keyframe feeds generation, not just display.
+        imageUrl: dream.video || dream.original_video || dream.thumbnail || "",
+        name: dream.name,
+      });
     }
     onClose();
-  }, [
-    playlistKeyframes,
-    selectedUuids,
-    existingKeyframes,
-    addKeyframe,
-    onClose,
-  ]);
+  }, [dreams, selectedUuids, existingDreamUuids, addKeyframe, onClose]);
 
-  const validItems = playlistKeyframes.filter((pk) => pk.keyframe);
+  const showEmpty = !loading && selectedPlaylistId && dreams.length === 0;
 
   return (
     <ModalOverlay onClick={onClose}>
@@ -117,20 +153,39 @@ export const AddKeyframesFromPlaylistModal: React.FC<Props> = ({ onClose }) => {
             <p style={{ color: "#999", marginTop: "1rem" }}>Loading...</p>
           )}
 
-          {validItems.length > 0 && (
+          {showEmpty && (
+            <p style={{ color: "#999", marginTop: "1rem" }}>
+              No images in this playlist.
+            </p>
+          )}
+
+          {dreams.length > 0 && (
             <ImageSelectGrid>
-              {validItems.map((item) => (
-                <ImageSelectCard
-                  key={item.keyframe!.uuid}
-                  $selected={selectedUuids.has(item.keyframe!.uuid)}
-                  onClick={() => toggleSelected(item.keyframe!.uuid)}
-                >
-                  <ImageSelectThumbnail
-                    src={item.keyframe!.image}
-                    alt={item.keyframe!.name}
-                  />
-                </ImageSelectCard>
-              ))}
+              {dreams.map((dream) => {
+                const alreadyAdded = existingDreamUuids.has(dream.uuid);
+                return (
+                  <ImageSelectCard
+                    key={dream.uuid}
+                    $selected={selectedUuids.has(dream.uuid)}
+                    onClick={() => !alreadyAdded && toggleSelected(dream.uuid)}
+                    style={
+                      alreadyAdded
+                        ? { opacity: 0.4, cursor: "default" }
+                        : undefined
+                    }
+                    title={alreadyAdded ? "Already in strip" : dream.name}
+                  >
+                    <ImageSelectThumbnail
+                      src={dream.thumbnail ?? undefined}
+                      alt={dream.name}
+                      $ratio={mediaAspectRatio(
+                        dream.processedMediaWidth,
+                        dream.processedMediaHeight,
+                      )}
+                    />
+                  </ImageSelectCard>
+                );
+              })}
             </ImageSelectGrid>
           )}
         </ModalBody>

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -4,12 +4,12 @@ export type StudioMode = "flow" | "batch";
 
 export interface FlowKeyframe {
   id: string; // local UUID for drag/drop identity
-  // Backend Keyframe.uuid — only present when the frame was added from a
-  // playlist (playlist items reference a Keyframe entity). Uploaded frames
-  // are saved as image-type Dreams instead and have no Keyframe row.
+  // Backend Keyframe.uuid — assigned by ensureFlowKeyframe when the flow is
+  // saved to a playlist. Frames are not added as Keyframe entities: those rows
+  // carry no image, so they can't be browsed or displayed (see #716).
   keyframeUuid?: string;
-  // Source image Dream UUID. Set for uploaded frames and for playlist frames
-  // whose Keyframe has an associated image Dream.
+  // Source image Dream UUID. Set for uploaded frames and for frames picked
+  // from the image library or a playlist — every path adds image Dreams.
   dreamUuid?: string;
   imageUrl: string; // presigned URL or local objectURL while uploading
   name: string; // display name


### PR DESCRIPTION
Closes #716

## Problem

The flow builder's **"+ From Playlist"** picker rendered blank cards — no images at all.

It wasn't a broken URL. The modal listed `Keyframe` entities and read `keyframe.image`, which is always `null`. Live staging data, two playlists, two different users:

```json
{"uuid":"833d819a-db68-4f81-a16a-1f8ea32fb9db","name":"kf_FLUX.1 [schnell] 23","image":null,"dreams":[]}
{"uuid":"75954d77-43b1-40ac-8c36-ab246062b887","name":"kf_FLUX.1 [schnell] 7 → …","image":null,"dreams":[]}
```

The `null` originates at creation: `ensureFlowKeyframe` posts only a name, `createKeyframeSchema` accepts nothing else, and attaching an image requires a separate multipart upload (`/:uuid/image/init` → `/complete`) that Studio never performs. So `<img src={null}>` never issues a request and just draws an empty box.

Not a signing issue — `keyframe.image` and `dream.thumbnail` share the same `signKey()`. In the same responses, `playlist.thumbnail` and `user.avatar` come back as valid signed URLs.

## Fix

The picker shouldn't have been using keyframes at all. It now browses **dreams from the selected playlist** — a per-playlist subset of "+ My Images".

- Fetches `/v1/playlist/:uuid/items` instead of `/keyframes`. That endpoint `leftJoinAndSelect`s the whole dream, so thumbnails arrive populated and signed — no extra presign request per card.
- Filters to image dreams, the same subset "+ My Images" shows. Dreams predating `mediaType` are treated as images.
- Adds frames by `dreamUuid` with a real `imageUrl`, preferring the full-resolution source over the thumbnail since keyframes feed generation, not just display.
- Dedupes against the strip by `dreamUuid`; already-added cards are dimmed and inert, matching the library picker.
- Reserves each card's aspect ratio from `processedMediaWidth`/`Height`, so the grid doesn't reflow as thumbnails load.
- Resets selection when the playlist changes and ignores in-flight responses for a superseded playlist.

Keyframe rows are still created by `ensureFlowKeyframe` when a flow is saved — they just stop being the browse and display source. `FlowKeyframe`'s doc comments described the old behaviour and are updated to match.

## Also affected, not fixed here

`ItemCard`'s `getThumbnail` returns `keyframe.image` (`item-card.tsx:147`), so the playlist page's **Keyframes tab** is blank for these same keyframes. Whether that surface should keep showing keyframes at all is a separate question.

## Testing

- `tsc --noEmit` clean, ESLint clean, 165/165 Vitest pass.
- Endpoint behaviour verified against staging: `/v1/playlist/:uuid/items` returns signed `dreamItem.thumbnail` plus `processedMediaWidth`/`Height`.
- Manually verified in the browser against staging.
- Note for reviewers: a *Studio Flow* playlist correctly shows "No images in this playlist" — those hold the generated videos, not the source stills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
