### PR TITLE
feat(studio): multi-select transitions, group editing, take history

### DIFF
--- a/src/components/pages/studio/components/crossfade-video.tsx
+++ b/src/components/pages/studio/components/crossfade-video.tsx
@@ -30,6 +30,12 @@ interface Props {
   loop?: boolean;
   onEnded?: () => void;
   /**
+   * Bump to replay the segment already on screen from the start. Needed
+   * because re-selecting the current segment changes no prop the player would
+   * otherwise notice, so there is nothing to react to.
+   */
+  replayToken?: number;
+  /**
    * Reports a segment's true shape once the browser has read the file header,
    * correcting the `ratio` hint. Covers dreams whose dimensions were never
    * recorded, and any case where the file played is not the one those
@@ -57,6 +63,7 @@ export function CrossfadeVideo({
   loop = false,
   onEnded,
   onMeasured,
+  replayToken,
 }: Props) {
   const targetKey = segments[index]?.key ?? null;
 
@@ -101,6 +108,21 @@ export function CrossfadeVideo({
     if (front.paused && front.currentTime > 0.05) front.currentTime = 0;
     front.play().catch(() => undefined);
   }, [buf.front, active, layerRefs]);
+
+  // Replay only when the requested segment is the one already up front. If the
+  // token arrived alongside an index change, the segment is still loading into
+  // the back layer and the effect above plays it from the start anyway.
+  useEffect(() => {
+    if (!replayToken || !active) return;
+    if (buf.loaded[buf.front] !== targetKey) return;
+    const front = layerRefs[buf.front].current;
+    if (!front) return;
+    front.currentTime = 0;
+    front.play().catch(() => undefined);
+    // Deliberately keyed on the token alone: this fires on request, not on
+    // every buffer change that happens to leave the same segment up front.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [replayToken]);
 
   return (
     <LayerStack>

--- a/src/components/pages/studio/components/flow-builder.tsx
+++ b/src/components/pages/studio/components/flow-builder.tsx
@@ -51,7 +51,7 @@ export const FlowBuilder: React.FC = () => {
   useGeneratedFrameSync();
 
   // Generation controls
-  const { generateAll, generateOne, isGenerating } = useFlowGeneration();
+  const { generateAll, generateMany, isGenerating } = useFlowGeneration();
   const uploadDream = useUploadImageDream();
 
   const [showPlaylistModal, setShowPlaylistModal] = useState(false);
@@ -153,12 +153,11 @@ export const FlowBuilder: React.FC = () => {
         onAddGenerate={() => setShowGenerateModal(true)}
         onAddFromPlaylist={handleAddFromPlaylist}
         onAddFromLibrary={handleAddFromLibrary}
-        onRetry={generateOne}
       />
 
       <TransitionSettingsPanel
         onGenerateAll={generateAll}
-        onGenerateOne={generateOne}
+        onGenerateSelected={generateMany}
         isGenerating={isGenerating}
       />
 

--- a/src/components/pages/studio/components/flow-preview.tsx
+++ b/src/components/pages/studio/components/flow-preview.tsx
@@ -34,6 +34,7 @@ interface PreviewLightboxProps {
   onMeasured: (key: string, ratio: string) => void;
   onClose: () => void;
   onEnded: () => void;
+  replayToken?: number;
 }
 
 function PreviewLightbox({
@@ -44,6 +45,7 @@ function PreviewLightbox({
   onMeasured,
   onClose,
   onEnded,
+  replayToken,
 }: PreviewLightboxProps) {
   const overlayRef = useLightboxA11y<HTMLDivElement>(onClose);
 
@@ -64,6 +66,7 @@ function PreviewLightbox({
           loop={loop}
           onMeasured={onMeasured}
           onEnded={onEnded}
+          replayToken={replayToken}
         />
       </LightboxVideo>
     </LightboxOverlay>,
@@ -85,6 +88,15 @@ export function FlowPreview() {
       frameLightboxOpen: s.frameLightboxId !== null,
     })),
   );
+
+  // The dream of the last-clicked transition. Selecting a transition should
+  // play it, so the preview follows this rather than only advancing on its own.
+  const primaryDreamUuid = useFlowStore((s) => {
+    const selected = s.selectedTransitionIndices;
+    if (selected.length === 0) return undefined;
+    return s.transitions[selected[selected.length - 1]]?.dreamUuid;
+  });
+  const playRequest = useFlowStore((s) => s.previewPlayRequest);
 
   const completedUuids = useMemo(
     () =>
@@ -157,6 +169,29 @@ export function FlowPreview() {
     if (segmentCount > 1) goTo(targetIndex + 1);
   }, [goTo, targetIndex, segmentCount]);
 
+  // Depend on the joined keys, not the array: `segments` is rebuilt every
+  // render, so an array dep would re-run this effect forever.
+  const segmentKeys = segments.map((segment) => segment.key).join(",");
+
+  useEffect(() => {
+    if (!primaryDreamUuid) return;
+    const next = segmentKeys.split(",").indexOf(primaryDreamUuid);
+    // A selected transition that hasn't rendered yet has no segment to show —
+    // leave whatever is playing alone rather than jumping to an unrelated clip.
+    if (next >= 0) setTargetIndex(next);
+  }, [primaryDreamUuid, segmentKeys]);
+
+  // An explicit play request seeks to the segment and, via replayToken,
+  // restarts it even when it is already the one on screen.
+  const [replayToken, setReplayToken] = useState(0);
+  useEffect(() => {
+    if (!playRequest) return;
+    const next = segmentKeys.split(",").indexOf(playRequest.dreamUuid);
+    if (next < 0) return;
+    setTargetIndex(next);
+    setReplayToken(playRequest.seq);
+  }, [playRequest, segmentKeys]);
+
   useEffect(() => {
     if (segmentCount < 2) return;
     if (frameLightboxOpen) return;
@@ -198,6 +233,7 @@ export function FlowPreview() {
             muted
             loop={segmentCount === 1}
             onEnded={advance}
+            replayToken={replayToken}
           />
 
           {showNav && (
@@ -258,6 +294,7 @@ export function FlowPreview() {
           onMeasured={handleMeasured}
           onClose={() => setPreviewLightboxOpen(false)}
           onEnded={advance}
+          replayToken={replayToken}
         />
       )}
     </>

--- a/src/components/pages/studio/components/force-settings-dialog.styled.tsx
+++ b/src/components/pages/studio/components/force-settings-dialog.styled.tsx
@@ -1,0 +1,82 @@
+import styled from "styled-components";
+import { FLOW, flowFadeIn } from "@/constants/flow-theme.constants";
+
+export const DialogOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: ${flowFadeIn} 0.15s ease both;
+`;
+
+export const DialogCard = styled.div`
+  width: min(420px, 100%);
+  background: ${FLOW.bgCard};
+  border: 1px solid ${FLOW.border};
+  border-radius: ${FLOW.radius};
+  padding: 22px;
+  font-family: ${FLOW.fontFamily};
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55);
+`;
+
+export const DialogTitle = styled.h2`
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 700;
+  color: ${FLOW.text};
+`;
+
+export const DialogBody = styled.p`
+  margin: 0 0 18px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: ${FLOW.textDim};
+`;
+
+export const DialogActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+const DialogButtonBase = styled.button`
+  padding: 8px 16px;
+  border-radius: ${FLOW.radiusSm};
+  font-family: ${FLOW.fontFamily};
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease;
+
+  &:focus-visible {
+    outline: 2px solid ${FLOW.selected};
+    outline-offset: 2px;
+  }
+`;
+
+export const CancelButton = styled(DialogButtonBase)`
+  background: transparent;
+  border: 1px solid ${FLOW.border};
+  color: ${FLOW.textDim};
+
+  &:hover {
+    border-color: ${FLOW.borderHover};
+    color: ${FLOW.text};
+  }
+`;
+
+export const ConfirmButton = styled(DialogButtonBase)`
+  background: ${FLOW.accent};
+  border: 1px solid ${FLOW.accent};
+  color: ${FLOW.bg};
+
+  &:hover {
+    background: #e0b768;
+  }
+`;

--- a/src/components/pages/studio/components/force-settings-dialog.styled.tsx
+++ b/src/components/pages/studio/components/force-settings-dialog.styled.tsx
@@ -60,7 +60,12 @@ const DialogButtonBase = styled.button`
   }
 `;
 
-export const CancelButton = styled(DialogButtonBase)`
+/**
+ * Both buttons wear the same neutral treatment. Confirming forces settings onto
+ * transitions that disagree, so nothing here should read as the obvious answer
+ * — the only emphasis in the dialog is the focus ring, and it starts on Cancel.
+ */
+const DialogButton = styled(DialogButtonBase)`
   background: transparent;
   border: 1px solid ${FLOW.border};
   color: ${FLOW.textDim};
@@ -71,12 +76,5 @@ export const CancelButton = styled(DialogButtonBase)`
   }
 `;
 
-export const ConfirmButton = styled(DialogButtonBase)`
-  background: ${FLOW.accent};
-  border: 1px solid ${FLOW.accent};
-  color: ${FLOW.bg};
-
-  &:hover {
-    background: #e0b768;
-  }
-`;
+export const CancelButton = DialogButton;
+export const ConfirmButton = DialogButton;

--- a/src/components/pages/studio/components/force-settings-dialog.tsx
+++ b/src/components/pages/studio/components/force-settings-dialog.tsx
@@ -11,22 +11,17 @@ import {
 } from "./force-settings-dialog.styled";
 
 interface ForceSettingsDialogProps {
-  /** Human-readable name of the field being edited, e.g. "Prompt". */
-  fieldLabel: string;
-  /** How many transitions the edit would be forced onto. */
-  count: number;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 /**
- * Shown when an edit would overwrite a setting the selected transitions
- * currently disagree about. Editing them as a group means picking one value,
- * so the choice is made explicit rather than silently flattening the others.
+ * Shown when transitions that disagree about a setting are about to be edited
+ * as one group. A group with mixed settings has no honest thing to show in the
+ * panel, so the disagreement is resolved up front: OK forces one value on all
+ * of them, Cancel leaves them apart.
  */
 export function ForceSettingsDialog({
-  fieldLabel,
-  count,
   onConfirm,
   onCancel,
 }: ForceSettingsDialogProps) {
@@ -37,6 +32,16 @@ export function ForceSettingsDialog({
       ref={overlayRef}
       tabIndex={-1}
       onClick={onCancel}
+      // Return cancels: forcing settings is the destructive answer, so it is
+      // never what a blind keypress does. Cancel holds focus from the moment
+      // the dialog opens (it is the first focusable thing in it), so a keypress
+      // that reaches a button is that button's to handle — this is only for the
+      // ones that land on the dialog itself.
+      onKeyDown={(e) => {
+        if (e.key !== "Enter" || e.target instanceof HTMLButtonElement) return;
+        e.preventDefault();
+        onCancel();
+      }}
       role="dialog"
       aria-modal="true"
       aria-labelledby="force-settings-title"
@@ -44,11 +49,11 @@ export function ForceSettingsDialog({
     >
       <DialogCard onClick={(e) => e.stopPropagation()}>
         <DialogTitle id="force-settings-title">
-          Can&rsquo;t edit mismatched settings
+          Transitions have different settings
         </DialogTitle>
         <DialogBody id="force-settings-body">
-          The {count} selected transitions don&rsquo;t share the same{" "}
-          <strong>{fieldLabel}</strong>. Force them all to the same value?
+          Editing them together forces one value on all of them &mdash; the
+          settings shown now. Cancel leaves them as they are.
         </DialogBody>
         <DialogActions>
           <CancelButton type="button" onClick={onCancel}>

--- a/src/components/pages/studio/components/force-settings-dialog.tsx
+++ b/src/components/pages/studio/components/force-settings-dialog.tsx
@@ -1,0 +1,65 @@
+import { createPortal } from "react-dom";
+import { useLightboxA11y } from "../hooks/useLightboxA11y";
+import {
+  DialogOverlay,
+  DialogCard,
+  DialogTitle,
+  DialogBody,
+  DialogActions,
+  CancelButton,
+  ConfirmButton,
+} from "./force-settings-dialog.styled";
+
+interface ForceSettingsDialogProps {
+  /** Human-readable name of the field being edited, e.g. "Prompt". */
+  fieldLabel: string;
+  /** How many transitions the edit would be forced onto. */
+  count: number;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Shown when an edit would overwrite a setting the selected transitions
+ * currently disagree about. Editing them as a group means picking one value,
+ * so the choice is made explicit rather than silently flattening the others.
+ */
+export function ForceSettingsDialog({
+  fieldLabel,
+  count,
+  onConfirm,
+  onCancel,
+}: ForceSettingsDialogProps) {
+  const overlayRef = useLightboxA11y<HTMLDivElement>(onCancel);
+
+  return createPortal(
+    <DialogOverlay
+      ref={overlayRef}
+      tabIndex={-1}
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="force-settings-title"
+      aria-describedby="force-settings-body"
+    >
+      <DialogCard onClick={(e) => e.stopPropagation()}>
+        <DialogTitle id="force-settings-title">
+          Can&rsquo;t edit mismatched settings
+        </DialogTitle>
+        <DialogBody id="force-settings-body">
+          The {count} selected transitions don&rsquo;t share the same{" "}
+          <strong>{fieldLabel}</strong>. Force them all to the same value?
+        </DialogBody>
+        <DialogActions>
+          <CancelButton type="button" onClick={onCancel}>
+            Cancel
+          </CancelButton>
+          <ConfirmButton type="button" onClick={onConfirm}>
+            OK
+          </ConfirmButton>
+        </DialogActions>
+      </DialogCard>
+    </DialogOverlay>,
+    document.body,
+  );
+}

--- a/src/components/pages/studio/components/reference-frame-strip.styled.tsx
+++ b/src/components/pages/studio/components/reference-frame-strip.styled.tsx
@@ -12,6 +12,46 @@ export const SectionHeader = styled.div`
   margin-bottom: 20px;
 `;
 
+export const SectionActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const SelectionCount = styled.span`
+  font-family: ${FLOW.fontFamily};
+  font-size: 12px;
+  font-weight: 600;
+  color: ${FLOW.selected};
+  white-space: nowrap;
+`;
+
+export const SelectionButton = styled.button`
+  background: none;
+  border: 1px solid ${FLOW.border};
+  border-radius: ${FLOW.radiusSm};
+  color: ${FLOW.textDim};
+  cursor: pointer;
+  font-family: ${FLOW.fontFamily};
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  white-space: nowrap;
+  transition:
+    color 0.18s ease,
+    border-color 0.18s ease;
+
+  &:hover:not(:disabled) {
+    color: ${FLOW.text};
+    border-color: ${FLOW.selected};
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+`;
+
 export const SectionLabel = styled.div`
   font-size: 11px;
   font-weight: 600;

--- a/src/components/pages/studio/components/reference-frame-strip.styled.tsx
+++ b/src/components/pages/studio/components/reference-frame-strip.styled.tsx
@@ -26,6 +26,19 @@ export const SelectionCount = styled.span`
   white-space: nowrap;
 `;
 
+/**
+ * How many rendered transitions have been edited since. Kept beside the
+ * selection count so work waiting outside the current scope stays visible —
+ * with a selection active, Generate runs the selection, not these.
+ */
+export const StaleCount = styled.span`
+  font-family: ${FLOW.fontFamily};
+  font-size: 12px;
+  font-weight: 600;
+  color: ${FLOW.accent};
+  white-space: nowrap;
+`;
+
 export const SelectionButton = styled.button`
   background: none;
   border: 1px solid ${FLOW.border};

--- a/src/components/pages/studio/components/reference-frame-strip.tsx
+++ b/src/components/pages/studio/components/reference-frame-strip.tsx
@@ -23,6 +23,9 @@ import {
   StripSection,
   SectionHeader,
   SectionLabel,
+  SectionActions,
+  SelectionButton,
+  SelectionCount,
   StripContainer,
   TransitionGap,
   GapLine,
@@ -40,7 +43,6 @@ interface Props {
   onAddGenerate: () => void;
   onAddFromPlaylist: () => void;
   onAddFromLibrary: () => void;
-  onRetry: (index: number) => void;
 }
 
 export const ReferenceFrameStrip: React.FC<Props> = ({
@@ -48,19 +50,26 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
   onAddGenerate,
   onAddFromPlaylist,
   onAddFromLibrary,
-  onRetry,
 }) => {
   // Actions (stable refs)
   const removeReferenceFrame = useFlowStore((s) => s.removeReferenceFrame);
   const reorderReferenceFrames = useFlowStore((s) => s.reorderReferenceFrames);
   const setLoop = useFlowStore((s) => s.setLoop);
   const selectTransition = useFlowStore((s) => s.selectTransition);
+  const toggleTransitionSelection = useFlowStore(
+    (s) => s.toggleTransitionSelection,
+  );
+  const selectAllTransitions = useFlowStore((s) => s.selectAllTransitions);
+  const clearTransitionSelection = useFlowStore(
+    (s) => s.clearTransitionSelection,
+  );
 
   // Data
   const rawFrames = useFlowStore((s) => s.referenceFrames);
   const loop = useFlowStore((s) => s.loop);
   const transitions = useFlowStore((s) => s.transitions);
   const globalDuration = useFlowStore((s) => s.globalDuration);
+  const selectedIndices = useFlowStore((s) => s.selectedTransitionIndices);
 
   const displayFrames = useMemo(
     () => buildFramesWithLoop(rawFrames, loop),
@@ -107,11 +116,22 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
             transition={transition}
             effectiveDuration={effectiveDuration}
             mismatch={describeMismatch(displayFrames[i - 1], frame)}
-            onClick={() => {
-              if (transition.status === "failed") {
-                onRetry(transitionIndex);
-              } else {
-                selectTransition(transitionIndex);
+            selected={selectedIndices.includes(transitionIndex)}
+            onClick={({ toggle }) => {
+              if (toggle) toggleTransitionSelection(transitionIndex);
+              else selectTransition(transitionIndex);
+              // Clicking a transition plays it, every time — including when it
+              // was already the selected one, where nothing about the
+              // selection changes and there is no state transition to react
+              // to. A shift-click that removed it is the one exception:
+              // playing what you just deselected is not what was asked for.
+              const store = useFlowStore.getState();
+              if (!store.selectedTransitionIndices.includes(transitionIndex)) {
+                return;
+              }
+              const clicked = store.transitions[transitionIndex];
+              if (clicked?.status === "processed" && clicked.dreamUuid) {
+                store.requestPreviewPlay(clicked.dreamUuid);
               }
             }}
           />,
@@ -139,7 +159,30 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
     <StripSection>
       <SectionHeader>
         <SectionLabel>Reference Frames</SectionLabel>
-        <FlowReset />
+        <SectionActions>
+          {selectedIndices.length > 1 && (
+            <SelectionCount>{selectedIndices.length} selected</SelectionCount>
+          )}
+          {transitions.length > 0 && (
+            <>
+              <SelectionButton
+                type="button"
+                disabled={selectedIndices.length === transitions.length}
+                onClick={() => selectAllTransitions()}
+              >
+                Select all
+              </SelectionButton>
+              <SelectionButton
+                type="button"
+                disabled={selectedIndices.length === 0}
+                onClick={() => clearTransitionSelection()}
+              >
+                Clear all
+              </SelectionButton>
+            </>
+          )}
+          <FlowReset />
+        </SectionActions>
       </SectionHeader>
 
       {displayFrames.length === 0 ? (

--- a/src/components/pages/studio/components/reference-frame-strip.tsx
+++ b/src/components/pages/studio/components/reference-frame-strip.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -13,12 +13,21 @@ import {
   horizontalListSortingStrategy,
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
+import { useShallow } from "zustand/react/shallow";
 import { useFlowStore, buildFramesWithLoop } from "@/stores/flow.store";
 import { ReferenceFrameCard } from "./reference-frame-card";
 import { ReferenceFrameLightbox } from "./reference-frame-lightbox";
 import { TransitionGapEnhanced } from "./transition-gap";
 import { describeMismatch } from "../utils/frame-aspect";
 import { FlowReset } from "./flow-reset";
+import { ForceSettingsDialog } from "./force-settings-dialog";
+import {
+  forcedFieldPatch,
+  mismatchedFields,
+  type TransitionField,
+  type TransitionGlobals,
+} from "../utils/transition-field-values";
+import { isTransitionStale } from "../utils/transition-staleness";
 import {
   StripSection,
   SectionHeader,
@@ -26,6 +35,7 @@ import {
   SectionActions,
   SelectionButton,
   SelectionCount,
+  StaleCount,
   StripContainer,
   TransitionGap,
   GapLine,
@@ -68,12 +78,99 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
   const rawFrames = useFlowStore((s) => s.referenceFrames);
   const loop = useFlowStore((s) => s.loop);
   const transitions = useFlowStore((s) => s.transitions);
-  const globalDuration = useFlowStore((s) => s.globalDuration);
   const selectedIndices = useFlowStore((s) => s.selectedTransitionIndices);
+  // Every global, because a transition without an override renders from them:
+  // editing a global moves what the next run would produce, which is exactly
+  // what the stale marker is about.
+  const globals = useFlowStore(
+    useShallow(
+      (s): TransitionGlobals => ({
+        globalPresetId: s.globalPresetId,
+        globalPrompt: s.globalPrompt,
+        globalNegativePrompt: s.globalNegativePrompt,
+        globalDuration: s.globalDuration,
+        globalModel: s.globalModel,
+        globalNumInferenceSteps: s.globalNumInferenceSteps,
+        globalGuidance: s.globalGuidance,
+        globalSeed: s.globalSeed,
+        globalLora: s.globalLora,
+      }),
+    ),
+  );
+  const globalDuration = globals.globalDuration;
+
+  const staleFlags = useMemo(
+    () =>
+      transitions.map((transition) => isTransitionStale(transition, globals)),
+    [transitions, globals],
+  );
+  const staleCount = staleFlags.filter(Boolean).length;
 
   const displayFrames = useMemo(
     () => buildFramesWithLoop(rawFrames, loop),
     [rawFrames, loop],
+  );
+
+  /** A selection held back until the user confirms unifying its settings. */
+  const [pendingSelection, setPendingSelection] = useState<{
+    confirm: () => void;
+  } | null>(null);
+
+  const playTransition = useCallback((index: number) => {
+    const store = useFlowStore.getState();
+    const transition = store.transitions[index];
+    if (transition?.status === "processed" && transition.dreamUuid) {
+      store.requestPreviewPlay(transition.dreamUuid);
+    }
+  }, []);
+
+  /**
+   * Select `next`, but only once those transitions agree about every setting:
+   * the panel edits a selection as one thing, and there is no honest way to
+   * show two values in one field. Anything they disagree about is settled here,
+   * before the selection exists — confirm and the source's settings are forced
+   * onto all of them, cancel and the selection is left alone.
+   *
+   * `source` is the primary of the selection being extended, so the values the
+   * panel is already showing are the ones that win.
+   */
+  const selectWhenAligned = useCallback(
+    (next: readonly number[], source: number, apply: () => void) => {
+      const state = useFlowStore.getState();
+      const globals: TransitionGlobals = {
+        globalPresetId: state.globalPresetId,
+        globalPrompt: state.globalPrompt,
+        globalNegativePrompt: state.globalNegativePrompt,
+        globalDuration: state.globalDuration,
+        globalModel: state.globalModel,
+        globalNumInferenceSteps: state.globalNumInferenceSteps,
+        globalGuidance: state.globalGuidance,
+        globalSeed: state.globalSeed,
+        globalLora: state.globalLora,
+      };
+      const selected = next
+        .map((index) => state.transitions[index])
+        .filter((transition): transition is NonNullable<typeof transition> =>
+          Boolean(transition),
+        );
+      const clashes: TransitionField[] = mismatchedFields(selected, globals);
+      if (clashes.length === 0) {
+        apply();
+        return;
+      }
+      setPendingSelection({
+        confirm: () => {
+          const store = useFlowStore.getState();
+          const from = store.transitions[source];
+          if (from) {
+            const patch = forcedFieldPatch(from, globals, clashes);
+            for (const index of next) store.setTransitionOverride(index, patch);
+          }
+          apply();
+        },
+      });
+    },
+    [],
   );
 
   const sensors = useSensors(
@@ -117,22 +214,33 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
             effectiveDuration={effectiveDuration}
             mismatch={describeMismatch(displayFrames[i - 1], frame)}
             selected={selectedIndices.includes(transitionIndex)}
+            stale={staleFlags[transitionIndex]}
             onClick={({ toggle }) => {
-              if (toggle) toggleTransitionSelection(transitionIndex);
-              else selectTransition(transitionIndex);
               // Clicking a transition plays it, every time — including when it
               // was already the selected one, where nothing about the
               // selection changes and there is no state transition to react
               // to. A shift-click that removed it is the one exception:
               // playing what you just deselected is not what was asked for.
-              const store = useFlowStore.getState();
-              if (!store.selectedTransitionIndices.includes(transitionIndex)) {
+              const current = useFlowStore.getState().selectedTransitionIndices;
+              if (!toggle) {
+                selectTransition(transitionIndex);
+                playTransition(transitionIndex);
                 return;
               }
-              const clicked = store.transitions[transitionIndex];
-              if (clicked?.status === "processed" && clicked.dreamUuid) {
-                store.requestPreviewPlay(clicked.dreamUuid);
+              if (current.includes(transitionIndex)) {
+                toggleTransitionSelection(transitionIndex);
+                return;
               }
+              selectWhenAligned(
+                [...current, transitionIndex],
+                current.length > 0
+                  ? current[current.length - 1]
+                  : transitionIndex,
+                () => {
+                  toggleTransitionSelection(transitionIndex);
+                  playTransition(transitionIndex);
+                },
+              );
             }}
           />,
         );
@@ -163,12 +271,27 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
           {selectedIndices.length > 1 && (
             <SelectionCount>{selectedIndices.length} selected</SelectionCount>
           )}
+          {staleCount > 0 && (
+            <StaleCount title="Rendered, then edited. Generate with nothing selected to bring them up to date.">
+              {staleCount} edited
+            </StaleCount>
+          )}
           {transitions.length > 0 && (
             <>
               <SelectionButton
                 type="button"
                 disabled={selectedIndices.length === transitions.length}
-                onClick={() => selectAllTransitions()}
+                onClick={() => {
+                  const current =
+                    useFlowStore.getState().selectedTransitionIndices;
+                  selectWhenAligned(
+                    transitions.map((_, i) => i),
+                    // Nothing selected yet, so nothing on screen to preserve:
+                    // the first transition sets the value the rest take.
+                    current.length > 0 ? current[current.length - 1] : 0,
+                    selectAllTransitions,
+                  );
+                }}
               >
                 Select all
               </SelectionButton>
@@ -207,6 +330,16 @@ export const ReferenceFrameStrip: React.FC<Props> = ({
             <StripContainer>{stripItems}</StripContainer>
           </SortableContext>
         </DndContext>
+      )}
+
+      {pendingSelection && (
+        <ForceSettingsDialog
+          onConfirm={() => {
+            pendingSelection.confirm();
+            setPendingSelection(null);
+          }}
+          onCancel={() => setPendingSelection(null)}
+        />
       )}
 
       <StripControls>

--- a/src/components/pages/studio/components/transition-gap.styled.tsx
+++ b/src/components/pages/studio/components/transition-gap.styled.tsx
@@ -29,16 +29,47 @@ const breathGlow = keyframes`
   50%      { box-shadow: 0 0 0 6px transparent; }
 `;
 
-export const GapContainer = styled.div<{ $expanded: boolean }>`
+export const GapContainer = styled.div<{
+  $expanded: boolean;
+  $selected?: boolean;
+}>`
   flex-shrink: 0;
   width: ${(p) => (p.$expanded ? "84px" : "64px")};
+  align-self: stretch;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 14px;
   cursor: pointer;
-  transition: width 0.3s ease;
+  user-select: none;
+  border-radius: ${FLOW.radiusSm};
+  transition:
+    width 0.3s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${FLOW.selected};
+    outline-offset: 2px;
+  }
+
+  /* Selection reads as a filled blue slab so a run of selected transitions is
+     legible at a glance, independent of each one's status colour. */
+  ${(p) =>
+    p.$selected &&
+    css`
+      background: ${FLOW.selectedDim};
+      box-shadow: inset 0 0 0 1.5px ${FLOW.selected};
+
+      &:hover {
+        background: ${FLOW.selectedDim};
+      }
+    `}
 `;
 
 export type GapLineVariant = "idle" | "configured" | "failed" | "mismatched";

--- a/src/components/pages/studio/components/transition-gap.styled.tsx
+++ b/src/components/pages/studio/components/transition-gap.styled.tsx
@@ -196,10 +196,15 @@ export const GapStatusLabel = styled.span<{ $status: string }>`
   gap: 3px;
 `;
 
-export const DurationLabel = styled.span`
-  font-size: 11px;
-  font-family: ${FLOW.fontFamily};
-  font-weight: 600;
-  color: ${FLOW.accent};
-  letter-spacing: 0.04em;
+/**
+ * Marks a rendered transition whose settings have been edited since — the video
+ * on screen is not what these settings would produce. Sits where the duration
+ * used to, so a gap keeps its height whether or not it is marked.
+ */
+export const StaleDot = styled.span`
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: ${FLOW.accent};
+  box-shadow: 0 0 0 3px ${FLOW.accentGlow};
 `;

--- a/src/components/pages/studio/components/transition-gap.tsx
+++ b/src/components/pages/studio/components/transition-gap.tsx
@@ -7,7 +7,7 @@ import {
   StatusNode,
   ProgressRing,
   GapStatusLabel,
-  DurationLabel,
+  StaleDot,
 } from "./transition-gap.styled";
 
 /** Click selects; shift-click (or ctrl/cmd-click) toggles this one in or out. */
@@ -20,6 +20,8 @@ interface TransitionGapProps {
   effectiveDuration: number;
   mismatch?: string;
   selected: boolean;
+  /** Rendered, then edited: the video on screen is behind the settings. */
+  stale?: boolean;
   onClick: (modifiers: TransitionClickModifiers) => void;
 }
 
@@ -41,12 +43,16 @@ export function TransitionGapEnhanced({
   effectiveDuration,
   mismatch,
   selected,
+  stale = false,
   onClick,
 }: TransitionGapProps) {
   const { status, progress } = transition;
   const configured = hasOverrides(transition);
 
   const selectedSuffix = selected ? " Selected." : "";
+  // Spelled out for anyone not seeing the dot: the marker is the only thing
+  // separating a rendered transition from a rendered-then-edited one.
+  const staleSuffix = stale ? " Edited since it was rendered." : "";
 
   const activate = {
     role: "button" as const,
@@ -98,7 +104,8 @@ export function TransitionGapEnhanced({
     );
   }
 
-  // Idle but configured — solid line + duration pill.
+  // Idle but configured — solid line, no marker: nothing has been rendered
+  // here, so there is no gap between what is on screen and these settings.
   if (status === "idle" && configured) {
     return (
       <GapContainer
@@ -107,7 +114,6 @@ export function TransitionGapEnhanced({
         aria-label={`Transition with custom settings, ${effectiveDuration} seconds. Activate to select it.${selectedSuffix}`}
       >
         <GapLine $variant="configured" />
-        <DurationLabel>{effectiveDuration}s</DurationLabel>
       </GapContainer>
     );
   }
@@ -148,18 +154,24 @@ export function TransitionGapEnhanced({
     );
   }
 
-  // Success — filled gold disc with a check, soft halo, duration below.
+  // Success — filled gold disc with a check and a soft halo, and a dot below it
+  // when the settings have moved on since this render.
   if (status === "processed") {
     return (
       <GapContainer
         $expanded
         {...activate}
-        aria-label={`Transition rendered, ${effectiveDuration} seconds. Activate to select it.${selectedSuffix}`}
+        title={
+          stale
+            ? "Edited since it was rendered — generate to bring the video up to date"
+            : undefined
+        }
+        aria-label={`Transition rendered, ${effectiveDuration} seconds.${staleSuffix} Activate to select it.${selectedSuffix}`}
       >
         <StatusNode $variant="processed">
           <Check size={14} strokeWidth={3} />
         </StatusNode>
-        <DurationLabel>{effectiveDuration}s</DurationLabel>
+        {stale && <StaleDot aria-hidden="true" />}
       </GapContainer>
     );
   }

--- a/src/components/pages/studio/components/transition-gap.tsx
+++ b/src/components/pages/studio/components/transition-gap.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
 import { Check, Loader2, AlertTriangle, RotateCcw } from "lucide-react";
 import type { FlowTransition } from "@/types/flow.types";
 import {
@@ -10,11 +10,17 @@ import {
   DurationLabel,
 } from "./transition-gap.styled";
 
+/** Click selects; shift-click (or ctrl/cmd-click) toggles this one in or out. */
+export interface TransitionClickModifiers {
+  toggle: boolean;
+}
+
 interface TransitionGapProps {
   transition: FlowTransition;
   effectiveDuration: number;
   mismatch?: string;
-  onClick: () => void;
+  selected: boolean;
+  onClick: (modifiers: TransitionClickModifiers) => void;
 }
 
 function hasOverrides(t: FlowTransition): boolean {
@@ -34,19 +40,34 @@ export function TransitionGapEnhanced({
   transition,
   effectiveDuration,
   mismatch,
+  selected,
   onClick,
 }: TransitionGapProps) {
   const { status, progress } = transition;
   const configured = hasOverrides(transition);
 
+  const selectedSuffix = selected ? " Selected." : "";
+
   const activate = {
     role: "button" as const,
     tabIndex: 0,
-    onClick,
+    $selected: selected,
+    "aria-pressed": selected,
+    // Swallow the mousedown default for every click, which does two jobs.
+    // It stops a shift-click extending the browser's text selection from
+    // wherever the last click landed, which painted a range highlight across
+    // the reference frame between two gaps. And it keeps mouse clicks from
+    // focusing the gap at all: a focused gap starts matching :focus-visible
+    // the moment Chrome sees any key, so merely *pressing shift* — before any
+    // click — lit up a second blue ring on top of the selection. Keyboard
+    // users still Tab here and still get the ring, which is the case it is for.
+    onMouseDown: (e: MouseEvent<HTMLDivElement>) => e.preventDefault(),
+    onClick: (e: MouseEvent<HTMLDivElement>) =>
+      onClick({ toggle: e.shiftKey || e.metaKey || e.ctrlKey }),
     onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
       if (e.key !== "Enter" && e.key !== " ") return;
       e.preventDefault();
-      onClick();
+      onClick({ toggle: e.shiftKey || e.metaKey || e.ctrlKey });
     },
   };
 
@@ -55,8 +76,8 @@ export function TransitionGapEnhanced({
       <GapContainer
         $expanded
         {...activate}
-        title={`Aspect ratio mismatch: ${mismatch}. Generate All will skip this transition - open it to generate it anyway.`}
-        aria-label={`Transition with mismatched aspect ratios, ${mismatch}. Generate All will skip it. Activate to open its settings.`}
+        title={`Aspect ratio mismatch: ${mismatch}. Generate All will skip this transition - select it to generate it anyway.`}
+        aria-label={`Transition with mismatched aspect ratios, ${mismatch}. Generate All will skip it. Activate to select it.${selectedSuffix}`}
       >
         <GapLine $variant="mismatched" />
         <GapStatusLabel $status="failed">mismatch</GapStatusLabel>
@@ -70,7 +91,7 @@ export function TransitionGapEnhanced({
       <GapContainer
         $expanded={false}
         {...activate}
-        aria-label="Transition, not yet generated. Activate to open its settings."
+        aria-label={`Transition, not yet generated. Activate to select it.${selectedSuffix}`}
       >
         <GapLine $variant="idle" />
       </GapContainer>
@@ -83,7 +104,7 @@ export function TransitionGapEnhanced({
       <GapContainer
         $expanded={false}
         {...activate}
-        aria-label={`Transition with custom settings, ${effectiveDuration} seconds. Activate to open its settings.`}
+        aria-label={`Transition with custom settings, ${effectiveDuration} seconds. Activate to select it.${selectedSuffix}`}
       >
         <GapLine $variant="configured" />
         <DurationLabel>{effectiveDuration}s</DurationLabel>
@@ -94,7 +115,11 @@ export function TransitionGapEnhanced({
   // Queued — soft pulsing dot.
   if (status === "queue") {
     return (
-      <GapContainer $expanded {...activate} aria-label="Transition queued">
+      <GapContainer
+        $expanded
+        {...activate}
+        aria-label={`Transition queued.${selectedSuffix}`}
+      >
         <StatusNode $variant="queued" />
         <GapStatusLabel $status="queued">queued</GapStatusLabel>
       </GapContainer>
@@ -110,7 +135,7 @@ export function TransitionGapEnhanced({
         {...activate}
         aria-label={`Transition rendering${
           pct > 0 ? `, ${Math.round(pct)}%` : ""
-        }`}
+        }.${selectedSuffix}`}
       >
         <StatusNode $variant="processing">
           {pct > 0 && <ProgressRing $percent={pct} />}
@@ -129,7 +154,7 @@ export function TransitionGapEnhanced({
       <GapContainer
         $expanded
         {...activate}
-        aria-label={`Transition rendered, ${effectiveDuration} seconds. Activate to open its settings.`}
+        aria-label={`Transition rendered, ${effectiveDuration} seconds. Activate to select it.${selectedSuffix}`}
       >
         <StatusNode $variant="processed">
           <Check size={14} strokeWidth={3} />
@@ -139,22 +164,22 @@ export function TransitionGapEnhanced({
     );
   }
 
-  // Failed — red ring with warning icon. Whole node is "click to retry". A
-  // mismatch here is the likely cause, so name it rather than just offering the
-  // retry that will fail the same way.
+  // Failed — red ring with warning icon. Selecting it loads its settings into
+  // the panel, where Retry regenerates. A mismatch here is the likely cause, so
+  // name it rather than just offering the retry that will fail the same way.
   return (
     <GapContainer
       $expanded
       {...activate}
       title={
         mismatch
-          ? `Aspect ratio mismatch: ${mismatch}. Click to retry anyway.`
-          : "Click to retry"
+          ? `Aspect ratio mismatch: ${mismatch}. Select it and use Retry to run it anyway.`
+          : "Select it, then use Retry"
       }
       aria-label={
         mismatch
-          ? `Transition failed, aspect ratios mismatched, ${mismatch}. Activate to retry.`
-          : "Transition failed. Activate to retry."
+          ? `Transition failed, aspect ratios mismatched, ${mismatch}. Activate to select it.${selectedSuffix}`
+          : `Transition failed. Activate to select it.${selectedSuffix}`
       }
     >
       <StatusNode $variant="failed">

--- a/src/components/pages/studio/components/transition-history.styled.tsx
+++ b/src/components/pages/studio/components/transition-history.styled.tsx
@@ -1,0 +1,126 @@
+import styled, { css } from "styled-components";
+import { FLOW } from "@/constants/flow-theme.constants";
+
+/**
+ * Inline strip that lives in the Transition Settings header row, right of the
+ * title. It used to be its own section, but that section appearing and
+ * disappearing as takes complete shoved the preview up and down the page.
+ * Here the enclosing row reserves the height once (HISTORY_ROW_HEIGHT), so the
+ * panel is the same height whether or not there is anything to show.
+ */
+export const HISTORY_ROW_HEIGHT = 88;
+
+export const HistoryInline = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* Heading sits above the thumbs, both hard against the right edge of the
+     settings row. */
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 0;
+`;
+
+export const HistoryTitle = styled.span`
+  flex-shrink: 0;
+  font-family: ${FLOW.fontFamily};
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: ${FLOW.textMuted};
+`;
+
+export const HistoryRail = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  overflow-x: auto;
+  min-width: 0;
+
+  /* The rail scrolls on its own so a long take list never widens the header. */
+  scrollbar-width: thin;
+  scrollbar-color: ${FLOW.borderHover} transparent;
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${FLOW.borderHover};
+    border-radius: 2px;
+  }
+`;
+
+export const HistoryItem = styled.button<{ $current: boolean }>`
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: ${FLOW.fontFamily};
+  transition: background-color 0.18s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${FLOW.selected};
+    outline-offset: 1px;
+  }
+
+  ${(p) =>
+    p.$current &&
+    css`
+      cursor: default;
+    `}
+`;
+
+export const HistoryThumb = styled.div<{ $current: boolean }>`
+  width: 84px;
+  height: 48px;
+  border-radius: 5px;
+  overflow: hidden;
+  background: ${FLOW.bgElevated};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  /* The rectangle that marks which take is live in the flow. */
+  box-shadow: ${(p) =>
+    p.$current
+      ? `0 0 0 2px ${FLOW.accent}, 0 0 10px ${FLOW.accentGlow}`
+      : `inset 0 0 0 1px ${FLOW.border}`};
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;
+
+export const HistoryPlaceholder = styled.span`
+  font-size: 10px;
+  color: ${FLOW.textMuted};
+`;
+
+export const HistoryTime = styled.span<{ $current: boolean }>`
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  color: ${(p) => (p.$current ? FLOW.accent : FLOW.textMuted)};
+  font-weight: ${(p) => (p.$current ? 700 : 500)};
+`;
+
+export const HistoryEmpty = styled.span`
+  font-family: ${FLOW.fontFamily};
+  font-size: 11px;
+  color: ${FLOW.textMuted};
+  white-space: nowrap;
+`;

--- a/src/components/pages/studio/components/transition-history.tsx
+++ b/src/components/pages/studio/components/transition-history.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useQueries, type QueryFunctionContext } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+import { useFlowStore } from "@/stores/flow.store";
+import { DREAM_QUERY_KEY, getDream } from "@/api/dream/query/useDream";
+import type { Dream } from "@/types/dream.types";
+import {
+  middleFilmstripUrl,
+  formatRunTime,
+} from "../utils/transition-history.util";
+import {
+  HistoryInline,
+  HistoryTitle,
+  HistoryRail,
+  HistoryItem,
+  HistoryThumb,
+  HistoryPlaceholder,
+  HistoryTime,
+  HistoryEmpty,
+} from "./transition-history.styled";
+
+export function TransitionHistory() {
+  const { transitions, selectedIndices } = useFlowStore(
+    useShallow((s) => ({
+      transitions: s.transitions,
+      selectedIndices: s.selectedTransitionIndices,
+    })),
+  );
+
+  // Restoring a take rewrites one position's settings, so it only makes sense
+  // against a single transition. With several selected there is no "this one".
+  const index = selectedIndices.length === 1 ? selectedIndices[0] : null;
+  const transition = index === null ? undefined : transitions[index];
+
+  const entries = useMemo(
+    () =>
+      (transition?.history ?? [])
+        .filter((entry) => entry.completed)
+        .slice()
+        .sort((a, b) => a.createdAt - b.createdAt),
+    [transition?.history],
+  );
+
+  const dreamQueries = useQueries({
+    queries: entries.map((entry) => ({
+      queryKey: [DREAM_QUERY_KEY, entry.dreamUuid],
+      queryFn: ({ signal }: QueryFunctionContext) =>
+        getDream(entry.dreamUuid, signal),
+      staleTime: Infinity,
+      // A just-finished dream has no filmstrip until the video service has run.
+      refetchInterval: (data: unknown) =>
+        (data as Dream | undefined)?.filmstrip?.length ? false : 5000,
+      refetchIntervalInBackground: false,
+    })),
+  });
+
+  // Takes run oldest-to-newest, so the current one is usually rightmost — and
+  // in a narrow header the rail scrolls, which would leave it clipped out of
+  // view. Keep whichever take is live in the flow on screen.
+  const currentRef = useRef<HTMLButtonElement>(null);
+  const currentUuid = transition?.dreamUuid;
+  useEffect(() => {
+    currentRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [currentUuid, entries.length]);
+
+  if (index === null || !transition) return null;
+
+  return (
+    <HistoryInline>
+      <HistoryTitle>History</HistoryTitle>
+      {entries.length === 0 ? (
+        <HistoryEmpty>No takes yet</HistoryEmpty>
+      ) : (
+        <HistoryRail role="list">
+          {entries.map((entry, i) => {
+            const isCurrent = entry.dreamUuid === transition.dreamUuid;
+            const thumb = middleFilmstripUrl(dreamQueries[i]?.data);
+            const time = formatRunTime(entry.createdAt);
+            return (
+              <HistoryItem
+                key={entry.dreamUuid}
+                ref={isCurrent ? currentRef : undefined}
+                type="button"
+                role="listitem"
+                $current={isCurrent}
+                aria-current={isCurrent}
+                title={
+                  isCurrent
+                    ? `Current take, generated ${time}`
+                    : `Restore the take generated ${time}`
+                }
+                aria-label={
+                  isCurrent
+                    ? `Take ${i + 1} of ${
+                        entries.length
+                      }, generated ${time}. Currently in the flow.`
+                    : `Take ${i + 1} of ${
+                        entries.length
+                      }, generated ${time}. Activate to restore it.`
+                }
+                onClick={() => {
+                  if (isCurrent) return;
+                  useFlowStore
+                    .getState()
+                    .restoreTransitionRun(index, entry.dreamUuid);
+                }}
+              >
+                <HistoryThumb $current={isCurrent}>
+                  {thumb ? (
+                    <img src={thumb} alt="" loading="lazy" />
+                  ) : (
+                    <HistoryPlaceholder>…</HistoryPlaceholder>
+                  )}
+                </HistoryThumb>
+                <HistoryTime $current={isCurrent}>{time}</HistoryTime>
+              </HistoryItem>
+            );
+          })}
+        </HistoryRail>
+      )}
+    </HistoryInline>
+  );
+}

--- a/src/components/pages/studio/components/transition-settings-panel.styled.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { FLOW, flowSlideIn } from "@/constants/flow-theme.constants";
+import { HISTORY_ROW_HEIGHT } from "./transition-history.styled";
 
 export const PanelContainer = styled.div`
   padding: 24px 28px;
@@ -11,7 +12,16 @@ export const PanelHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  gap: 16px;
+  /* Reserved once, so the row is the same height whether or not the history
+     strip on its right has anything in it. Without this the panel grew and
+     shrank as takes completed, shoving the preview below it up and down. */
+  min-height: ${HISTORY_ROW_HEIGHT}px;
+  margin-bottom: 12px;
+`;
+
+export const PanelHeaderMain = styled.div`
+  min-width: 0;
 `;
 
 export const PanelTitle = styled.span`
@@ -29,18 +39,11 @@ export const PanelSubtitle = styled.span`
   color: ${FLOW.textDim};
 `;
 
-export const CloseButton = styled.button`
-  background: none;
-  border: none;
-  color: ${FLOW.textDim};
-  cursor: pointer;
-  font-size: 16px;
-  padding: 4px;
-  line-height: 1;
-
-  &:hover {
-    color: ${FLOW.text};
-  }
+export const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 `;
 
 export const FieldRow = styled.div`

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import { useFlowStore, LOOP_FRAME_ID } from "@/stores/flow.store";
 import { useShallow } from "zustand/react/shallow";
 import type { LoRAConfig, VideoModel } from "@/types/studio.types";
@@ -23,6 +23,8 @@ import {
 import { SEED_HINT } from "@/components/pages/studio/constants/seed-options";
 import { useSeedInput } from "@/components/pages/studio/hooks/useSeedInput";
 import { GuidanceField } from "./guidance-field";
+import { ForceSettingsDialog } from "./force-settings-dialog";
+import { TransitionHistory } from "./transition-history";
 import {
   getPresetGroups,
   resolvePresetAction,
@@ -30,11 +32,18 @@ import {
 import { resolveNegativePromptSupport } from "@/components/pages/studio/utils/negative-prompt-support";
 import { resolveGenerationTargets } from "@/components/pages/studio/utils/flow-generation-targets";
 import {
+  TRANSITION_FIELD_LABELS,
+  selectionHasMismatch,
+  type TransitionField,
+  type TransitionGlobals,
+} from "@/components/pages/studio/utils/transition-field-values";
+import {
   PanelContainer,
   PanelHeader,
   PanelTitle,
   PanelSubtitle,
-  CloseButton,
+  PanelHeaderMain,
+  HeaderActions,
   FieldRow,
   FieldGroup,
   FieldLabel,
@@ -56,20 +65,27 @@ import {
 
 interface TransitionSettingsPanelProps {
   onGenerateAll: () => void;
-  onGenerateOne: (index: number) => void;
+  onGenerateSelected: (indices: readonly number[]) => void;
   isGenerating: boolean;
+}
+
+/** An edit held back until the user confirms flattening a mismatched field. */
+interface PendingEdit {
+  fieldLabel: string;
+  count: number;
+  run: () => void;
 }
 
 export function TransitionSettingsPanel({
   onGenerateAll,
-  onGenerateOne,
+  onGenerateSelected,
   isGenerating,
 }: TransitionSettingsPanelProps) {
   // Data via useShallow (re-renders when any selected value changes).
   const {
     transitions,
     referenceFrames,
-    selectedTransitionIndex,
+    selectedIndices,
     settingsExpanded,
     globalPresetId,
     globalPrompt,
@@ -84,7 +100,7 @@ export function TransitionSettingsPanel({
     useShallow((s) => ({
       transitions: s.transitions,
       referenceFrames: s.referenceFrames,
-      selectedTransitionIndex: s.selectedTransitionIndex,
+      selectedIndices: s.selectedTransitionIndices,
       settingsExpanded: s.settingsExpanded,
       globalPresetId: s.globalPresetId,
       globalPrompt: s.globalPrompt,
@@ -98,16 +114,21 @@ export function TransitionSettingsPanel({
     })),
   );
 
+  const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
+
   const { data: modelsData } = useModels({ mediaType: "video" });
   const modelOptions = modelsData?.data?.models ?? [];
   const modelConstraints = useModelConstraints({ mediaType: "video" });
 
-  // Per-transition mode?
-  const isPerTransition = selectedTransitionIndex !== null;
+  // Per-transition mode? The last-clicked index is the "primary": the one the
+  // panel names and whose values it displays when several are selected.
+  const isPerTransition = selectedIndices.length > 0;
+  const selectionCount = selectedIndices.length;
+  const primaryIndex = isPerTransition
+    ? selectedIndices[selectedIndices.length - 1]
+    : null;
   const selectedTransition =
-    selectedTransitionIndex !== null
-      ? transitions[selectedTransitionIndex]
-      : null;
+    primaryIndex !== null ? transitions[primaryIndex] : null;
 
   // Effective values (override > global > preset fallback)
   const currentPresetId = selectedTransition?.presetOverride ?? globalPresetId;
@@ -205,13 +226,22 @@ export function TransitionSettingsPanel({
     guidanceOverride: number;
     seedOverride: number;
   };
-  const setValue = useCallback(
-    <K extends keyof FieldMap>(field: K, value: FieldMap[K]) => {
+
+  /**
+   * Write one field to every target. `indices` empty means global mode — the
+   * same edit lands on the flow-wide defaults instead.
+   */
+  const writeField = useCallback(
+    <K extends keyof FieldMap>(
+      indices: readonly number[],
+      field: K,
+      value: FieldMap[K],
+    ) => {
       const store = useFlowStore.getState();
-      if (isPerTransition && selectedTransitionIndex !== null) {
-        store.setTransitionOverride(selectedTransitionIndex, {
-          [field]: value,
-        });
+      if (indices.length > 0) {
+        for (const index of indices) {
+          store.setTransitionOverride(index, { [field]: value });
+        }
         return;
       }
       switch (field) {
@@ -241,7 +271,66 @@ export function TransitionSettingsPanel({
           break;
       }
     },
-    [isPerTransition, selectedTransitionIndex],
+    [],
+  );
+
+  /**
+   * Run an edit against the current selection, first checking whether it would
+   * flatten a field the selected transitions disagree about. `gatedFields` are
+   * the ones the user is directly editing — knock-on clamps (a duration the new
+   * model can't do, say) follow the edit and aren't gated separately, or a
+   * single interaction could raise several dialogs in a row.
+   *
+   * Store state is read via getState() inside the callback so this identity
+   * stays stable across settings keystrokes.
+   */
+  const applyEdit = useCallback(
+    (
+      gatedFields: TransitionField[],
+      run: (indices: readonly number[]) => void,
+    ) => {
+      const state = useFlowStore.getState();
+      const indices = state.selectedTransitionIndices;
+      if (indices.length > 1) {
+        const selected = indices
+          .map((i) => state.transitions[i])
+          .filter((t): t is NonNullable<typeof t> => Boolean(t));
+        const globals: TransitionGlobals = {
+          globalPresetId: state.globalPresetId,
+          globalPrompt: state.globalPrompt,
+          globalNegativePrompt: state.globalNegativePrompt,
+          globalDuration: state.globalDuration,
+          globalModel: state.globalModel,
+          globalNumInferenceSteps: state.globalNumInferenceSteps,
+          globalGuidance: state.globalGuidance,
+          globalSeed: state.globalSeed,
+          globalLora: state.globalLora,
+        };
+        const clash = gatedFields.find((field) =>
+          selectionHasMismatch(selected, globals, field),
+        );
+        if (clash) {
+          setPendingEdit({
+            fieldLabel: TRANSITION_FIELD_LABELS[clash],
+            count: selected.length,
+            run: () => run(indices),
+          });
+          return;
+        }
+      }
+      run(indices);
+    },
+    [],
+  );
+
+  /** Edit a single field, gated on that same field. */
+  const setValue = useCallback(
+    <K extends keyof FieldMap>(field: K, value: FieldMap[K]) => {
+      applyEdit([field as TransitionField], (indices) =>
+        writeField(indices, field, value),
+      );
+    },
+    [applyEdit, writeField],
   );
 
   const seedInput = useSeedInput(currentSeed, (seed) =>
@@ -250,116 +339,123 @@ export function TransitionSettingsPanel({
 
   const handlePresetChange = useCallback(
     (presetName: string) => {
-      setValue("presetOverride", presetName || "");
+      applyEdit(["presetOverride"], (indices) => {
+        writeField(indices, "presetOverride", presetName || "");
 
-      // Fill prompt (and negative prompt) from preset. The negative is cleared
-      // for presets that don't define one, so a previous preset's negative
-      // never silently rides along on the next transition.
-      const action = resolvePresetAction(presetName);
-      if (action) {
-        setValue("promptOverride", action.prompt);
-        setValue("negativePromptOverride", action.negativePrompt ?? "");
-      }
+        // Fill prompt (and negative prompt) from preset. The negative is cleared
+        // for presets that don't define one, so a previous preset's negative
+        // never silently rides along on the next transition.
+        const action = resolvePresetAction(presetName);
+        if (action) {
+          writeField(indices, "promptOverride", action.prompt);
+          writeField(
+            indices,
+            "negativePromptOverride",
+            action.negativePrompt ?? "",
+          );
+        }
 
-      // Clear any explicit LoRA override so the preset's LoRA takes effect
-      const store = useFlowStore.getState();
-      if (isPerTransition && selectedTransitionIndex !== null) {
-        store.setTransitionOverride(selectedTransitionIndex, {
-          loraOverride: undefined,
-        });
-      } else {
-        store.setGlobalLora(undefined);
-      }
+        // Clear any explicit LoRA override so the preset's LoRA takes effect
+        const store = useFlowStore.getState();
+        if (indices.length > 0) {
+          for (const index of indices) {
+            store.setTransitionOverride(index, { loraOverride: undefined });
+          }
+        } else {
+          store.setGlobalLora(undefined);
+        }
 
-      // Clamp duration if needed
-      const newAllowed = getAllowedDurationsForActions(
-        action ? [action] : [],
-        currentModelDurations,
-      );
-      const clamped = clampDurationToAllowed(currentDuration, newAllowed);
-      if (clamped !== currentDuration) {
-        setValue("durationOverride", clamped);
-      }
+        // Clamp duration if needed
+        const newAllowed = getAllowedDurationsForActions(
+          action ? [action] : [],
+          currentModelDurations,
+        );
+        const clamped = clampDurationToAllowed(currentDuration, newAllowed);
+        if (clamped !== currentDuration) {
+          writeField(indices, "durationOverride", clamped);
+        }
+      });
     },
-    [
-      setValue,
-      currentModelDurations,
-      currentDuration,
-      isPerTransition,
-      selectedTransitionIndex,
-    ],
+    [applyEdit, writeField, currentModelDurations, currentDuration],
   );
 
   const handleModelChange = useCallback(
     (model: VideoModel) => {
-      setValue("modelOverride", model);
+      applyEdit(["modelOverride"], (indices) => {
+        writeField(indices, "modelOverride", model);
 
-      const fixedDurations = modelConstraints.get(model)?.durationsSec;
-      const newAllowed = getAllowedDurationsForActions(
-        presetAction ? [presetAction] : [],
-        fixedDurations,
-      );
-      const clamped = clampDurationToAllowed(currentDuration, newAllowed);
-      if (clamped !== currentDuration) {
-        setValue("durationOverride", clamped);
-      }
+        const fixedDurations = modelConstraints.get(model)?.durationsSec;
+        const newAllowed = getAllowedDurationsForActions(
+          presetAction ? [presetAction] : [],
+          fixedDurations,
+        );
+        const clamped = clampDurationToAllowed(currentDuration, newAllowed);
+        if (clamped !== currentDuration) {
+          writeField(indices, "durationOverride", clamped);
+        }
 
-      const nextConstraint = resolveGuidanceConstraint(
-        model,
-        modelConstraints.get(model),
-      );
-      const clampedGuidance = guidanceForModel(currentGuidance, nextConstraint);
-      if (clampedGuidance !== currentGuidance) {
-        setValue("guidanceOverride", clampedGuidance);
-      }
+        const nextConstraint = resolveGuidanceConstraint(
+          model,
+          modelConstraints.get(model),
+        );
+        const clampedGuidance = guidanceForModel(
+          currentGuidance,
+          nextConstraint,
+        );
+        if (clampedGuidance !== currentGuidance) {
+          writeField(indices, "guidanceOverride", clampedGuidance);
+        }
+      });
     },
     [
+      applyEdit,
+      writeField,
       presetAction,
       currentDuration,
       currentGuidance,
-      setValue,
       modelConstraints,
     ],
   );
 
   const handleLoraChange = useCallback(
     (loraKey: string) => {
-      const loraOption = loraKey
-        ? loraOptions.find((o) => o.key === loraKey)
-        : undefined;
-      const nextLora = loraOption?.highNoiseLoras ?? [];
+      applyEdit(["loraOverride"], (indices) => {
+        const loraOption = loraKey
+          ? loraOptions.find((o) => o.key === loraKey)
+          : undefined;
+        const nextLora = loraOption?.highNoiseLoras ?? [];
 
-      const store = useFlowStore.getState();
-      if (isPerTransition && selectedTransitionIndex !== null) {
-        store.setTransitionOverride(selectedTransitionIndex, {
-          loraOverride: nextLora,
-        });
-      } else {
-        store.setGlobalLora(nextLora);
-      }
+        const store = useFlowStore.getState();
+        if (indices.length > 0) {
+          for (const index of indices) {
+            store.setTransitionOverride(index, { loraOverride: nextLora });
+          }
+        } else {
+          store.setGlobalLora(nextLora);
+        }
 
-      // Re-clamp duration against the new LoRA, since LoRAs can restrict durations.
-      const clampAction = {
-        prompt: presetAction?.prompt ?? "",
-        highNoiseLoras: nextLora,
-      };
-      const newAllowed = getAllowedDurationsForActions(
-        [clampAction],
-        currentModelDurations,
-      );
-      const clamped = clampDurationToAllowed(currentDuration, newAllowed);
-      if (clamped !== currentDuration) {
-        setValue("durationOverride", clamped);
-      }
+        // Re-clamp duration against the new LoRA, since LoRAs can restrict durations.
+        const clampAction = {
+          prompt: presetAction?.prompt ?? "",
+          highNoiseLoras: nextLora,
+        };
+        const newAllowed = getAllowedDurationsForActions(
+          [clampAction],
+          currentModelDurations,
+        );
+        const clamped = clampDurationToAllowed(currentDuration, newAllowed);
+        if (clamped !== currentDuration) {
+          writeField(indices, "durationOverride", clamped);
+        }
+      });
     },
     [
-      isPerTransition,
-      selectedTransitionIndex,
+      applyEdit,
+      writeField,
       loraOptions,
       presetAction,
       currentModelDurations,
       currentDuration,
-      setValue,
     ],
   );
 
@@ -375,9 +471,11 @@ export function TransitionSettingsPanel({
   const generateAllDisabled =
     isGenerating || generateAllTargets.length === 0 || needsPrompt;
 
-  const generateOneDisabled = isGenerating || needsPrompt;
+  const generateSelectedDisabled = isGenerating || needsPrompt;
 
-  const generateCount = isPerTransition ? 1 : generateAllTargets.length;
+  const generateCount = isPerTransition
+    ? selectionCount
+    : generateAllTargets.length;
   const { totalCostUsd, costBreakdown } = useCostEstimate({
     model: modelOptions.find((m) => m.id === currentModel),
     params: { durationSec: currentDuration },
@@ -398,28 +496,34 @@ export function TransitionSettingsPanel({
   const fromName =
     selectedTransition && findName(selectedTransition.fromFrameId);
   const toName = selectedTransition && findName(selectedTransition.toFrameId);
+  const extraCount = selectionCount - 1;
 
-  const isComplete = selectedTransition?.status === "processed";
+  const generateLabel = !isPerTransition
+    ? "Generate All"
+    : selectionCount > 1
+      ? `Generate ${selectionCount} selected`
+      : selectedTransition?.status === "processed"
+        ? "Regenerate"
+        : selectedTransition?.status === "failed"
+          ? "Retry"
+          : "Generate";
 
   return (
     <PanelContainer>
       <PanelHeader>
-        <div>
+        <PanelHeaderMain>
           <PanelTitle>Transition Settings</PanelTitle>
           {isPerTransition && fromName && toName && (
             <PanelSubtitle>
               {" "}
               &mdash; Editing: {fromName} &rarr; {toName}
+              {extraCount > 0 && ` and ${extraCount} more`}
             </PanelSubtitle>
           )}
-        </div>
-        {isPerTransition && (
-          <CloseButton
-            onClick={() => useFlowStore.getState().selectTransition(null)}
-          >
-            &times;
-          </CloseButton>
-        )}
+        </PanelHeaderMain>
+        <HeaderActions>
+          <TransitionHistory />
+        </HeaderActions>
       </PanelHeader>
 
       {/* Collapsed view */}
@@ -479,9 +583,11 @@ export function TransitionSettingsPanel({
 
         <GenerateButton
           $disabled={
-            isPerTransition ? generateOneDisabled : generateAllDisabled
+            isPerTransition ? generateSelectedDisabled : generateAllDisabled
           }
-          disabled={isPerTransition ? generateOneDisabled : generateAllDisabled}
+          disabled={
+            isPerTransition ? generateSelectedDisabled : generateAllDisabled
+          }
           title={
             needsPrompt
               ? "Add a prompt or pick a preset to generate"
@@ -489,18 +595,14 @@ export function TransitionSettingsPanel({
           }
           onClick={() => {
             if (guardOverBudget()) return;
-            if (isPerTransition && selectedTransitionIndex !== null) {
-              onGenerateOne(selectedTransitionIndex);
+            if (isPerTransition) {
+              onGenerateSelected(selectedIndices);
             } else {
               onGenerateAll();
             }
           }}
         >
-          {isPerTransition
-            ? isComplete
-              ? "Regenerate"
-              : "Generate"
-            : "Generate All"}
+          {generateLabel}
         </GenerateButton>
       </FieldRow>
 
@@ -634,16 +736,31 @@ export function TransitionSettingsPanel({
       )}
 
       {/* Per-transition extras */}
-      {isPerTransition && selectedTransitionIndex !== null && (
+      {isPerTransition && (
         <ResetLink
-          onClick={() =>
-            useFlowStore
-              .getState()
-              .clearTransitionOverride(selectedTransitionIndex)
-          }
+          onClick={() => {
+            const store = useFlowStore.getState();
+            for (const index of store.selectedTransitionIndices) {
+              store.clearTransitionOverride(index);
+            }
+          }}
         >
-          Reset to defaults
+          {selectionCount > 1
+            ? `Reset ${selectionCount} transitions to defaults`
+            : "Reset to defaults"}
         </ResetLink>
+      )}
+
+      {pendingEdit && (
+        <ForceSettingsDialog
+          fieldLabel={pendingEdit.fieldLabel}
+          count={pendingEdit.count}
+          onConfirm={() => {
+            pendingEdit.run();
+            setPendingEdit(null);
+          }}
+          onCancel={() => setPendingEdit(null)}
+        />
       )}
     </PanelContainer>
   );

--- a/src/components/pages/studio/components/transition-settings-panel.tsx
+++ b/src/components/pages/studio/components/transition-settings-panel.tsx
@@ -30,9 +30,11 @@ import {
   resolvePresetAction,
 } from "@/components/pages/studio/utils/resolve-flow-settings";
 import { resolveNegativePromptSupport } from "@/components/pages/studio/utils/negative-prompt-support";
-import { resolveGenerationTargets } from "@/components/pages/studio/utils/flow-generation-targets";
 import {
-  TRANSITION_FIELD_LABELS,
+  resolveGenerationTargets,
+  resolveSelectedTargets,
+} from "@/components/pages/studio/utils/flow-generation-targets";
+import {
   selectionHasMismatch,
   type TransitionField,
   type TransitionGlobals,
@@ -69,10 +71,15 @@ interface TransitionSettingsPanelProps {
   isGenerating: boolean;
 }
 
-/** An edit held back until the user confirms flattening a mismatched field. */
+/**
+ * An edit held back until the user confirms flattening a mismatched field.
+ *
+ * A selection is unified when it is made (see reference-frame-strip), so this
+ * is a backstop, not the usual path: rebuilding the transition list — a
+ * reference frame reordered or removed — can leave already-selected indices
+ * pointing at transitions that no longer agree.
+ */
 interface PendingEdit {
-  fieldLabel: string;
-  count: number;
   run: () => void;
 }
 
@@ -310,11 +317,7 @@ export function TransitionSettingsPanel({
           selectionHasMismatch(selected, globals, field),
         );
         if (clash) {
-          setPendingEdit({
-            fieldLabel: TRANSITION_FIELD_LABELS[clash],
-            count: selected.length,
-            run: () => run(indices),
-          });
+          setPendingEdit({ run: () => run(indices) });
           return;
         }
       }
@@ -463,19 +466,47 @@ export function TransitionSettingsPanel({
   // so it becomes required. With a preset, the preset supplies a prompt.
   const needsPrompt = !presetAction && !currentPrompt.trim();
 
+  // What each mode would actually start. This count drives the cost estimate
+  // sitting beside the button, so the clips it prices are the dreams the click
+  // produces — not the number of things on screen.
   const { targets: generateAllTargets } = useMemo(
-    () => resolveGenerationTargets(transitions, referenceFrames),
-    [transitions, referenceFrames],
+    () =>
+      resolveGenerationTargets(transitions, referenceFrames, {
+        globalPresetId,
+        globalPrompt,
+        globalNegativePrompt,
+        globalDuration,
+        globalModel,
+        globalNumInferenceSteps,
+        globalGuidance,
+        globalSeed,
+        globalLora,
+      }),
+    [
+      transitions,
+      referenceFrames,
+      globalPresetId,
+      globalPrompt,
+      globalNegativePrompt,
+      globalDuration,
+      globalModel,
+      globalNumInferenceSteps,
+      globalGuidance,
+      globalSeed,
+      globalLora,
+    ],
   );
 
-  const generateAllDisabled =
-    isGenerating || generateAllTargets.length === 0 || needsPrompt;
-
-  const generateSelectedDisabled = isGenerating || needsPrompt;
+  const { targets: generateSelectedTargets } = useMemo(
+    () => resolveSelectedTargets(selectedIndices, transitions, referenceFrames),
+    [selectedIndices, transitions, referenceFrames],
+  );
 
   const generateCount = isPerTransition
-    ? selectionCount
+    ? generateSelectedTargets.length
     : generateAllTargets.length;
+
+  const generateDisabled = isGenerating || generateCount === 0 || needsPrompt;
   const { totalCostUsd, costBreakdown } = useCostEstimate({
     model: modelOptions.find((m) => m.id === currentModel),
     params: { durationSec: currentDuration },
@@ -497,16 +528,6 @@ export function TransitionSettingsPanel({
     selectedTransition && findName(selectedTransition.fromFrameId);
   const toName = selectedTransition && findName(selectedTransition.toFrameId);
   const extraCount = selectionCount - 1;
-
-  const generateLabel = !isPerTransition
-    ? "Generate All"
-    : selectionCount > 1
-      ? `Generate ${selectionCount} selected`
-      : selectedTransition?.status === "processed"
-        ? "Regenerate"
-        : selectedTransition?.status === "failed"
-          ? "Retry"
-          : "Generate";
 
   return (
     <PanelContainer>
@@ -582,16 +603,14 @@ export function TransitionSettingsPanel({
         <CostEstimate amountUsd={totalCostUsd} breakdown={costBreakdown} />
 
         <GenerateButton
-          $disabled={
-            isPerTransition ? generateSelectedDisabled : generateAllDisabled
-          }
-          disabled={
-            isPerTransition ? generateSelectedDisabled : generateAllDisabled
-          }
+          $disabled={generateDisabled}
+          disabled={generateDisabled}
           title={
             needsPrompt
               ? "Add a prompt or pick a preset to generate"
-              : undefined
+              : isPerTransition
+                ? "Generate the selected transitions, edited or not"
+                : "Generate every transition whose video is behind its settings"
           }
           onClick={() => {
             if (guardOverBudget()) return;
@@ -602,7 +621,7 @@ export function TransitionSettingsPanel({
             }
           }}
         >
-          {generateLabel}
+          Generate
         </GenerateButton>
       </FieldRow>
 
@@ -753,8 +772,6 @@ export function TransitionSettingsPanel({
 
       {pendingEdit && (
         <ForceSettingsDialog
-          fieldLabel={pendingEdit.fieldLabel}
-          count={pendingEdit.count}
           onConfirm={() => {
             pendingEdit.run();
             setPendingEdit(null);

--- a/src/components/pages/studio/hooks/useFlowGeneration.test.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => {
   const ensureFlowKeyframe = vi.fn(
     async (frame: { id: string }) => `frame-${frame.id}`,
   );
-  const setTransitionDream = vi.fn();
+  const recordTransitionRun = vi.fn();
   const updateTransitionStatus = vi.fn();
   const store = {
     transitions: [
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => {
     invalidateQueries,
     post,
     ensureFlowKeyframe,
-    setTransitionDream,
+    recordTransitionRun,
     updateTransitionStatus,
     store,
   };
@@ -72,14 +72,14 @@ vi.mock("../../../../stores/flow.store", () => ({
     (
       selector: (
         state: typeof mocks.store & {
-          setTransitionDream: typeof mocks.setTransitionDream;
+          recordTransitionRun: typeof mocks.recordTransitionRun;
           updateTransitionStatus: typeof mocks.updateTransitionStatus;
         },
       ) => unknown,
     ) =>
       selector({
         ...mocks.store,
-        setTransitionDream: mocks.setTransitionDream,
+        recordTransitionRun: mocks.recordTransitionRun,
         updateTransitionStatus: mocks.updateTransitionStatus,
       }),
     { getState: () => mocks.store },
@@ -92,11 +92,14 @@ vi.mock("../utils/build-video-algo-params", () => ({
 
 vi.mock("../utils/resolve-flow-settings", () => ({
   resolveEffectiveSettings: () => ({
+    presetId: "",
+    prompt: "move",
     model: "ltx-i2v",
-    action: undefined,
+    action: { prompt: "move", highNoiseLoras: [], lowNoiseLoras: [] },
     duration: 5,
     numInferenceSteps: 20,
     guidance: 3,
+    seed: -1,
     negativePrompt: "",
   }),
 }));
@@ -128,6 +131,57 @@ describe("useFlowGeneration", () => {
 
     expect(mocks.post).toHaveBeenCalledTimes(2);
     expect(mocks.invalidateQueries).toHaveBeenCalledWith(["getUser"]);
+    // Nothing was rolled back to "failed" — the happy path really ran.
+    expect(mocks.updateTransitionStatus).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "failed",
+    );
+  });
+
+  it("records each run with the settings it used, for the history strip", async () => {
+    const { generateAll } = useFlowGeneration();
+
+    await generateAll();
+
+    expect(mocks.recordTransitionRun).toHaveBeenCalledTimes(2);
+    const [index, dreamUuid, settings, createdAt] =
+      mocks.recordTransitionRun.mock.calls[0];
+    expect(index).toBe(0);
+    expect(dreamUuid).toBe("new-1");
+    expect(settings).toMatchObject({
+      promptOverride: "move",
+      modelOverride: "ltx-i2v",
+      durationOverride: 5,
+      numInferenceStepsOverride: 20,
+      guidanceOverride: 3,
+      seedOverride: -1,
+      loraOverride: [],
+    });
+    expect(typeof createdAt).toBe("number");
+  });
+
+  it("regenerates an explicit selection, processed ones included", async () => {
+    // Generate All skips these; asking for a rerun of what you picked must not.
+    mocks.store.transitions = [
+      { fromFrameId: "frame-1", toFrameId: "frame-2", status: "processed" },
+      { fromFrameId: "frame-2", toFrameId: "frame-3", status: "processed" },
+    ];
+
+    const { generateMany } = useFlowGeneration();
+    await generateMany([1]);
+
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+    expect(mocks.recordTransitionRun).toHaveBeenCalledWith(
+      1,
+      "new-1",
+      expect.anything(),
+      expect.any(Number),
+    );
+
+    mocks.store.transitions = [
+      { fromFrameId: "frame-1", toFrameId: "frame-2", status: "idle" },
+      { fromFrameId: "frame-2", toFrameId: "frame-3", status: "idle" },
+    ];
   });
 
   it("skips a transition whose two frames have different aspect ratios", async () => {

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -6,21 +6,42 @@ import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { buildVideoAlgoParams } from "@/components/pages/studio/utils/build-video-algo-params";
 import { resolveEffectiveSettings } from "@/components/pages/studio/utils/resolve-flow-settings";
-import type { FlowTransition } from "@/types/flow.types";
+import type { FlowTransition, TransitionRunSettings } from "@/types/flow.types";
 import queryClient from "@/api/query-client";
 import { USER_QUERY_KEY } from "@/api/user/query/useUser";
 import { ensureFlowKeyframe } from "@/components/pages/studio/utils/flow-keyframes";
 import { resolveGenerationTargets } from "@/components/pages/studio/utils/flow-generation-targets";
+import { isTransitionMismatched } from "@/components/pages/studio/utils/frame-aspect";
 
 // Cap concurrent dream creations so "Generate All" doesn't fan out 50+ requests at once.
 const GENERATE_CONCURRENCY = 4;
+
+/** Worker-pool style concurrency cap over a list of transition targets. */
+async function runWithConcurrency(
+  targets: ReadonlyArray<{ index: number; transition: FlowTransition }>,
+  run: (index: number, transition: FlowTransition) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < targets.length) {
+      const next = targets[cursor++];
+      await run(next.index, next.transition);
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(GENERATE_CONCURRENCY, targets.length) },
+      worker,
+    ),
+  );
+}
 
 export function useFlowGeneration() {
   const [isGenerating, setIsGenerating] = useState(false);
   const generatingCount = useRef(0);
 
   // Actions are stable refs — subscribe individually, not via useShallow.
-  const setTransitionDream = useFlowStore((s) => s.setTransitionDream);
+  const recordTransitionRun = useFlowStore((s) => s.recordTransitionRun);
   const updateTransitionStatus = useFlowStore((s) => s.updateTransitionStatus);
 
   const generateTransition = useCallback(
@@ -101,14 +122,28 @@ export function useFlowGeneration() {
           { headers },
         );
 
-        setTransitionDream(index, dreamUuid);
+        // Snapshot the *resolved* settings, not the overrides: this is what
+        // lets the history strip restore this take later, after the globals
+        // it fell back to have moved on.
+        const runSettings: TransitionRunSettings = {
+          presetOverride: settings.presetId,
+          promptOverride: settings.prompt,
+          negativePromptOverride: settings.negativePrompt,
+          durationOverride: settings.duration,
+          modelOverride: settings.model,
+          numInferenceStepsOverride: settings.numInferenceSteps,
+          guidanceOverride: settings.guidance,
+          seedOverride: settings.seed,
+          loraOverride: settings.action.highNoiseLoras ?? [],
+        };
+        recordTransitionRun(index, dreamUuid, runSettings, Date.now());
         updateTransitionStatus(index, "queue");
       } catch (error) {
         Bugsnag.notify(error as Error);
         updateTransitionStatus(index, "failed");
       }
     },
-    [setTransitionDream, updateTransitionStatus],
+    [recordTransitionRun, updateTransitionStatus],
   );
 
   const startGenerating = useCallback(() => {
@@ -141,20 +176,7 @@ export function useFlowGeneration() {
         );
       }
 
-      // Worker-pool style concurrency cap.
-      let cursor = 0;
-      const worker = async () => {
-        while (cursor < targets.length) {
-          const next = targets[cursor++];
-          await generateTransition(next.index, next.transition);
-        }
-      };
-      await Promise.all(
-        Array.from(
-          { length: Math.min(GENERATE_CONCURRENCY, targets.length) },
-          worker,
-        ),
-      );
+      await runWithConcurrency(targets, generateTransition);
       if (targets.length > 0) {
         await queryClient.invalidateQueries([USER_QUERY_KEY]);
       }
@@ -178,5 +200,55 @@ export function useFlowGeneration() {
     [generateTransition, startGenerating, stopGenerating],
   );
 
-  return { generateAll, generateOne, isGenerating };
+  /**
+   * Regenerate an explicit selection. Unlike Generate All this does not skip
+   * already-processed transitions — asking for a rerun of the ones you picked
+   * is the whole point — but it still refuses aspect-ratio mismatches, which
+   * would only fail the same way they did before.
+   */
+  const generateMany = useCallback(
+    async (indices: readonly number[]) => {
+      startGenerating();
+      try {
+        const { transitions, referenceFrames } = useFlowStore.getState();
+        const byId = new Map(referenceFrames.map((frame) => [frame.id, frame]));
+        const targets: Array<{ index: number; transition: FlowTransition }> =
+          [];
+        let skippedForMismatch = 0;
+
+        for (const index of indices) {
+          const transition = transitions[index];
+          if (!transition) continue;
+          if (
+            isTransitionMismatched(
+              byId.get(transition.fromFrameId),
+              byId.get(transition.toFrameId),
+            )
+          ) {
+            skippedForMismatch += 1;
+            continue;
+          }
+          targets.push({ index, transition });
+        }
+
+        if (skippedForMismatch > 0) {
+          toast.info(
+            `Skipped ${skippedForMismatch} transition${
+              skippedForMismatch === 1 ? "" : "s"
+            } with mismatched aspect ratios.`,
+          );
+        }
+
+        await runWithConcurrency(targets, generateTransition);
+        if (targets.length > 0) {
+          await queryClient.invalidateQueries([USER_QUERY_KEY]);
+        }
+      } finally {
+        stopGenerating();
+      }
+    },
+    [generateTransition, startGenerating, stopGenerating],
+  );
+
+  return { generateAll, generateOne, generateMany, isGenerating };
 }

--- a/src/components/pages/studio/hooks/useFlowGeneration.ts
+++ b/src/components/pages/studio/hooks/useFlowGeneration.ts
@@ -6,12 +6,15 @@ import { axiosClient } from "@/client/axios.client";
 import { getRequestHeaders, ContentType } from "@/constants/auth.constants";
 import { buildVideoAlgoParams } from "@/components/pages/studio/utils/build-video-algo-params";
 import { resolveEffectiveSettings } from "@/components/pages/studio/utils/resolve-flow-settings";
-import type { FlowTransition, TransitionRunSettings } from "@/types/flow.types";
+import { runSettingsFromEffective } from "@/components/pages/studio/utils/transition-staleness";
+import type { FlowTransition } from "@/types/flow.types";
 import queryClient from "@/api/query-client";
 import { USER_QUERY_KEY } from "@/api/user/query/useUser";
 import { ensureFlowKeyframe } from "@/components/pages/studio/utils/flow-keyframes";
-import { resolveGenerationTargets } from "@/components/pages/studio/utils/flow-generation-targets";
-import { isTransitionMismatched } from "@/components/pages/studio/utils/frame-aspect";
+import {
+  resolveGenerationTargets,
+  resolveSelectedTargets,
+} from "@/components/pages/studio/utils/flow-generation-targets";
 
 // Cap concurrent dream creations so "Generate All" doesn't fan out 50+ requests at once.
 const GENERATE_CONCURRENCY = 4;
@@ -125,18 +128,12 @@ export function useFlowGeneration() {
         // Snapshot the *resolved* settings, not the overrides: this is what
         // lets the history strip restore this take later, after the globals
         // it fell back to have moved on.
-        const runSettings: TransitionRunSettings = {
-          presetOverride: settings.presetId,
-          promptOverride: settings.prompt,
-          negativePromptOverride: settings.negativePrompt,
-          durationOverride: settings.duration,
-          modelOverride: settings.model,
-          numInferenceStepsOverride: settings.numInferenceSteps,
-          guidanceOverride: settings.guidance,
-          seedOverride: settings.seed,
-          loraOverride: settings.action.highNoiseLoras ?? [],
-        };
-        recordTransitionRun(index, dreamUuid, runSettings, Date.now());
+        recordTransitionRun(
+          index,
+          dreamUuid,
+          runSettingsFromEffective(settings),
+          Date.now(),
+        );
         updateTransitionStatus(index, "queue");
       } catch (error) {
         Bugsnag.notify(error as Error);
@@ -162,10 +159,21 @@ export function useFlowGeneration() {
   const generateAll = useCallback(async () => {
     startGenerating();
     try {
-      const { transitions, referenceFrames } = useFlowStore.getState();
+      const store = useFlowStore.getState();
       const { targets, skippedForMismatch } = resolveGenerationTargets(
-        transitions,
-        referenceFrames,
+        store.transitions,
+        store.referenceFrames,
+        {
+          globalPresetId: store.globalPresetId,
+          globalPrompt: store.globalPrompt,
+          globalNegativePrompt: store.globalNegativePrompt,
+          globalDuration: store.globalDuration,
+          globalModel: store.globalModel,
+          globalNumInferenceSteps: store.globalNumInferenceSteps,
+          globalGuidance: store.globalGuidance,
+          globalSeed: store.globalSeed,
+          globalLora: store.globalLora,
+        },
       );
 
       if (skippedForMismatch > 0) {
@@ -211,25 +219,11 @@ export function useFlowGeneration() {
       startGenerating();
       try {
         const { transitions, referenceFrames } = useFlowStore.getState();
-        const byId = new Map(referenceFrames.map((frame) => [frame.id, frame]));
-        const targets: Array<{ index: number; transition: FlowTransition }> =
-          [];
-        let skippedForMismatch = 0;
-
-        for (const index of indices) {
-          const transition = transitions[index];
-          if (!transition) continue;
-          if (
-            isTransitionMismatched(
-              byId.get(transition.fromFrameId),
-              byId.get(transition.toFrameId),
-            )
-          ) {
-            skippedForMismatch += 1;
-            continue;
-          }
-          targets.push({ index, transition });
-        }
+        const { targets, skippedForMismatch } = resolveSelectedTargets(
+          indices,
+          transitions,
+          referenceFrames,
+        );
 
         if (skippedForMismatch > 0) {
           toast.info(

--- a/src/components/pages/studio/utils/flow-generation-targets.test.ts
+++ b/src/components/pages/studio/utils/flow-generation-targets.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import type {
+  FlowReferenceFrame,
+  FlowTransition,
+  TransitionStatus,
+} from "@/types/flow.types";
+import type { TransitionGlobals } from "./transition-field-values";
+import {
+  resolveGenerationTargets,
+  resolveSelectedTargets,
+} from "./flow-generation-targets";
+import { currentRunSettings } from "./transition-staleness";
+
+const GLOBALS: TransitionGlobals = {
+  globalPresetId: "",
+  globalPrompt: "drift",
+  globalNegativePrompt: "",
+  globalDuration: 5,
+  globalModel: "kling-25-i2v",
+  globalNumInferenceSteps: 30,
+  globalGuidance: 0.5,
+  globalSeed: -1,
+  globalLora: undefined,
+};
+
+const frame = (id: string): FlowReferenceFrame => ({
+  id,
+  name: id,
+  imageUrl: `${id}.png`,
+  naturalWidth: 1024,
+  naturalHeight: 1024,
+});
+
+const FRAMES = [frame("a"), frame("b")];
+
+const at = (status: TransitionStatus): FlowTransition => ({
+  fromFrameId: "a",
+  toFrameId: "b",
+  status,
+});
+
+/** Rendered from exactly the settings it currently resolves to. */
+const current = (overrides: Partial<FlowTransition> = {}): FlowTransition => {
+  const base: FlowTransition = {
+    ...at("processed"),
+    dreamUuid: "dream-1",
+    ...overrides,
+  };
+  return {
+    ...base,
+    history: [
+      {
+        dreamUuid: "dream-1",
+        createdAt: 1,
+        completed: true,
+        settings: currentRunSettings(base, GLOBALS),
+      },
+    ],
+  };
+};
+
+const indexes = (result: { targets: Array<{ index: number }> }) =>
+  result.targets.map((t) => t.index);
+
+describe("resolveGenerationTargets", () => {
+  it("takes the never-rendered ones", () => {
+    const result = resolveGenerationTargets(
+      [at("idle"), at("failed")],
+      FRAMES,
+      GLOBALS,
+    );
+    expect(indexes(result)).toEqual([0, 1]);
+    expect(result.neverRendered).toBe(2);
+    expect(result.stale).toBe(0);
+  });
+
+  it("skips a rendered transition that still matches its settings", () => {
+    const result = resolveGenerationTargets([current()], FRAMES, GLOBALS);
+    expect(indexes(result)).toEqual([]);
+  });
+
+  // The bug this all exists for: edit a rendered transition and Generate used
+  // to skip it, because "processed" was read as "done".
+  it("takes a rendered transition that has been edited since", () => {
+    const edited = { ...current(), promptOverride: "swirl" };
+    const result = resolveGenerationTargets([edited], FRAMES, GLOBALS);
+    expect(indexes(result)).toEqual([0]);
+    expect(result.stale).toBe(1);
+    expect(result.neverRendered).toBe(0);
+  });
+
+  it("takes one made stale by a global moving under it", () => {
+    const result = resolveGenerationTargets([current()], FRAMES, {
+      ...GLOBALS,
+      globalPrompt: "swirl",
+    });
+    expect(indexes(result)).toEqual([0]);
+    expect(result.stale).toBe(1);
+  });
+
+  it("leaves in-flight work alone", () => {
+    const result = resolveGenerationTargets(
+      [at("queue"), at("processing")],
+      FRAMES,
+      GLOBALS,
+    );
+    expect(indexes(result)).toEqual([]);
+  });
+
+  it("counts out mismatched aspect ratios instead of running them", () => {
+    const frames = [
+      frame("a"),
+      { ...frame("b"), naturalWidth: 1920, naturalHeight: 1080 },
+    ];
+    const result = resolveGenerationTargets([at("idle")], frames, GLOBALS);
+    expect(indexes(result)).toEqual([]);
+    expect(result.skippedForMismatch).toBe(1);
+  });
+});
+
+describe("resolveSelectedTargets", () => {
+  it("takes everything picked, rendered and unedited included", () => {
+    const result = resolveSelectedTargets(
+      [0, 1],
+      [current(), at("idle")],
+      FRAMES,
+    );
+    expect(indexes(result)).toEqual([0, 1]);
+  });
+
+  it("keeps the caller's order and ignores indices that do not exist", () => {
+    const result = resolveSelectedTargets(
+      [1, 0, 9],
+      [at("idle"), at("idle")],
+      FRAMES,
+    );
+    expect(indexes(result)).toEqual([1, 0]);
+  });
+
+  it("still counts out mismatched aspect ratios", () => {
+    const frames = [
+      frame("a"),
+      { ...frame("b"), naturalWidth: 1920, naturalHeight: 1080 },
+    ];
+    const result = resolveSelectedTargets([0], [current()], frames);
+    expect(indexes(result)).toEqual([]);
+    expect(result.skippedForMismatch).toBe(1);
+  });
+});

--- a/src/components/pages/studio/utils/flow-generation-targets.ts
+++ b/src/components/pages/studio/utils/flow-generation-targets.ts
@@ -1,29 +1,83 @@
 import type { FlowReferenceFrame, FlowTransition } from "@/types/flow.types";
 import { isTransitionMismatched } from "./frame-aspect";
+import { isTransitionStale } from "./transition-staleness";
+import type { TransitionGlobals } from "./transition-field-values";
 
 export interface GenerationTargets {
   targets: Array<{ index: number; transition: FlowTransition }>;
   skippedForMismatch: number;
+  /** Of the targets: never rendered, and rendered-then-edited. */
+  neverRendered: number;
+  stale: number;
 }
 
+/**
+ * What "Generate" runs when nothing is selected: everything whose video is not
+ * what the current settings would produce. That is the never-rendered ones and
+ * the ones edited since their render — a finished transition is only done while
+ * its settings still match the take in the flow.
+ *
+ * In-flight work is left alone, and aspect-ratio mismatches are counted out
+ * rather than run, since they would fail the same way they did before.
+ */
 export const resolveGenerationTargets = (
   transitions: readonly FlowTransition[],
   referenceFrames: readonly FlowReferenceFrame[],
+  globals: TransitionGlobals,
 ): GenerationTargets => {
   const byId = new Map(referenceFrames.map((frame) => [frame.id, frame]));
   const targets: GenerationTargets["targets"] = [];
   let skippedForMismatch = 0;
+  let neverRendered = 0;
+  let stale = 0;
 
   transitions.forEach((transition, index) => {
     const { status, fromFrameId, toFrameId } = transition;
-    if (status === "processed" || status === "processing" || status === "queue")
-      return;
+    if (status === "processing" || status === "queue") return;
+    const isStale =
+      status === "processed" && isTransitionStale(transition, globals);
+    if (status === "processed" && !isStale) return;
     if (isTransitionMismatched(byId.get(fromFrameId), byId.get(toFrameId))) {
       skippedForMismatch += 1;
       return;
     }
     targets.push({ index, transition });
+    if (isStale) stale += 1;
+    else neverRendered += 1;
   });
+
+  return { targets, skippedForMismatch, neverRendered, stale };
+};
+
+/**
+ * What "Generate" runs against an explicit selection: all of it, rendered or
+ * not, edited or not. Picking transitions and asking for a run is a request for
+ * those transitions — staleness decides the default scope, never the chosen
+ * one. Mismatched pairs are still counted out.
+ */
+export const resolveSelectedTargets = (
+  indices: readonly number[],
+  transitions: readonly FlowTransition[],
+  referenceFrames: readonly FlowReferenceFrame[],
+): Pick<GenerationTargets, "targets" | "skippedForMismatch"> => {
+  const byId = new Map(referenceFrames.map((frame) => [frame.id, frame]));
+  const targets: GenerationTargets["targets"] = [];
+  let skippedForMismatch = 0;
+
+  for (const index of indices) {
+    const transition = transitions[index];
+    if (!transition) continue;
+    if (
+      isTransitionMismatched(
+        byId.get(transition.fromFrameId),
+        byId.get(transition.toFrameId),
+      )
+    ) {
+      skippedForMismatch += 1;
+      continue;
+    }
+    targets.push({ index, transition });
+  }
 
   return { targets, skippedForMismatch };
 };

--- a/src/components/pages/studio/utils/resolve-flow-settings.ts
+++ b/src/components/pages/studio/utils/resolve-flow-settings.ts
@@ -68,7 +68,7 @@ interface GlobalSettings {
   globalLora: LoRAConfig[] | undefined;
 }
 
-interface EffectiveSettings {
+export interface EffectiveSettings {
   presetId: string;
   prompt: string;
   negativePrompt: string;

--- a/src/components/pages/studio/utils/transition-field-values.test.ts
+++ b/src/components/pages/studio/utils/transition-field-values.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import type { FlowTransition } from "@/types/flow.types";
+import {
+  effectiveFieldValue,
+  fieldComparisonKey,
+  mismatchedFields,
+  selectionHasMismatch,
+  type TransitionGlobals,
+} from "./transition-field-values";
+
+const GLOBALS: TransitionGlobals = {
+  globalPresetId: "Abstract",
+  globalPrompt: "drift",
+  globalNegativePrompt: "",
+  globalDuration: 5,
+  globalModel: "kling-25-i2v",
+  globalNumInferenceSteps: 30,
+  globalGuidance: 0.5,
+  globalSeed: -1,
+  globalLora: undefined,
+};
+
+const t = (overrides: Partial<FlowTransition> = {}): FlowTransition => ({
+  fromFrameId: "a",
+  toFrameId: "b",
+  status: "idle",
+  ...overrides,
+});
+
+describe("effectiveFieldValue", () => {
+  it("falls back to the global when there is no override", () => {
+    expect(effectiveFieldValue(t(), GLOBALS, "promptOverride")).toBe("drift");
+    expect(effectiveFieldValue(t(), GLOBALS, "durationOverride")).toBe(5);
+  });
+
+  it("prefers the override", () => {
+    expect(
+      effectiveFieldValue(
+        t({ promptOverride: "swirl" }),
+        GLOBALS,
+        "promptOverride",
+      ),
+    ).toBe("swirl");
+  });
+
+  it("treats an empty-string override as a real value, not absence", () => {
+    expect(
+      effectiveFieldValue(
+        t({ negativePromptOverride: "" }),
+        { ...GLOBALS, globalNegativePrompt: "blurry" },
+        "negativePromptOverride",
+      ),
+    ).toBe("");
+  });
+});
+
+describe("fieldComparisonKey", () => {
+  it("collapses LoRA arrays to their paths", () => {
+    expect(fieldComparisonKey([{ path: "x.safetensors", scale: 1 }])).toBe(
+      "x.safetensors",
+    );
+  });
+
+  it("treats undefined and an empty LoRA list alike", () => {
+    expect(fieldComparisonKey(undefined)).toBe("");
+    expect(fieldComparisonKey([])).toBe("");
+  });
+
+  it("does not conflate different numbers", () => {
+    expect(fieldComparisonKey(5)).not.toBe(fieldComparisonKey(8));
+  });
+});
+
+describe("selectionHasMismatch", () => {
+  it("is false for a selection of one", () => {
+    expect(
+      selectionHasMismatch(
+        [t({ promptOverride: "x" })],
+        GLOBALS,
+        "promptOverride",
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when every transition falls back to the same global", () => {
+    expect(
+      selectionHasMismatch([t(), t(), t()], GLOBALS, "durationOverride"),
+    ).toBe(false);
+  });
+
+  it("is false when an override happens to equal the global", () => {
+    expect(
+      selectionHasMismatch(
+        [t(), t({ durationOverride: 5 })],
+        GLOBALS,
+        "durationOverride",
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when one transition overrides and the others do not", () => {
+    expect(
+      selectionHasMismatch(
+        [t(), t({ durationOverride: 8 })],
+        GLOBALS,
+        "durationOverride",
+      ),
+    ).toBe(true);
+  });
+
+  it("compares each field independently", () => {
+    const selection = [t({ promptOverride: "a" }), t({ promptOverride: "b" })];
+    expect(selectionHasMismatch(selection, GLOBALS, "promptOverride")).toBe(
+      true,
+    );
+    expect(selectionHasMismatch(selection, GLOBALS, "modelOverride")).toBe(
+      false,
+    );
+  });
+});
+
+describe("mismatchedFields", () => {
+  it("lists only the fields that actually disagree", () => {
+    const selection = [
+      t({ promptOverride: "a", durationOverride: 5 }),
+      t({ promptOverride: "b", durationOverride: 5 }),
+    ];
+    expect(mismatchedFields(selection, GLOBALS)).toEqual(["promptOverride"]);
+  });
+
+  it("is empty for an aligned selection", () => {
+    expect(mismatchedFields([t(), t()], GLOBALS)).toEqual([]);
+  });
+});

--- a/src/components/pages/studio/utils/transition-field-values.test.ts
+++ b/src/components/pages/studio/utils/transition-field-values.test.ts
@@ -3,10 +3,12 @@ import type { FlowTransition } from "@/types/flow.types";
 import {
   effectiveFieldValue,
   fieldComparisonKey,
+  forcedFieldPatch,
   mismatchedFields,
   selectionHasMismatch,
   type TransitionGlobals,
 } from "./transition-field-values";
+import { resolvePresetAction } from "./resolve-flow-settings";
 
 const GLOBALS: TransitionGlobals = {
   globalPresetId: "Abstract",
@@ -130,5 +132,95 @@ describe("mismatchedFields", () => {
 
   it("is empty for an aligned selection", () => {
     expect(mismatchedFields([t(), t()], GLOBALS)).toEqual([]);
+  });
+});
+
+describe("preset-derived values", () => {
+  // With no prompt stored anywhere, the panel shows the effective preset's
+  // prompt — so two transitions on different presets are showing different
+  // prompts, and comparing the (identical, absent) overrides would miss it.
+  const NO_PROMPT: TransitionGlobals = { ...GLOBALS, globalPrompt: "" };
+
+  it("falls back to the preset's prompt when nothing is stored", () => {
+    expect(
+      effectiveFieldValue(
+        t({ presetOverride: "Morph" }),
+        NO_PROMPT,
+        "promptOverride",
+      ),
+    ).toBe(resolvePresetAction("Morph")?.prompt);
+  });
+
+  it("prefers a stored prompt over the preset's", () => {
+    expect(
+      effectiveFieldValue(
+        t({ presetOverride: "Morph", promptOverride: "swirl" }),
+        NO_PROMPT,
+        "promptOverride",
+      ),
+    ).toBe("swirl");
+  });
+
+  it("reports a prompt mismatch between two presets that carry different ones", () => {
+    const selection = [
+      t({ presetOverride: "Morph" }),
+      t({ presetOverride: "Kaleidoscope" }),
+    ];
+    expect(selectionHasMismatch(selection, NO_PROMPT, "promptOverride")).toBe(
+      true,
+    );
+    expect(mismatchedFields(selection, NO_PROMPT)).toEqual([
+      "presetOverride",
+      "promptOverride",
+    ]);
+  });
+
+  it("falls back to the preset's LoRA when nothing is stored", () => {
+    const preset = "Camera Basics";
+    expect(
+      effectiveFieldValue(
+        t({ presetOverride: preset }),
+        GLOBALS,
+        "loraOverride",
+      ),
+    ).toEqual(resolvePresetAction(preset)?.highNoiseLoras);
+  });
+
+  it("reports a LoRA mismatch driven by the preset alone", () => {
+    const selection = [t({ presetOverride: "Camera Basics" }), t()];
+    expect(selectionHasMismatch(selection, GLOBALS, "loraOverride")).toBe(true);
+  });
+});
+
+describe("forcedFieldPatch", () => {
+  it("writes the source's effective value for each clashing field", () => {
+    const source = t({ promptOverride: "swirl", durationOverride: 10 });
+    expect(
+      forcedFieldPatch(source, GLOBALS, ["promptOverride", "durationOverride"]),
+    ).toEqual({ promptOverride: "swirl", durationOverride: 10 });
+  });
+
+  it("resolves a field the source only inherits", () => {
+    expect(forcedFieldPatch(t(), GLOBALS, ["durationOverride"])).toEqual({
+      durationOverride: GLOBALS.globalDuration,
+    });
+  });
+
+  it("touches nothing outside the fields it is given", () => {
+    const patch = forcedFieldPatch(
+      t({ promptOverride: "swirl", modelOverride: "ltx-i2v" }),
+      GLOBALS,
+      ["promptOverride"],
+    );
+    expect(Object.keys(patch)).toEqual(["promptOverride"]);
+  });
+
+  it("leaves the selection agreeing about every field it forced", () => {
+    const globals = { ...GLOBALS, globalPrompt: "" };
+    const source = t({ presetOverride: "Morph" });
+    const other = t({ presetOverride: "Kaleidoscope" });
+    const clashes = mismatchedFields([source, other], globals);
+    const aligned = { ...other, ...forcedFieldPatch(source, globals, clashes) };
+    expect(mismatchedFields([source, aligned], globals)).toEqual([]);
   });
 });

--- a/src/components/pages/studio/utils/transition-field-values.ts
+++ b/src/components/pages/studio/utils/transition-field-values.ts
@@ -1,5 +1,6 @@
 import type { FlowTransition } from "@/types/flow.types";
 import type { LoRAConfig, VideoModel } from "@/types/studio.types";
+import { resolvePresetAction } from "./resolve-flow-settings";
 
 /**
  * The override keys the settings panel can write. Each one has a global
@@ -56,14 +57,28 @@ const GLOBAL_KEY: Record<TransitionField, keyof TransitionGlobals> = {
 /**
  * Effective value of one field for one transition: override, else global.
  * `undefined` and a missing key are the same thing here — that is what "no
- * override" means — so `?? global` is the whole rule.
+ * override" means — so `?? global` is the base rule.
+ *
+ * Prompt and LoRA have one more step, because the settings panel resolves them
+ * that way for display: with nothing stored, the effective preset supplies
+ * them. Stopping at the global would call two transitions equal while the panel
+ * showed each a different preset's prompt.
  */
 export function effectiveFieldValue(
   transition: FlowTransition,
   globals: TransitionGlobals,
   field: TransitionField,
 ): unknown {
-  return transition[field] ?? globals[GLOBAL_KEY[field]];
+  const stored = transition[field] ?? globals[GLOBAL_KEY[field]];
+  if (field !== "promptOverride" && field !== "loraOverride") return stored;
+
+  const preset = resolvePresetAction(
+    transition.presetOverride ?? globals.globalPresetId ?? "",
+  );
+  if (field === "promptOverride") {
+    return (stored as string | undefined) || preset?.prompt || "";
+  }
+  return stored ?? preset?.highNoiseLoras;
 }
 
 /**
@@ -97,6 +112,25 @@ export function selectionHasMismatch(
       fieldComparisonKey(effectiveFieldValue(transition, globals, field)) !==
       first,
   );
+}
+
+/**
+ * The patch that forces `fields` onto another transition: the source's
+ * effective value for each, written as an explicit override. Only the fields
+ * that actually clash belong here — a field the selection already agrees about
+ * agrees because both sides resolve the same way, and pinning it would freeze
+ * a value that is currently free to follow the globals.
+ */
+export function forcedFieldPatch(
+  source: FlowTransition,
+  globals: TransitionGlobals,
+  fields: readonly TransitionField[],
+): Partial<FlowTransition> {
+  const patch: Record<string, unknown> = {};
+  for (const field of fields) {
+    patch[field] = effectiveFieldValue(source, globals, field);
+  }
+  return patch as Partial<FlowTransition>;
 }
 
 /** Every field the given transitions disagree about, in panel order. */

--- a/src/components/pages/studio/utils/transition-field-values.ts
+++ b/src/components/pages/studio/utils/transition-field-values.ts
@@ -1,0 +1,110 @@
+import type { FlowTransition } from "@/types/flow.types";
+import type { LoRAConfig, VideoModel } from "@/types/studio.types";
+
+/**
+ * The override keys the settings panel can write. Each one has a global
+ * counterpart that applies when the transition carries no override.
+ */
+export type TransitionField =
+  | "presetOverride"
+  | "promptOverride"
+  | "negativePromptOverride"
+  | "durationOverride"
+  | "modelOverride"
+  | "numInferenceStepsOverride"
+  | "guidanceOverride"
+  | "seedOverride"
+  | "loraOverride";
+
+export interface TransitionGlobals {
+  globalPresetId: string;
+  globalPrompt: string;
+  globalNegativePrompt: string;
+  globalDuration: number;
+  globalModel: VideoModel;
+  globalNumInferenceSteps: number;
+  globalGuidance: number;
+  globalSeed: number;
+  globalLora: LoRAConfig[] | undefined;
+}
+
+/** Human-readable field names, used in the mismatch prompt. */
+export const TRANSITION_FIELD_LABELS: Record<TransitionField, string> = {
+  presetOverride: "Preset",
+  promptOverride: "Prompt",
+  negativePromptOverride: "Negative Prompt",
+  durationOverride: "Duration",
+  modelOverride: "Model",
+  numInferenceStepsOverride: "Steps",
+  guidanceOverride: "Guidance",
+  seedOverride: "Seed",
+  loraOverride: "LoRA",
+};
+
+const GLOBAL_KEY: Record<TransitionField, keyof TransitionGlobals> = {
+  presetOverride: "globalPresetId",
+  promptOverride: "globalPrompt",
+  negativePromptOverride: "globalNegativePrompt",
+  durationOverride: "globalDuration",
+  modelOverride: "globalModel",
+  numInferenceStepsOverride: "globalNumInferenceSteps",
+  guidanceOverride: "globalGuidance",
+  seedOverride: "globalSeed",
+  loraOverride: "globalLora",
+};
+
+/**
+ * Effective value of one field for one transition: override, else global.
+ * `undefined` and a missing key are the same thing here — that is what "no
+ * override" means — so `?? global` is the whole rule.
+ */
+export function effectiveFieldValue(
+  transition: FlowTransition,
+  globals: TransitionGlobals,
+  field: TransitionField,
+): unknown {
+  return transition[field] ?? globals[GLOBAL_KEY[field]];
+}
+
+/**
+ * Comparable form of a field value. LoRA is an array of objects, and only the
+ * path identifies it to the picker, so it collapses to its paths; everything
+ * else compares by value.
+ */
+export function fieldComparisonKey(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) {
+    return (value as LoRAConfig[]).map((lora) => lora?.path ?? "").join("|");
+  }
+  return String(value);
+}
+
+/**
+ * Do the given transitions currently disagree about this field? A selection of
+ * one (or none) can never disagree.
+ */
+export function selectionHasMismatch(
+  transitions: readonly FlowTransition[],
+  globals: TransitionGlobals,
+  field: TransitionField,
+): boolean {
+  if (transitions.length < 2) return false;
+  const first = fieldComparisonKey(
+    effectiveFieldValue(transitions[0], globals, field),
+  );
+  return transitions.some(
+    (transition) =>
+      fieldComparisonKey(effectiveFieldValue(transition, globals, field)) !==
+      first,
+  );
+}
+
+/** Every field the given transitions disagree about, in panel order. */
+export function mismatchedFields(
+  transitions: readonly FlowTransition[],
+  globals: TransitionGlobals,
+): TransitionField[] {
+  return (Object.keys(TRANSITION_FIELD_LABELS) as TransitionField[]).filter(
+    (field) => selectionHasMismatch(transitions, globals, field),
+  );
+}

--- a/src/components/pages/studio/utils/transition-history.util.test.ts
+++ b/src/components/pages/studio/utils/transition-history.util.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import type { Dream } from "@/types/dream.types";
+import { middleFilmstripUrl, formatRunTime } from "./transition-history.util";
+
+const dream = (partial: Partial<Dream>) => partial as Dream;
+
+describe("middleFilmstripUrl", () => {
+  it("picks the middle frame of an odd-length filmstrip", () => {
+    expect(
+      middleFilmstripUrl(
+        dream({
+          filmstrip: [
+            { frameNumber: 0, url: "a" },
+            { frameNumber: 10, url: "b" },
+            { frameNumber: 20, url: "c" },
+          ],
+        }),
+      ),
+    ).toBe("b");
+  });
+
+  it("picks the lower middle of an even-length filmstrip", () => {
+    expect(
+      middleFilmstripUrl(
+        dream({
+          filmstrip: [
+            { frameNumber: 0, url: "a" },
+            { frameNumber: 10, url: "b" },
+            { frameNumber: 20, url: "c" },
+            { frameNumber: 30, url: "d" },
+          ],
+        }),
+      ),
+    ).toBe("b");
+  });
+
+  it("orders by frame number rather than trusting array order", () => {
+    expect(
+      middleFilmstripUrl(
+        dream({
+          filmstrip: [
+            { frameNumber: 20, url: "c" },
+            { frameNumber: 0, url: "a" },
+            { frameNumber: 10, url: "b" },
+          ],
+        }),
+      ),
+    ).toBe("b");
+  });
+
+  it("falls back to the poster thumbnail with no filmstrip", () => {
+    expect(middleFilmstripUrl(dream({ thumbnail: "poster.jpg" }))).toBe(
+      "poster.jpg",
+    );
+    expect(
+      middleFilmstripUrl(dream({ filmstrip: [], thumbnail: "poster.jpg" })),
+    ).toBe("poster.jpg");
+  });
+
+  it("returns undefined when there is nothing to show", () => {
+    expect(middleFilmstripUrl(undefined)).toBeUndefined();
+    expect(middleFilmstripUrl(dream({ thumbnail: "" }))).toBeUndefined();
+  });
+});
+
+describe("formatRunTime", () => {
+  const noon = new Date(2026, 7, 22, 12, 0, 0).getTime();
+
+  it("shows only the clock time for a run from today", () => {
+    const morning = new Date(2026, 7, 22, 9, 5, 0).getTime();
+    const label = formatRunTime(morning, noon);
+    expect(label).not.toMatch(/\d{1,2}\s*(Aug|August)|Aug/);
+    expect(label).toMatch(/\d/);
+  });
+
+  it("carries the date for a run from another day", () => {
+    const yesterday = new Date(2026, 7, 21, 9, 5, 0).getTime();
+    expect(formatRunTime(yesterday, noon)).toMatch(/Aug/);
+  });
+
+  it("distinguishes the same clock time on different days", () => {
+    const sameTimeYesterday = new Date(2026, 7, 21, 12, 0, 0).getTime();
+    expect(formatRunTime(sameTimeYesterday, noon)).not.toBe(
+      formatRunTime(noon, noon),
+    );
+  });
+});

--- a/src/components/pages/studio/utils/transition-history.util.ts
+++ b/src/components/pages/studio/utils/transition-history.util.ts
@@ -1,0 +1,42 @@
+import type { Dream } from "@/types/dream.types";
+
+/**
+ * The filmstrip frame nearest the middle of the clip. The first frame of a
+ * transition is (by construction) its start reference frame, so it looks the
+ * same for every take at a position — the middle is where takes actually
+ * differ, which is what makes the history strip worth looking at.
+ *
+ * Falls back to the dream's poster thumbnail while the filmstrip is missing.
+ */
+export function middleFilmstripUrl(dream?: Dream): string | undefined {
+  const frames = dream?.filmstrip;
+  if (frames && frames.length > 0) {
+    const ordered = [...frames].sort((a, b) => a.frameNumber - b.frameNumber);
+    return ordered[Math.floor((ordered.length - 1) / 2)]?.url;
+  }
+  return dream?.thumbnail || undefined;
+}
+
+/**
+ * Short label identifying a take. Same-day runs — the common case while
+ * iterating — show just the clock time; older ones carry the date so two takes
+ * from different days can't read as the same moment.
+ */
+export function formatRunTime(createdAt: number, now: number = Date.now()) {
+  const date = new Date(createdAt);
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const today = new Date(now);
+  const sameDay =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  if (sameDay) return time;
+  const day = date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  return `${day} ${time}`;
+}

--- a/src/components/pages/studio/utils/transition-staleness.test.ts
+++ b/src/components/pages/studio/utils/transition-staleness.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type { FlowTransition } from "@/types/flow.types";
+import type { TransitionGlobals } from "./transition-field-values";
+import { currentRunSettings, isTransitionStale } from "./transition-staleness";
+
+const GLOBALS: TransitionGlobals = {
+  globalPresetId: "",
+  globalPrompt: "drift",
+  globalNegativePrompt: "",
+  globalDuration: 5,
+  globalModel: "kling-25-i2v",
+  globalNumInferenceSteps: 30,
+  globalGuidance: 0.5,
+  globalSeed: -1,
+  globalLora: undefined,
+};
+
+/** A transition rendered from exactly the settings it currently resolves to. */
+const rendered = (
+  overrides: Partial<FlowTransition> = {},
+  globals: TransitionGlobals = GLOBALS,
+): FlowTransition => {
+  const base: FlowTransition = {
+    fromFrameId: "a",
+    toFrameId: "b",
+    status: "processed",
+    dreamUuid: "dream-1",
+    ...overrides,
+  };
+  return {
+    ...base,
+    history: [
+      {
+        dreamUuid: "dream-1",
+        createdAt: 1,
+        completed: true,
+        settings: currentRunSettings(base, globals),
+      },
+    ],
+  };
+};
+
+describe("isTransitionStale", () => {
+  it("is false for a transition rendered from its current settings", () => {
+    expect(isTransitionStale(rendered(), GLOBALS)).toBe(false);
+  });
+
+  it("is true once an override is edited", () => {
+    const transition = rendered();
+    expect(
+      isTransitionStale({ ...transition, promptOverride: "swirl" }, GLOBALS),
+    ).toBe(true);
+  });
+
+  it("is true when a global moves under a transition with no override", () => {
+    expect(
+      isTransitionStale(rendered(), { ...GLOBALS, globalPrompt: "swirl" }),
+    ).toBe(true);
+  });
+
+  it("ignores a global the transition overrides", () => {
+    const transition = rendered({ promptOverride: "swirl" });
+    expect(
+      isTransitionStale(transition, { ...GLOBALS, globalPrompt: "other" }),
+    ).toBe(false);
+  });
+
+  it("compares against the take in the flow, not the newest one", () => {
+    // An older take restored: dreamUuid points back at it, and its settings are
+    // what the panel now shows, so the transition is current.
+    const older = rendered();
+    const transition: FlowTransition = {
+      ...older,
+      history: [
+        ...(older.history ?? []),
+        {
+          dreamUuid: "dream-2",
+          createdAt: 2,
+          completed: true,
+          settings: currentRunSettings(
+            { ...older, promptOverride: "swirl" },
+            GLOBALS,
+          ),
+        },
+      ],
+    };
+    expect(isTransitionStale(transition, GLOBALS)).toBe(false);
+  });
+
+  it("is false for a take with no recorded settings", () => {
+    const transition = rendered();
+    expect(isTransitionStale({ ...transition, history: [] }, GLOBALS)).toBe(
+      false,
+    );
+  });
+
+  it("is false for anything not rendered", () => {
+    for (const status of ["idle", "queue", "processing", "failed"] as const) {
+      const transition = { ...rendered({ promptOverride: "swirl" }), status };
+      expect(isTransitionStale(transition, GLOBALS)).toBe(false);
+    }
+  });
+
+  it("notices a LoRA change", () => {
+    const transition = rendered({
+      loraOverride: [{ path: "a.safetensors", scale: 1 }],
+    });
+    expect(
+      isTransitionStale(
+        { ...transition, loraOverride: [{ path: "b.safetensors", scale: 1 }] },
+        GLOBALS,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not fire on a random seed, which records as -1 either way", () => {
+    expect(isTransitionStale(rendered({ seedOverride: -1 }), GLOBALS)).toBe(
+      false,
+    );
+  });
+});

--- a/src/components/pages/studio/utils/transition-staleness.ts
+++ b/src/components/pages/studio/utils/transition-staleness.ts
@@ -1,0 +1,89 @@
+import type { FlowTransition, TransitionRunSettings } from "@/types/flow.types";
+import {
+  resolveEffectiveSettings,
+  type EffectiveSettings,
+} from "./resolve-flow-settings";
+import {
+  fieldComparisonKey,
+  type TransitionGlobals,
+} from "./transition-field-values";
+
+/**
+ * The snapshot a run records, derived from the settings it resolved.
+ *
+ * Generation writes its snapshot through here and the staleness check below
+ * reads through here, so "what this take was made from" and "what we would send
+ * now" are produced by one piece of code. Two copies of this mapping would let
+ * a field be recorded one way and compared another, and the difference would
+ * show up as a transition that is permanently stale or never stale.
+ */
+export function runSettingsFromEffective(
+  settings: EffectiveSettings,
+): TransitionRunSettings {
+  return {
+    presetOverride: settings.presetId,
+    promptOverride: settings.prompt,
+    negativePromptOverride: settings.negativePrompt,
+    durationOverride: settings.duration,
+    modelOverride: settings.model,
+    numInferenceStepsOverride: settings.numInferenceSteps,
+    guidanceOverride: settings.guidance,
+    seedOverride: settings.seed,
+    loraOverride: settings.action.highNoiseLoras ?? [],
+  };
+}
+
+/** What a run started for this transition right now would be recorded as. */
+export function currentRunSettings(
+  transition: FlowTransition,
+  globals: TransitionGlobals,
+): TransitionRunSettings {
+  return runSettingsFromEffective(
+    resolveEffectiveSettings(transition, globals),
+  );
+}
+
+/** Two snapshots describing the same render. LoRA compares by path. */
+export function runSettingsMatch(
+  a: TransitionRunSettings,
+  b: TransitionRunSettings,
+): boolean {
+  return (
+    a.presetOverride === b.presetOverride &&
+    a.promptOverride === b.promptOverride &&
+    a.negativePromptOverride === b.negativePromptOverride &&
+    a.durationOverride === b.durationOverride &&
+    a.modelOverride === b.modelOverride &&
+    a.numInferenceStepsOverride === b.numInferenceStepsOverride &&
+    a.guidanceOverride === b.guidanceOverride &&
+    a.seedOverride === b.seedOverride &&
+    fieldComparisonKey(a.loraOverride) === fieldComparisonKey(b.loraOverride)
+  );
+}
+
+/**
+ * Has this transition been edited since the take now in the flow was made?
+ *
+ * Only a rendered transition can be stale: everything else is already visible
+ * as its status. The comparison is against the run that produced the video on
+ * screen — not the newest run — so restoring an older take reads as current,
+ * which it is.
+ *
+ * A take with no recorded settings (persisted before runs carried a snapshot)
+ * is treated as current. There is nothing to compare it against, and guessing
+ * "stale" would mark every old flow for regeneration on sight.
+ */
+export function isTransitionStale(
+  transition: FlowTransition,
+  globals: TransitionGlobals,
+): boolean {
+  if (transition.status !== "processed" || !transition.dreamUuid) return false;
+  const entry = transition.history?.find(
+    (run) => run.dreamUuid === transition.dreamUuid,
+  );
+  if (!entry?.settings) return false;
+  return !runSettingsMatch(
+    currentRunSettings(transition, globals),
+    entry.settings,
+  );
+}

--- a/src/constants/flow-theme.constants.ts
+++ b/src/constants/flow-theme.constants.ts
@@ -30,6 +30,12 @@ export const FLOW = {
   accentDim: "rgba(212, 168, 83, 0.15)",
   accentGlow: "rgba(212, 168, 83, 0.08)",
 
+  // Selection (blue). Deliberately not `processing`: a selected transition and
+  // a rendering one have to stay tellable apart at a glance.
+  selected: "#6ea8fe",
+  selectedDim: "rgba(110, 168, 254, 0.18)",
+  selectedGlow: "rgba(110, 168, 254, 0.35)",
+
   // Status
   success: "#4ade80",
   successDim: "rgba(74, 222, 128, 0.18)",

--- a/src/stores/flow.store.test.ts
+++ b/src/stores/flow.store.test.ts
@@ -21,12 +21,37 @@ globalThis.localStorage = {
 };
 
 // Dynamic import after localStorage is set up (persist middleware needs it)
-const { useFlowStore } = await import("./flow.store");
+const { useFlowStore, MAX_TRANSITION_HISTORY } = await import("./flow.store");
 
 // Reset store between tests
 beforeEach(() => {
   useFlowStore.getState().resetFlow();
 });
+
+/** Add `count + 1` frames so the store derives exactly `count` transitions. */
+function seedTransitions(count: number) {
+  useFlowStore.getState().resetFlow();
+  for (let i = 0; i <= count; i++) {
+    useFlowStore.getState().addReferenceFrame({
+      id: `frame-${i}`,
+      dreamUuid: `dream-${i}`,
+      imageUrl: `url-${i}`,
+      name: `frame ${i}`,
+    });
+  }
+}
+
+const RUN_SETTINGS = {
+  presetOverride: "Abstract",
+  promptOverride: "drift",
+  negativePromptOverride: "",
+  durationOverride: 5,
+  modelOverride: "kling-25-i2v" as const,
+  numInferenceStepsOverride: 30,
+  guidanceOverride: 0.5,
+  seedOverride: -1,
+  loraOverride: [],
+};
 
 describe("flow store", () => {
   describe("reference frames", () => {
@@ -468,7 +493,7 @@ describe("Phase 1: transitions", () => {
       expect(s.globalModel).toBe("kling-25-i2v");
       expect(s.globalNumInferenceSteps).toBe(30);
       expect(s.globalGuidance).toBe(0.5);
-      expect(s.selectedTransitionIndex).toBeNull();
+      expect(s.selectedTransitionIndices).toEqual([]);
       expect(s.settingsExpanded).toBe(false);
     });
 
@@ -495,11 +520,85 @@ describe("Phase 1: transitions", () => {
 
   describe("UI state", () => {
     it("selects and deselects transitions", () => {
+      seedTransitions(4);
       const store = useFlowStore.getState();
       store.selectTransition(2);
-      expect(useFlowStore.getState().selectedTransitionIndex).toBe(2);
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([2]);
       store.selectTransition(null);
-      expect(useFlowStore.getState().selectedTransitionIndex).toBeNull();
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([]);
+    });
+
+    it("ignores selection of an index with no transition", () => {
+      seedTransitions(2);
+      useFlowStore.getState().selectTransition(9);
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([]);
+    });
+
+    it("toggles indices in and out, keeping click order", () => {
+      seedTransitions(4);
+      const store = () => useFlowStore.getState();
+      store().selectTransition(1);
+      store().toggleTransitionSelection(3);
+      store().toggleTransitionSelection(0);
+      // Newest click stays last — it is the primary the panel names.
+      expect(store().selectedTransitionIndices).toEqual([1, 3, 0]);
+
+      store().toggleTransitionSelection(3);
+      expect(store().selectedTransitionIndices).toEqual([1, 0]);
+    });
+
+    it("selects all and clears all", () => {
+      seedTransitions(3);
+      useFlowStore.getState().selectAllTransitions();
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([
+        0, 1, 2,
+      ]);
+      useFlowStore.getState().clearTransitionSelection();
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([]);
+    });
+
+    it("drops selected indices when deleting a frame shortens the flow", () => {
+      seedTransitions(4);
+      useFlowStore.getState().selectAllTransitions();
+      expect(useFlowStore.getState().selectedTransitionIndices).toHaveLength(4);
+
+      useFlowStore.getState().removeReferenceFrame("frame-4");
+      useFlowStore.getState().removeReferenceFrame("frame-3");
+
+      expect(useFlowStore.getState().transitions).toHaveLength(2);
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([0, 1]);
+    });
+
+    it("prunes on demand for state handed over by a session restore", () => {
+      seedTransitions(2);
+      useFlowStore.setState({ selectedTransitionIndices: [0, 1, 7] });
+      useFlowStore.getState().pruneTransitionSelection();
+      expect(useFlowStore.getState().selectedTransitionIndices).toEqual([0, 1]);
+    });
+
+    it("replays on every play request, including a repeat of the same dream", () => {
+      const store = () => useFlowStore.getState();
+      expect(store().previewPlayRequest).toBeNull();
+
+      store().requestPreviewPlay("dream-a");
+      expect(store().previewPlayRequest).toEqual({
+        dreamUuid: "dream-a",
+        seq: 1,
+      });
+
+      // Same dream again: the uuid is unchanged, so the sequence number is the
+      // only thing telling the preview a fresh replay was asked for.
+      store().requestPreviewPlay("dream-a");
+      expect(store().previewPlayRequest).toEqual({
+        dreamUuid: "dream-a",
+        seq: 2,
+      });
+
+      store().requestPreviewPlay("dream-b");
+      expect(store().previewPlayRequest).toEqual({
+        dreamUuid: "dream-b",
+        seq: 3,
+      });
     });
 
     it("toggles settings expanded", () => {
@@ -644,5 +743,128 @@ describe("frame lightbox (#694)", () => {
     store.openFrameLightbox("a");
     store.resetFlow();
     expect(useFlowStore.getState().frameLightboxId).toBeNull();
+  });
+});
+
+describe("transition run history", () => {
+  const store = () => useFlowStore.getState();
+
+  it("records a run and marks it completed only once it renders", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+
+    let t = store().transitions[0];
+    expect(t.dreamUuid).toBe("dream-a");
+    expect(t.history).toHaveLength(1);
+    expect(t.history?.[0].completed).toBeUndefined();
+
+    store().updateTransitionStatus(0, "processed");
+    t = store().transitions[0];
+    expect(t.history?.[0].completed).toBe(true);
+  });
+
+  it("keeps every take at a position across regenerations", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+    store().updateTransitionStatus(0, "processed");
+    store().recordTransitionRun(
+      0,
+      "dream-b",
+      { ...RUN_SETTINGS, promptOverride: "swirl" },
+      2000,
+    );
+    store().updateTransitionStatus(0, "processed");
+
+    const t = store().transitions[0];
+    expect(t.history?.map((e) => e.dreamUuid)).toEqual(["dream-a", "dream-b"]);
+    expect(t.dreamUuid).toBe("dream-b");
+  });
+
+  it("does not duplicate a row when the same dream is re-recorded", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 3000);
+
+    const history = store().transitions[0].history;
+    expect(history).toHaveLength(1);
+    expect(history?.[0].createdAt).toBe(3000);
+  });
+
+  it("drops the uprez when a new run replaces the dream", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+    store().setTransitionUprez(0, "uprez-a");
+    store().updateTransitionUprezStatus(0, "processed");
+
+    store().recordTransitionRun(0, "dream-b", RUN_SETTINGS, 2000);
+    const t = store().transitions[0];
+    expect(t.uprezDreamUuid).toBeUndefined();
+    expect(t.uprezStatus).toBeUndefined();
+  });
+
+  it("restores a completed take with the settings it ran under", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(
+      0,
+      "dream-a",
+      { ...RUN_SETTINGS, promptOverride: "first take", durationOverride: 5 },
+      1000,
+    );
+    store().updateTransitionStatus(0, "processed");
+    store().recordTransitionRun(
+      0,
+      "dream-b",
+      { ...RUN_SETTINGS, promptOverride: "second take", durationOverride: 8 },
+      2000,
+    );
+    store().updateTransitionStatus(0, "processed");
+
+    store().restoreTransitionRun(0, "dream-a");
+
+    const t = store().transitions[0];
+    expect(t.dreamUuid).toBe("dream-a");
+    expect(t.status).toBe("processed");
+    expect(t.promptOverride).toBe("first take");
+    expect(t.durationOverride).toBe(5);
+    // Both takes stay available — restoring is not destructive.
+    expect(t.history).toHaveLength(2);
+  });
+
+  it("refuses to restore a take that never completed", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+    store().updateTransitionStatus(0, "processed");
+    store().recordTransitionRun(0, "dream-b", RUN_SETTINGS, 2000);
+    store().updateTransitionStatus(0, "failed");
+
+    store().restoreTransitionRun(0, "dream-b");
+    expect(store().transitions[0].dreamUuid).toBe("dream-b");
+    expect(store().transitions[0].status).toBe("failed");
+  });
+
+  it("keeps history when overrides are reset to defaults", () => {
+    seedTransitions(1);
+    store().recordTransitionRun(0, "dream-a", RUN_SETTINGS, 1000);
+    store().updateTransitionStatus(0, "processed");
+    store().setTransitionOverride(0, { promptOverride: "custom" });
+
+    store().clearTransitionOverride(0);
+
+    const t = store().transitions[0];
+    expect(t.promptOverride).toBeUndefined();
+    expect(t.history).toHaveLength(1);
+  });
+
+  it("caps history growth", () => {
+    seedTransitions(1);
+    for (let i = 0; i < MAX_TRANSITION_HISTORY + 5; i++) {
+      store().recordTransitionRun(0, `dream-${i}`, RUN_SETTINGS, 1000 + i);
+    }
+    const history = store().transitions[0].history;
+    expect(history).toHaveLength(MAX_TRANSITION_HISTORY);
+    // The oldest takes fall off the front, not the newest off the back.
+    expect(history?.[history.length - 1].dreamUuid).toBe(
+      `dream-${MAX_TRANSITION_HISTORY + 4}`,
+    );
   });
 });

--- a/src/stores/flow.store.ts
+++ b/src/stores/flow.store.ts
@@ -3,6 +3,8 @@ import { persist } from "zustand/middleware";
 import type {
   FlowReferenceFrame,
   FlowTransition,
+  TransitionHistoryEntry,
+  TransitionRunSettings,
   TransitionStatus,
 } from "@/types/flow.types";
 import type { VideoModel, LoRAConfig } from "@/types/studio.types";
@@ -58,9 +60,15 @@ type FlowStoreState = {
   transitions: FlowTransition[];
 
   // Phase 1 — UI state
-  selectedTransitionIndex: number | null;
+  // Selected transition indices in click order; the last one is the "primary"
+  // (the one the panel names and the preview plays). Empty = global mode.
+  selectedTransitionIndices: number[];
   settingsExpanded: boolean;
   previewLightboxOpen: boolean;
+  // Explicit "play this dream now" request. Carries a sequence number because
+  // clicking the same transition twice must replay it — a bare uuid would be
+  // an unchanged value the preview could not tell apart from no request.
+  previewPlayRequest: { dreamUuid: string; seq: number } | null;
   // Id (not index) of the frame shown in the lightbox; null = closed.
   frameLightboxId: string | null;
 
@@ -80,8 +88,13 @@ type FlowStoreState = {
   ) => void;
   clearTransitionOverride: (index: number) => void;
   selectTransition: (index: number | null) => void;
+  toggleTransitionSelection: (index: number) => void;
+  selectAllTransitions: () => void;
+  clearTransitionSelection: () => void;
+  pruneTransitionSelection: () => void;
   setSettingsExpanded: (expanded: boolean) => void;
   setPreviewLightboxOpen: (open: boolean) => void;
+  requestPreviewPlay: (dreamUuid: string) => void;
   openFrameLightbox: (id: string) => void;
   closeFrameLightbox: () => void;
   stepFrameLightbox: (delta: number) => void;
@@ -91,6 +104,13 @@ type FlowStoreState = {
     progress?: number,
   ) => void;
   setTransitionDream: (index: number, dreamUuid: string) => void;
+  recordTransitionRun: (
+    index: number,
+    dreamUuid: string,
+    settings: TransitionRunSettings,
+    createdAt: number,
+  ) => void;
+  restoreTransitionRun: (index: number, dreamUuid: string) => void;
   setTransitionUprez: (index: number, uprezDreamUuid: string) => void;
   updateTransitionUprezStatus: (
     index: number,
@@ -117,13 +137,39 @@ const PHASE_1_DEFAULTS = {
   globalSeed: -1,
   globalLora: undefined as LoRAConfig[] | undefined,
   transitions: [] as FlowTransition[],
-  selectedTransitionIndex: null as number | null,
+  selectedTransitionIndices: [] as number[],
   settingsExpanded: false,
   previewLightboxOpen: false,
+  previewPlayRequest: null as { dreamUuid: string; seq: number } | null,
   frameLightboxId: null as string | null,
   savedPlaylistUuid: null as string | null,
   syncedPlaylistDreamUuids: [] as string[],
 };
+
+// Past runs are cheap to keep but not free — each one is a persisted settings
+// snapshot and a dream the history strip may fetch. 20 is well past the point
+// where a user is still comparing takes.
+export const MAX_TRANSITION_HISTORY = 20;
+
+/** Drop selected indices that the new transition list no longer has. */
+function pruneSelection(indices: number[], length: number): number[] {
+  const next = indices.filter((i) => i >= 0 && i < length);
+  return next.length === indices.length ? indices : next;
+}
+
+function markHistoryCompleted(
+  history: TransitionHistoryEntry[] | undefined,
+  dreamUuid: string,
+): TransitionHistoryEntry[] | undefined {
+  if (!history) return history;
+  let changed = false;
+  const next = history.map((entry) => {
+    if (entry.dreamUuid !== dreamUuid || entry.completed) return entry;
+    changed = true;
+    return { ...entry, completed: true };
+  });
+  return changed ? next : history;
+}
 
 /**
  * Build transitions from adjacent frame pairs.
@@ -271,13 +317,18 @@ export const useFlowStore = create<FlowStoreState>()(
           const referenceFrames = s.referenceFrames.filter(
             (frame) => frame.id !== id,
           );
+          const transitions = deriveTransitions(
+            buildFramesWithLoop(referenceFrames, s.loop),
+            s.transitions,
+          );
           return {
             referenceFrames,
             frameLightboxId:
               s.frameLightboxId === id ? null : s.frameLightboxId,
-            transitions: deriveTransitions(
-              buildFramesWithLoop(referenceFrames, s.loop),
-              s.transitions,
+            transitions,
+            selectedTransitionIndices: pruneSelection(
+              s.selectedTransitionIndices,
+              transitions.length,
             ),
           };
         }),
@@ -302,13 +353,20 @@ export const useFlowStore = create<FlowStoreState>()(
         }),
 
       setLoop: (loop) =>
-        set((s) => ({
-          loop,
-          transitions: deriveTransitions(
+        set((s) => {
+          const transitions = deriveTransitions(
             buildFramesWithLoop(s.referenceFrames, loop),
             s.transitions,
-          ),
-        })),
+          );
+          return {
+            loop,
+            transitions,
+            selectedTransitionIndices: pruneSelection(
+              s.selectedTransitionIndices,
+              transitions.length,
+            ),
+          };
+        }),
 
       referenceFramesWithLoop: () => {
         const { referenceFrames, loop } = get();
@@ -356,6 +414,9 @@ export const useFlowStore = create<FlowStoreState>()(
             status: t.status,
             progress: t.progress,
             dreamUuid: t.dreamUuid,
+            // Past runs are results, not settings — clearing overrides must not
+            // throw them away, or "Reset to defaults" silently drops history.
+            history: t.history,
             uprezDreamUuid: t.uprezDreamUuid,
             uprezStatus: t.uprezStatus,
             uprezProgress: t.uprezProgress,
@@ -363,9 +424,53 @@ export const useFlowStore = create<FlowStoreState>()(
           return { transitions };
         }),
 
-      selectTransition: (index) => set({ selectedTransitionIndex: index }),
+      selectTransition: (index) =>
+        set((s) => ({
+          selectedTransitionIndices:
+            index === null || index < 0 || index >= s.transitions.length
+              ? []
+              : [index],
+        })),
+
+      toggleTransitionSelection: (index) =>
+        set((s) => {
+          if (index < 0 || index >= s.transitions.length) return s;
+          const current = s.selectedTransitionIndices;
+          const without = current.filter((i) => i !== index);
+          // Re-append rather than sort: the newest click is the primary, which
+          // is what the panel names and the preview plays.
+          return {
+            selectedTransitionIndices:
+              without.length === current.length ? [...current, index] : without,
+          };
+        }),
+
+      selectAllTransitions: () =>
+        set((s) => ({
+          selectedTransitionIndices: s.transitions.map((_, i) => i),
+        })),
+
+      clearTransitionSelection: () => set({ selectedTransitionIndices: [] }),
+
+      pruneTransitionSelection: () =>
+        set((s) => {
+          const valid = s.selectedTransitionIndices.filter(
+            (i) => i >= 0 && i < s.transitions.length,
+          );
+          return valid.length === s.selectedTransitionIndices.length
+            ? s
+            : { selectedTransitionIndices: valid };
+        }),
       setSettingsExpanded: (expanded) => set({ settingsExpanded: expanded }),
       setPreviewLightboxOpen: (open) => set({ previewLightboxOpen: open }),
+
+      requestPreviewPlay: (dreamUuid) =>
+        set((s) => ({
+          previewPlayRequest: {
+            dreamUuid,
+            seq: (s.previewPlayRequest?.seq ?? 0) + 1,
+          },
+        })),
 
       openFrameLightbox: (id) =>
         set((s) => ({
@@ -393,11 +498,18 @@ export const useFlowStore = create<FlowStoreState>()(
       updateTransitionStatus: (index, status, progress) =>
         set((s) => {
           const transitions = [...s.transitions];
-          if (!transitions[index]) return s;
+          const prev = transitions[index];
+          if (!prev) return s;
+          // A run only earns a history thumbnail once it has actually rendered.
+          const history =
+            status === "processed" && prev.dreamUuid
+              ? markHistoryCompleted(prev.history, prev.dreamUuid)
+              : prev.history;
           transitions[index] = {
-            ...transitions[index],
+            ...prev,
             status,
             progress,
+            history,
           };
           return { transitions };
         }),
@@ -407,6 +519,61 @@ export const useFlowStore = create<FlowStoreState>()(
           const transitions = [...s.transitions];
           if (!transitions[index]) return s;
           transitions[index] = { ...transitions[index], dreamUuid };
+          return { transitions };
+        }),
+
+      recordTransitionRun: (index, dreamUuid, settings, createdAt) =>
+        set((s) => {
+          const transitions = [...s.transitions];
+          const prev = transitions[index];
+          if (!prev) return s;
+          const history = [...(prev.history ?? [])];
+          // Regenerating an entry that is already in history (restore, then
+          // Generate without changing anything) must not duplicate the row.
+          const existing = history.findIndex((e) => e.dreamUuid === dreamUuid);
+          const entry: TransitionHistoryEntry = {
+            dreamUuid,
+            createdAt,
+            settings,
+          };
+          if (existing === -1) history.push(entry);
+          else history[existing] = { ...history[existing], ...entry };
+          const replacesDream = prev.dreamUuid !== dreamUuid;
+          transitions[index] = {
+            ...prev,
+            dreamUuid,
+            history: history.slice(-MAX_TRANSITION_HISTORY),
+            // The uprez was derived from the dream being replaced; carrying it
+            // over would attach an upscale of one take to a different one.
+            ...(replacesDream && {
+              uprezDreamUuid: undefined,
+              uprezStatus: undefined,
+              uprezProgress: undefined,
+            }),
+          };
+          return { transitions };
+        }),
+
+      restoreTransitionRun: (index, dreamUuid) =>
+        set((s) => {
+          const transitions = [...s.transitions];
+          const prev = transitions[index];
+          if (!prev) return s;
+          const entry = prev.history?.find((e) => e.dreamUuid === dreamUuid);
+          if (!entry || !entry.completed) return s;
+          transitions[index] = {
+            ...prev,
+            // The snapshot is a full override set, so the panel shows exactly
+            // the values this run used regardless of how globals have drifted.
+            ...entry.settings,
+            dreamUuid,
+            status: "processed",
+            progress: undefined,
+            // The uprez belonged to the run being replaced, not to this one.
+            uprezDreamUuid: undefined,
+            uprezStatus: undefined,
+            uprezProgress: undefined,
+          };
           return { transitions };
         }),
 
@@ -431,12 +598,19 @@ export const useFlowStore = create<FlowStoreState>()(
         }),
 
       recomputeTransitions: () =>
-        set((s) => ({
-          transitions: deriveTransitions(
+        set((s) => {
+          const transitions = deriveTransitions(
             buildFramesWithLoop(s.referenceFrames, s.loop),
             s.transitions,
-          ),
-        })),
+          );
+          return {
+            transitions,
+            selectedTransitionIndices: pruneSelection(
+              s.selectedTransitionIndices,
+              transitions.length,
+            ),
+          };
+        }),
 
       reconcileStaleTransitions: () =>
         set((s) => ({
@@ -524,10 +698,9 @@ export const useFlowStore = create<FlowStoreState>()(
         if (!state) return;
         state.reconcileStaleTransitions();
         state.recomputeTransitions();
-        const idx = state.selectedTransitionIndex;
-        if (idx !== null && (idx < 0 || idx >= state.transitions.length)) {
-          state.selectTransition(null);
-        }
+        // Selection is UI state and isn't persisted, but a session restore can
+        // hand one over — drop indices that no longer name a transition.
+        state.pruneTransitionSelection();
       },
       partialize: flowPartialize,
     },

--- a/src/stores/session.store.test.ts
+++ b/src/stores/session.store.test.ts
@@ -54,7 +54,7 @@ describe("session store", () => {
     useSessionStore.getState().createSession("Session B");
 
     useFlowStore.setState({
-      selectedTransitionIndex: 3,
+      selectedTransitionIndices: [3],
       settingsExpanded: true,
       previewLightboxOpen: true,
     });
@@ -63,7 +63,7 @@ describe("session store", () => {
     useSessionStore.getState().switchSession(sessions[0].id);
 
     const flowState = useFlowStore.getState();
-    expect(flowState.selectedTransitionIndex).toBeNull();
+    expect(flowState.selectedTransitionIndices).toEqual([]);
     expect(flowState.settingsExpanded).toBe(false);
     expect(flowState.previewLightboxOpen).toBe(false);
   });

--- a/src/stores/session.store.ts
+++ b/src/stores/session.store.ts
@@ -227,9 +227,10 @@ export const useSessionStore = create<SessionStoreState>()((set, get) => ({
         session.flowState as Parameters<typeof useFlowStore.setState>[0],
       );
       useFlowStore.setState({
-        selectedTransitionIndex: null,
+        selectedTransitionIndices: [],
         settingsExpanded: false,
         previewLightboxOpen: false,
+        previewPlayRequest: null,
         savedPlaylistUuid: flowState.savedPlaylistUuid ?? null,
         syncedPlaylistDreamUuids: flowState.syncedPlaylistDreamUuids ?? [],
       });

--- a/src/types/flow.types.ts
+++ b/src/types/flow.types.ts
@@ -33,6 +33,34 @@ export type TransitionStatus =
   | "processed"
   | "failed";
 
+/**
+ * The settings a single generation ran with, captured as a full override set.
+ * Snapshotting the *resolved* values (global + override) rather than just the
+ * overrides is what makes a history entry restorable: globals drift as the user
+ * keeps working, so overrides alone would replay a run under today's defaults.
+ */
+export interface TransitionRunSettings {
+  presetOverride: string;
+  promptOverride: string;
+  negativePromptOverride: string;
+  durationOverride: number;
+  modelOverride: VideoModel;
+  numInferenceStepsOverride: number;
+  guidanceOverride: number;
+  seedOverride: number;
+  loraOverride: LoRAConfig[];
+}
+
+/** One completed (or in-flight) generation for a transition position. */
+export interface TransitionHistoryEntry {
+  dreamUuid: string;
+  createdAt: number; // epoch ms
+  // Set once the run reaches "processed". Only completed runs are offered in
+  // the history strip — a failed or in-flight dream has nothing to show.
+  completed?: boolean;
+  settings: TransitionRunSettings;
+}
+
 export interface FlowTransition {
   fromFrameId: string; // FlowReferenceFrame.id
   toFrameId: string; // FlowReferenceFrame.id
@@ -52,6 +80,10 @@ export interface FlowTransition {
   dreamUuid?: string;
   status: TransitionStatus;
   progress?: number; // 0-100
+
+  // Every generation run at this position, oldest first. The entry matching
+  // `dreamUuid` is the one currently in the flow; the rest are restorable.
+  history?: TransitionHistoryEntry[];
 
   // Uprez state (undefined = not started)
   uprezDreamUuid?: string;


### PR DESCRIPTION
Closes #728.

Editing a flow's transitions gave no way to tell which one you were changing, only let you change one at a time, and threw the old render away on every regenerate. Three parts, matching the issue.

## 1. Selection

`selectedTransitionIndex` becomes `selectedTransitionIndices`, held in click order — the last click is the "primary" that the panel names and the preview plays.

- Click selects, shift/cmd/ctrl-click toggles.
- Selected gaps get a blue slab, from new `selected`/`selectedDim`/`selectedGlow` tokens. Deliberately **not** the existing `processing` blue, so "selected" and "rendering" stay tellable apart.
- **Select all** / **Clear all** beside Reset, with a live selection count.
- Clicking a transition plays it in the preview — every time, including when it is already selected.

That last point is why playback is an explicit request carrying a sequence number rather than a derived effect. Re-clicking the selected transition changes no state, so there is nothing to react to; a bare UUID would be an unchanged value. `CrossfadeVideo` takes a `replayToken` to restart the segment already on screen.

## 2. Group editing

Edits apply to the whole selection. When one would flatten a field the selection disagrees about, `ForceSettingsDialog` asks first — "force them all to the same value?".

Gating is per *interaction*, not per field. Choosing a preset writes prompt, negative prompt, LoRA and duration; gating each separately would raise four dialogs in a row. Only the field you touched is gated, and the knock-on clamps follow.

## 3. History

Every run is recorded on the transition and restorable.

The snapshot stores the **resolved** settings as a full override set, not the overrides. Globals drift while you keep working, so overrides alone would replay a take under today's defaults rather than the ones that produced it.

Shown as a right-aligned strip in the settings header, using the filmstrip frame nearest the middle of the clip — the first frame is the start reference frame, identical across every take at a position. The header reserves its height via `HISTORY_ROW_HEIGHT`, so the panel does not resize as takes complete and shove the preview up and down the page.

## Fixes that fell out

- `clearTransitionOverride` rebuilt the transition field by field and would have dropped `history` on "Reset to defaults".
- Regenerating left `uprezDreamUuid` pointing at the replaced dream's upscale.
- `useFlowGeneration`'s tests were passing while silently exercising the *failure* path — the mock store had no `recordTransitionRun`, so generation threw and the catch swallowed it. Mock fixed, plus an assertion that nothing rolls back to `failed`.

## Behaviour change

Clicking a **failed** transition now selects it rather than retrying immediately; the Generate button reads "Retry". Uniform click semantics were the point of part 1, but it is one less one-click path than before.

## Testing

`tsc --noEmit`, eslint, prettier, and production build all clean. 243 tests pass — 24 new, covering selection/toggle/prune, history record-restore-cap, replay sequencing, field mismatch detection, and filmstrip/time formatting.

Also driven by hand in the browser against staging: selection and the blue highlight, preview following clicks (including the re-click-while-selected case), history restoring a real take across three generations, and the panel holding its height as takes complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)